### PR TITLE
formatting using clang-format-9

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,79 +1,102 @@
+# Style file for MLSE Libraries based on the modified rocBLAS style
+
+# Common settings
+BasedOnStyle:  WebKit
+TabWidth:        4
+IndentWidth:     4
+UseTab:          Never
+ColumnLimit: 100
+
+# Other languages JavaScript, Proto
+
 ---
-Language:        Cpp
-AccessModifierOffset: 0
-AlignAfterOpenBracket: Align
+Language: Cpp
+
+# http://releases.llvm.org/6.0.1/tools/clang/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code
+# int formatted_code;
+# // clang-format off
+#     void    unformatted_code  ;
+# // clang-format on
+# void formatted_code_again;
+
+DisableFormat:   false
+Standard: Cpp11
+
+AccessModifierOffset: -4
+AlignAfterOpenBracket: true
 AlignConsecutiveAssignments: true
-AlignConsecutiveDeclarations: false
+AlignConsecutiveDeclarations: true
 AlignEscapedNewlinesLeft: true
 AlignOperands:   true
-AlignTrailingComments: true
+AlignTrailingComments: false
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: true
-AllowShortCaseLabelsOnASingleLine: true
-AllowShortFunctionsOnASingleLine: All
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterDefinitionReturnType: false
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: true
 BinPackArguments: false
 BinPackParameters: false
-BraceWrapping:   
-  AfterClass:      true
-  AfterControlStatement: true
-  AfterEnum:       true
-  AfterFunction:   true
-  AfterNamespace:  false
-  AfterObjCDeclaration: true
-  AfterStruct:     true
-  AfterUnion:      true
-  BeforeCatch:     true
-  BeforeElse:      true
-  IndentBraces:    false
-BreakBeforeBinaryOperators: None
+
+# Configure each individual brace in BraceWrapping
 BreakBeforeBraces: Custom
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
-ColumnLimit:     100
+# Control of individual brace wrapping cases
+BraceWrapping: {
+    AfterClass: 'true'
+    AfterControlStatement: 'true'
+    AfterEnum : 'true'
+    AfterFunction : 'true'
+    AfterNamespace : 'true'
+    AfterStruct : 'true'
+    AfterUnion : 'true'
+    BeforeCatch : 'true'
+    BeforeElse : 'true'
+    IndentBraces : 'false'
+#    AfterExternBlock : 'true'
+}
+
+#BreakAfterJavaFieldAnnotations: true
+#BreakBeforeInheritanceComma: false
+#BreakBeforeBinaryOperators: None
+#BreakBeforeTernaryOperators: true
+#BreakConstructorInitializersBeforeComma: true
+#BreakStringLiterals: true
+
 CommentPragmas:  '^ IWYU pragma:'
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
+#CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
+#SpaceBeforeCpp11BracedList: false
 DerivePointerAlignment: false
-DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
-IncludeCategories: 
-  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
-    Priority:        2
-  - Regex:           '^(<|"(gtest|isl|json)/)'
-    Priority:        3
-  - Regex:           '.*'
-    Priority:        1
 IndentCaseLabels: false
-IndentWidth:     4
-IndentWrappedFunctionNames: false
+#FixNamespaceComments: true
+IndentWrappedFunctionNames: true
 KeepEmptyLinesAtTheStartOfBlocks: true
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
+#JavaScriptQuotes: Double
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
-ObjCBlockIndentWidth: 2
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: true
+NamespaceIndentation: All
+ObjCBlockIndentWidth: 4
+#ObjCSpaceAfterProperty: true
+#ObjCSpaceBeforeProtocolList: true
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
+
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
-ReflowComments:  true
-SortIncludes:    false
 SpaceAfterCStyleCast: false
-# SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: Never
 SpaceInEmptyParentheses: false
@@ -83,8 +106,15 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
-TabWidth:        8
-UseTab:          Never
-...
+#SpaceAfterTemplateKeyword: true
+#SpaceBeforeInheritanceColon: true
 
+#SortUsingDeclarations: true
+SortIncludes: true
+
+# Comments are for developers, they should arrange them
+ReflowComments: false
+
+#IncludeBlocks: Preserve
+#IndentPPDirectives: AfterHash
+---

--- a/.githooks/install
+++ b/.githooks/install
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+cd $(git rev-parse --git-dir)
+cd hooks
+
+echo "Installing hooks..." 
+ln -s ../../.githooks/pre-commit pre-commit
+echo "Done!"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,43 @@
+#!/bin/sh
+#
+# This pre-commit hook checks if any versions of clang-format
+# are installed, and if so, uses the installed version to format
+# the staged changes.
+
+base=/opt/rocm/hcc/bin/clang-format
+format=""
+
+# Redirect output to stderr.
+exec 1>&2
+
+ # check if clang-format is installed
+type "$base" >/dev/null 2>&1 && format="$base"
+
+# no versions of clang-format are installed
+if [ -z "$format" ]
+then
+    echo "$base is not installed. Pre-commit hook will not be executed."
+    exit 0
+fi
+
+# Do everything from top - level
+cd $(git rev-parse --show-toplevel)
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+    against=HEAD
+else
+    # Initial commit: diff against an empty tree object
+    against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+# do the formatting
+for file in $(git diff-index --cached --name-only $against | grep -E '\.h$|\.hpp$|\.cpp$|\.cl$|\.h\.in$|\.hpp\.in$|\.cpp\.in$')
+do
+    if [ -e "$file" ]
+    then
+        echo "$format $file"
+        "$format" -i -style=file "$file"
+    fi
+done
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 // This shared library is available at https://github.com/ROCmSoftwarePlatform/rocJENKINS/
-@Library('rocJenkins') _
+@Library('rocJenkins@clang9') _
 
 // This is file for internal AMD use.
 // If you are interested in running your own Jenkins, please raise a github issue for assistance.

--- a/clients/common/arg_check.cpp
+++ b/clients/common/arg_check.cpp
@@ -23,9 +23,9 @@
 
 #include "arg_check.hpp"
 
-#include <iostream>
 #include <hip/hip_runtime_api.h>
 #include <hipsparse.h>
+#include <iostream>
 
 #ifdef GOOGLE_TEST
 #include <gtest/gtest.h>

--- a/clients/common/hipsparse_template_specialization.cpp
+++ b/clients/common/hipsparse_template_specialization.cpp
@@ -25,512 +25,298 @@
 
 #include <hipsparse.h>
 
-namespace hipsparse {
-
-template <>
-hipsparseStatus_t hipsparseXaxpyi(hipsparseHandle_t handle,
-                                  int nnz,
-                                  const float* alpha,
-                                  const float* x_val,
-                                  const int* x_ind,
-                                  float* y,
-                                  hipsparseIndexBase_t idx_base)
+namespace hipsparse
 {
-    return hipsparseSaxpyi(handle, nnz, alpha, x_val, x_ind, y, idx_base);
-}
 
-template <>
-hipsparseStatus_t hipsparseXaxpyi(hipsparseHandle_t handle,
-                                  int nnz,
-                                  const double* alpha,
-                                  const double* x_val,
-                                  const int* x_ind,
-                                  double* y,
-                                  hipsparseIndexBase_t idx_base)
-{
-    return hipsparseDaxpyi(handle, nnz, alpha, x_val, x_ind, y, idx_base);
-}
+    template <>
+    hipsparseStatus_t hipsparseXaxpyi(hipsparseHandle_t    handle,
+                                      int                  nnz,
+                                      const float*         alpha,
+                                      const float*         x_val,
+                                      const int*           x_ind,
+                                      float*               y,
+                                      hipsparseIndexBase_t idx_base)
+    {
+        return hipsparseSaxpyi(handle, nnz, alpha, x_val, x_ind, y, idx_base);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXdoti(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const float* x_val,
-                                 const int* x_ind,
-                                 const float* y,
-                                 float* result,
-                                 hipsparseIndexBase_t idx_base)
-{
-    return hipsparseSdoti(handle, nnz, x_val, x_ind, y, result, idx_base);
-}
+    template <>
+    hipsparseStatus_t hipsparseXaxpyi(hipsparseHandle_t    handle,
+                                      int                  nnz,
+                                      const double*        alpha,
+                                      const double*        x_val,
+                                      const int*           x_ind,
+                                      double*              y,
+                                      hipsparseIndexBase_t idx_base)
+    {
+        return hipsparseDaxpyi(handle, nnz, alpha, x_val, x_ind, y, idx_base);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXdoti(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const double* x_val,
-                                 const int* x_ind,
-                                 const double* y,
-                                 double* result,
-                                 hipsparseIndexBase_t idx_base)
-{
-    return hipsparseDdoti(handle, nnz, x_val, x_ind, y, result, idx_base);
-}
+    template <>
+    hipsparseStatus_t hipsparseXdoti(hipsparseHandle_t    handle,
+                                     int                  nnz,
+                                     const float*         x_val,
+                                     const int*           x_ind,
+                                     const float*         y,
+                                     float*               result,
+                                     hipsparseIndexBase_t idx_base)
+    {
+        return hipsparseSdoti(handle, nnz, x_val, x_ind, y, result, idx_base);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXgthr(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const float* y,
-                                 float* x_val,
-                                 const int* x_ind,
-                                 hipsparseIndexBase_t idx_base)
-{
-    return hipsparseSgthr(handle, nnz, y, x_val, x_ind, idx_base);
-}
+    template <>
+    hipsparseStatus_t hipsparseXdoti(hipsparseHandle_t    handle,
+                                     int                  nnz,
+                                     const double*        x_val,
+                                     const int*           x_ind,
+                                     const double*        y,
+                                     double*              result,
+                                     hipsparseIndexBase_t idx_base)
+    {
+        return hipsparseDdoti(handle, nnz, x_val, x_ind, y, result, idx_base);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXgthr(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const double* y,
-                                 double* x_val,
-                                 const int* x_ind,
-                                 hipsparseIndexBase_t idx_base)
-{
-    return hipsparseDgthr(handle, nnz, y, x_val, x_ind, idx_base);
-}
+    template <>
+    hipsparseStatus_t hipsparseXgthr(hipsparseHandle_t    handle,
+                                     int                  nnz,
+                                     const float*         y,
+                                     float*               x_val,
+                                     const int*           x_ind,
+                                     hipsparseIndexBase_t idx_base)
+    {
+        return hipsparseSgthr(handle, nnz, y, x_val, x_ind, idx_base);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXgthrz(hipsparseHandle_t handle,
-                                  int nnz,
-                                  float* y,
-                                  float* x_val,
-                                  const int* x_ind,
-                                  hipsparseIndexBase_t idx_base)
-{
-    return hipsparseSgthrz(handle, nnz, y, x_val, x_ind, idx_base);
-}
+    template <>
+    hipsparseStatus_t hipsparseXgthr(hipsparseHandle_t    handle,
+                                     int                  nnz,
+                                     const double*        y,
+                                     double*              x_val,
+                                     const int*           x_ind,
+                                     hipsparseIndexBase_t idx_base)
+    {
+        return hipsparseDgthr(handle, nnz, y, x_val, x_ind, idx_base);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXgthrz(hipsparseHandle_t handle,
-                                  int nnz,
-                                  double* y,
-                                  double* x_val,
-                                  const int* x_ind,
-                                  hipsparseIndexBase_t idx_base)
-{
-    return hipsparseDgthrz(handle, nnz, y, x_val, x_ind, idx_base);
-}
+    template <>
+    hipsparseStatus_t hipsparseXgthrz(hipsparseHandle_t    handle,
+                                      int                  nnz,
+                                      float*               y,
+                                      float*               x_val,
+                                      const int*           x_ind,
+                                      hipsparseIndexBase_t idx_base)
+    {
+        return hipsparseSgthrz(handle, nnz, y, x_val, x_ind, idx_base);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXroti(hipsparseHandle_t handle,
-                                 int nnz,
-                                 float* x_val,
-                                 const int* x_ind,
-                                 float* y,
-                                 const float* c,
-                                 const float* s,
-                                 hipsparseIndexBase_t idx_base)
-{
-    return hipsparseSroti(handle, nnz, x_val, x_ind, y, c, s, idx_base);
-}
+    template <>
+    hipsparseStatus_t hipsparseXgthrz(hipsparseHandle_t    handle,
+                                      int                  nnz,
+                                      double*              y,
+                                      double*              x_val,
+                                      const int*           x_ind,
+                                      hipsparseIndexBase_t idx_base)
+    {
+        return hipsparseDgthrz(handle, nnz, y, x_val, x_ind, idx_base);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXroti(hipsparseHandle_t handle,
-                                 int nnz,
-                                 double* x_val,
-                                 const int* x_ind,
-                                 double* y,
-                                 const double* c,
-                                 const double* s,
-                                 hipsparseIndexBase_t idx_base)
-{
-    return hipsparseDroti(handle, nnz, x_val, x_ind, y, c, s, idx_base);
-}
+    template <>
+    hipsparseStatus_t hipsparseXroti(hipsparseHandle_t    handle,
+                                     int                  nnz,
+                                     float*               x_val,
+                                     const int*           x_ind,
+                                     float*               y,
+                                     const float*         c,
+                                     const float*         s,
+                                     hipsparseIndexBase_t idx_base)
+    {
+        return hipsparseSroti(handle, nnz, x_val, x_ind, y, c, s, idx_base);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXsctr(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const float* x_val,
-                                 const int* x_ind,
-                                 float* y,
-                                 hipsparseIndexBase_t idx_base)
-{
-    return hipsparseSsctr(handle, nnz, x_val, x_ind, y, idx_base);
-}
+    template <>
+    hipsparseStatus_t hipsparseXroti(hipsparseHandle_t    handle,
+                                     int                  nnz,
+                                     double*              x_val,
+                                     const int*           x_ind,
+                                     double*              y,
+                                     const double*        c,
+                                     const double*        s,
+                                     hipsparseIndexBase_t idx_base)
+    {
+        return hipsparseDroti(handle, nnz, x_val, x_ind, y, c, s, idx_base);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXsctr(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const double* x_val,
-                                 const int* x_ind,
-                                 double* y,
-                                 hipsparseIndexBase_t idx_base)
-{
-    return hipsparseDsctr(handle, nnz, x_val, x_ind, y, idx_base);
-}
+    template <>
+    hipsparseStatus_t hipsparseXsctr(hipsparseHandle_t    handle,
+                                     int                  nnz,
+                                     const float*         x_val,
+                                     const int*           x_ind,
+                                     float*               y,
+                                     hipsparseIndexBase_t idx_base)
+    {
+        return hipsparseSsctr(handle, nnz, x_val, x_ind, y, idx_base);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXcsrmv(hipsparseHandle_t handle,
-                                  hipsparseOperation_t trans,
-                                  int m,
-                                  int n,
-                                  int nnz,
-                                  const float* alpha,
-                                  const hipsparseMatDescr_t descr,
-                                  const float* csr_val,
-                                  const int* csr_row_ptr,
-                                  const int* csr_col_ind,
-                                  const float* x,
-                                  const float* beta,
-                                  float* y)
-{
-    return hipsparseScsrmv(
-        handle, trans, m, n, nnz, alpha, descr, csr_val, csr_row_ptr, csr_col_ind, x, beta, y);
-}
+    template <>
+    hipsparseStatus_t hipsparseXsctr(hipsparseHandle_t    handle,
+                                     int                  nnz,
+                                     const double*        x_val,
+                                     const int*           x_ind,
+                                     double*              y,
+                                     hipsparseIndexBase_t idx_base)
+    {
+        return hipsparseDsctr(handle, nnz, x_val, x_ind, y, idx_base);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXcsrmv(hipsparseHandle_t handle,
-                                  hipsparseOperation_t trans,
-                                  int m,
-                                  int n,
-                                  int nnz,
-                                  const double* alpha,
-                                  const hipsparseMatDescr_t descr,
-                                  const double* csr_val,
-                                  const int* csr_row_ptr,
-                                  const int* csr_col_ind,
-                                  const double* x,
-                                  const double* beta,
-                                  double* y)
-{
-    return hipsparseDcsrmv(
-        handle, trans, m, n, nnz, alpha, descr, csr_val, csr_row_ptr, csr_col_ind, x, beta, y);
-}
+    template <>
+    hipsparseStatus_t hipsparseXcsrmv(hipsparseHandle_t         handle,
+                                      hipsparseOperation_t      trans,
+                                      int                       m,
+                                      int                       n,
+                                      int                       nnz,
+                                      const float*              alpha,
+                                      const hipsparseMatDescr_t descr,
+                                      const float*              csr_val,
+                                      const int*                csr_row_ptr,
+                                      const int*                csr_col_ind,
+                                      const float*              x,
+                                      const float*              beta,
+                                      float*                    y)
+    {
+        return hipsparseScsrmv(
+            handle, trans, m, n, nnz, alpha, descr, csr_val, csr_row_ptr, csr_col_ind, x, beta, y);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXcsrsv2_bufferSize(hipsparseHandle_t handle,
-                                              hipsparseOperation_t transA,
-                                              int m,
-                                              int nnz,
-                                              const hipsparseMatDescr_t descrA,
-                                              float* csrSortedValA,
-                                              const int* csrSortedRowPtrA,
-                                              const int* csrSortedColIndA,
-                                              csrsv2Info_t info,
-                                              int* pBufferSizeInBytes)
-{
-    return hipsparseScsrsv2_bufferSize(handle,
-                                       transA,
-                                       m,
-                                       nnz,
-                                       descrA,
-                                       csrSortedValA,
-                                       csrSortedRowPtrA,
-                                       csrSortedColIndA,
-                                       info,
-                                       pBufferSizeInBytes);
-}
+    template <>
+    hipsparseStatus_t hipsparseXcsrmv(hipsparseHandle_t         handle,
+                                      hipsparseOperation_t      trans,
+                                      int                       m,
+                                      int                       n,
+                                      int                       nnz,
+                                      const double*             alpha,
+                                      const hipsparseMatDescr_t descr,
+                                      const double*             csr_val,
+                                      const int*                csr_row_ptr,
+                                      const int*                csr_col_ind,
+                                      const double*             x,
+                                      const double*             beta,
+                                      double*                   y)
+    {
+        return hipsparseDcsrmv(
+            handle, trans, m, n, nnz, alpha, descr, csr_val, csr_row_ptr, csr_col_ind, x, beta, y);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXcsrsv2_bufferSize(hipsparseHandle_t handle,
-                                              hipsparseOperation_t transA,
-                                              int m,
-                                              int nnz,
-                                              const hipsparseMatDescr_t descrA,
-                                              double* csrSortedValA,
-                                              const int* csrSortedRowPtrA,
-                                              const int* csrSortedColIndA,
-                                              csrsv2Info_t info,
-                                              int* pBufferSizeInBytes)
-{
-    return hipsparseDcsrsv2_bufferSize(handle,
-                                       transA,
-                                       m,
-                                       nnz,
-                                       descrA,
-                                       csrSortedValA,
-                                       csrSortedRowPtrA,
-                                       csrSortedColIndA,
-                                       info,
-                                       pBufferSizeInBytes);
-}
+    template <>
+    hipsparseStatus_t hipsparseXcsrsv2_bufferSize(hipsparseHandle_t         handle,
+                                                  hipsparseOperation_t      transA,
+                                                  int                       m,
+                                                  int                       nnz,
+                                                  const hipsparseMatDescr_t descrA,
+                                                  float*                    csrSortedValA,
+                                                  const int*                csrSortedRowPtrA,
+                                                  const int*                csrSortedColIndA,
+                                                  csrsv2Info_t              info,
+                                                  int*                      pBufferSizeInBytes)
+    {
+        return hipsparseScsrsv2_bufferSize(handle,
+                                           transA,
+                                           m,
+                                           nnz,
+                                           descrA,
+                                           csrSortedValA,
+                                           csrSortedRowPtrA,
+                                           csrSortedColIndA,
+                                           info,
+                                           pBufferSizeInBytes);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXcsrsv2_bufferSizeExt(hipsparseHandle_t handle,
-                                                 hipsparseOperation_t transA,
-                                                 int m,
-                                                 int nnz,
-                                                 const hipsparseMatDescr_t descrA,
-                                                 float* csrSortedValA,
-                                                 const int* csrSortedRowPtrA,
-                                                 const int* csrSortedColIndA,
-                                                 csrsv2Info_t info,
-                                                 size_t* pBufferSize)
-{
-    return hipsparseScsrsv2_bufferSizeExt(handle,
-                                          transA,
-                                          m,
-                                          nnz,
-                                          descrA,
-                                          csrSortedValA,
-                                          csrSortedRowPtrA,
-                                          csrSortedColIndA,
-                                          info,
-                                          pBufferSize);
-}
+    template <>
+    hipsparseStatus_t hipsparseXcsrsv2_bufferSize(hipsparseHandle_t         handle,
+                                                  hipsparseOperation_t      transA,
+                                                  int                       m,
+                                                  int                       nnz,
+                                                  const hipsparseMatDescr_t descrA,
+                                                  double*                   csrSortedValA,
+                                                  const int*                csrSortedRowPtrA,
+                                                  const int*                csrSortedColIndA,
+                                                  csrsv2Info_t              info,
+                                                  int*                      pBufferSizeInBytes)
+    {
+        return hipsparseDcsrsv2_bufferSize(handle,
+                                           transA,
+                                           m,
+                                           nnz,
+                                           descrA,
+                                           csrSortedValA,
+                                           csrSortedRowPtrA,
+                                           csrSortedColIndA,
+                                           info,
+                                           pBufferSizeInBytes);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXcsrsv2_bufferSizeExt(hipsparseHandle_t handle,
-                                                 hipsparseOperation_t transA,
-                                                 int m,
-                                                 int nnz,
-                                                 const hipsparseMatDescr_t descrA,
-                                                 double* csrSortedValA,
-                                                 const int* csrSortedRowPtrA,
-                                                 const int* csrSortedColIndA,
-                                                 csrsv2Info_t info,
-                                                 size_t* pBufferSize)
-{
-    return hipsparseDcsrsv2_bufferSizeExt(handle,
-                                          transA,
-                                          m,
-                                          nnz,
-                                          descrA,
-                                          csrSortedValA,
-                                          csrSortedRowPtrA,
-                                          csrSortedColIndA,
-                                          info,
-                                          pBufferSize);
-}
+    template <>
+    hipsparseStatus_t hipsparseXcsrsv2_bufferSizeExt(hipsparseHandle_t         handle,
+                                                     hipsparseOperation_t      transA,
+                                                     int                       m,
+                                                     int                       nnz,
+                                                     const hipsparseMatDescr_t descrA,
+                                                     float*                    csrSortedValA,
+                                                     const int*                csrSortedRowPtrA,
+                                                     const int*                csrSortedColIndA,
+                                                     csrsv2Info_t              info,
+                                                     size_t*                   pBufferSize)
+    {
+        return hipsparseScsrsv2_bufferSizeExt(handle,
+                                              transA,
+                                              m,
+                                              nnz,
+                                              descrA,
+                                              csrSortedValA,
+                                              csrSortedRowPtrA,
+                                              csrSortedColIndA,
+                                              info,
+                                              pBufferSize);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXcsrsv2_analysis(hipsparseHandle_t handle,
-                                            hipsparseOperation_t transA,
-                                            int m,
-                                            int nnz,
-                                            const hipsparseMatDescr_t descrA,
-                                            const float* csrSortedValA,
-                                            const int* csrSortedRowPtrA,
-                                            const int* csrSortedColIndA,
-                                            csrsv2Info_t info,
-                                            hipsparseSolvePolicy_t policy,
-                                            void* pBuffer)
-{
-    return hipsparseScsrsv2_analysis(handle,
-                                     transA,
-                                     m,
-                                     nnz,
-                                     descrA,
-                                     csrSortedValA,
-                                     csrSortedRowPtrA,
-                                     csrSortedColIndA,
-                                     info,
-                                     policy,
-                                     pBuffer);
-}
+    template <>
+    hipsparseStatus_t hipsparseXcsrsv2_bufferSizeExt(hipsparseHandle_t         handle,
+                                                     hipsparseOperation_t      transA,
+                                                     int                       m,
+                                                     int                       nnz,
+                                                     const hipsparseMatDescr_t descrA,
+                                                     double*                   csrSortedValA,
+                                                     const int*                csrSortedRowPtrA,
+                                                     const int*                csrSortedColIndA,
+                                                     csrsv2Info_t              info,
+                                                     size_t*                   pBufferSize)
+    {
+        return hipsparseDcsrsv2_bufferSizeExt(handle,
+                                              transA,
+                                              m,
+                                              nnz,
+                                              descrA,
+                                              csrSortedValA,
+                                              csrSortedRowPtrA,
+                                              csrSortedColIndA,
+                                              info,
+                                              pBufferSize);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXcsrsv2_analysis(hipsparseHandle_t handle,
-                                            hipsparseOperation_t transA,
-                                            int m,
-                                            int nnz,
-                                            const hipsparseMatDescr_t descrA,
-                                            const double* csrSortedValA,
-                                            const int* csrSortedRowPtrA,
-                                            const int* csrSortedColIndA,
-                                            csrsv2Info_t info,
-                                            hipsparseSolvePolicy_t policy,
-                                            void* pBuffer)
-{
-    return hipsparseDcsrsv2_analysis(handle,
-                                     transA,
-                                     m,
-                                     nnz,
-                                     descrA,
-                                     csrSortedValA,
-                                     csrSortedRowPtrA,
-                                     csrSortedColIndA,
-                                     info,
-                                     policy,
-                                     pBuffer);
-}
-
-template <>
-hipsparseStatus_t hipsparseXcsrsv2_solve(hipsparseHandle_t handle,
-                                         hipsparseOperation_t transA,
-                                         int m,
-                                         int nnz,
-                                         const float* alpha,
-                                         const hipsparseMatDescr_t descrA,
-                                         const float* csrSortedValA,
-                                         const int* csrSortedRowPtrA,
-                                         const int* csrSortedColIndA,
-                                         csrsv2Info_t info,
-                                         const float* f,
-                                         float* x,
-                                         hipsparseSolvePolicy_t policy,
-                                         void* pBuffer)
-{
-    return hipsparseScsrsv2_solve(handle,
-                                  transA,
-                                  m,
-                                  nnz,
-                                  alpha,
-                                  descrA,
-                                  csrSortedValA,
-                                  csrSortedRowPtrA,
-                                  csrSortedColIndA,
-                                  info,
-                                  f,
-                                  x,
-                                  policy,
-                                  pBuffer);
-}
-
-template <>
-hipsparseStatus_t hipsparseXcsrsv2_solve(hipsparseHandle_t handle,
-                                         hipsparseOperation_t transA,
-                                         int m,
-                                         int nnz,
-                                         const double* alpha,
-                                         const hipsparseMatDescr_t descrA,
-                                         const double* csrSortedValA,
-                                         const int* csrSortedRowPtrA,
-                                         const int* csrSortedColIndA,
-                                         csrsv2Info_t info,
-                                         const double* f,
-                                         double* x,
-                                         hipsparseSolvePolicy_t policy,
-                                         void* pBuffer)
-{
-    return hipsparseDcsrsv2_solve(handle,
-                                  transA,
-                                  m,
-                                  nnz,
-                                  alpha,
-                                  descrA,
-                                  csrSortedValA,
-                                  csrSortedRowPtrA,
-                                  csrSortedColIndA,
-                                  info,
-                                  f,
-                                  x,
-                                  policy,
-                                  pBuffer);
-}
-
-template <>
-hipsparseStatus_t hipsparseXhybmv(hipsparseHandle_t handle,
-                                  hipsparseOperation_t trans,
-                                  const float* alpha,
-                                  const hipsparseMatDescr_t descr,
-                                  const hipsparseHybMat_t hyb,
-                                  const float* x,
-                                  const float* beta,
-                                  float* y)
-{
-    return hipsparseShybmv(handle, trans, alpha, descr, hyb, x, beta, y);
-}
-
-template <>
-hipsparseStatus_t hipsparseXhybmv(hipsparseHandle_t handle,
-                                  hipsparseOperation_t trans,
-                                  const double* alpha,
-                                  const hipsparseMatDescr_t descr,
-                                  const hipsparseHybMat_t hyb,
-                                  const double* x,
-                                  const double* beta,
-                                  double* y)
-{
-    return hipsparseDhybmv(handle, trans, alpha, descr, hyb, x, beta, y);
-}
-
-template <>
-hipsparseStatus_t hipsparseXcsrmm2(hipsparseHandle_t handle,
-                                   hipsparseOperation_t trans_A,
-                                   hipsparseOperation_t trans_B,
-                                   int m,
-                                   int n,
-                                   int k,
-                                   int nnz,
-                                   const float* alpha,
-                                   const hipsparseMatDescr_t descr,
-                                   const float* csr_val,
-                                   const int* csr_row_ptr,
-                                   const int* csr_col_ind,
-                                   const float* B,
-                                   int ldb,
-                                   const float* beta,
-                                   float* C,
-                                   int ldc)
-{
-    return hipsparseScsrmm2(handle,
-                            trans_A,
-                            trans_B,
-                            m,
-                            n,
-                            k,
-                            nnz,
-                            alpha,
-                            descr,
-                            csr_val,
-                            csr_row_ptr,
-                            csr_col_ind,
-                            B,
-                            ldb,
-                            beta,
-                            C,
-                            ldc);
-}
-
-template <>
-hipsparseStatus_t hipsparseXcsrmm2(hipsparseHandle_t handle,
-                                   hipsparseOperation_t trans_A,
-                                   hipsparseOperation_t trans_B,
-                                   int m,
-                                   int n,
-                                   int k,
-                                   int nnz,
-                                   const double* alpha,
-                                   const hipsparseMatDescr_t descr,
-                                   const double* csr_val,
-                                   const int* csr_row_ptr,
-                                   const int* csr_col_ind,
-                                   const double* B,
-                                   int ldb,
-                                   const double* beta,
-                                   double* C,
-                                   int ldc)
-{
-    return hipsparseDcsrmm2(handle,
-                            trans_A,
-                            trans_B,
-                            m,
-                            n,
-                            k,
-                            nnz,
-                            alpha,
-                            descr,
-                            csr_val,
-                            csr_row_ptr,
-                            csr_col_ind,
-                            B,
-                            ldb,
-                            beta,
-                            C,
-                            ldc);
-}
-
-template <>
-hipsparseStatus_t hipsparseXcsrilu02_bufferSize(hipsparseHandle_t handle,
-                                                int m,
-                                                int nnz,
+    template <>
+    hipsparseStatus_t hipsparseXcsrsv2_analysis(hipsparseHandle_t         handle,
+                                                hipsparseOperation_t      transA,
+                                                int                       m,
+                                                int                       nnz,
                                                 const hipsparseMatDescr_t descrA,
-                                                float* csrSortedValA,
-                                                const int* csrSortedRowPtrA,
-                                                const int* csrSortedColIndA,
-                                                csrilu02Info_t info,
-                                                int* pBufferSizeInBytes)
-{
-    return hipsparseScsrilu02_bufferSize(handle,
+                                                const float*              csrSortedValA,
+                                                const int*                csrSortedRowPtrA,
+                                                const int*                csrSortedColIndA,
+                                                csrsv2Info_t              info,
+                                                hipsparseSolvePolicy_t    policy,
+                                                void*                     pBuffer)
+    {
+        return hipsparseScsrsv2_analysis(handle,
+                                         transA,
                                          m,
                                          nnz,
                                          descrA,
@@ -538,21 +324,25 @@ hipsparseStatus_t hipsparseXcsrilu02_bufferSize(hipsparseHandle_t handle,
                                          csrSortedRowPtrA,
                                          csrSortedColIndA,
                                          info,
-                                         pBufferSizeInBytes);
-}
+                                         policy,
+                                         pBuffer);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXcsrilu02_bufferSize(hipsparseHandle_t handle,
-                                                int m,
-                                                int nnz,
+    template <>
+    hipsparseStatus_t hipsparseXcsrsv2_analysis(hipsparseHandle_t         handle,
+                                                hipsparseOperation_t      transA,
+                                                int                       m,
+                                                int                       nnz,
                                                 const hipsparseMatDescr_t descrA,
-                                                double* csrSortedValA,
-                                                const int* csrSortedRowPtrA,
-                                                const int* csrSortedColIndA,
-                                                csrilu02Info_t info,
-                                                int* pBufferSizeInBytes)
-{
-    return hipsparseDcsrilu02_bufferSize(handle,
+                                                const double*             csrSortedValA,
+                                                const int*                csrSortedRowPtrA,
+                                                const int*                csrSortedColIndA,
+                                                csrsv2Info_t              info,
+                                                hipsparseSolvePolicy_t    policy,
+                                                void*                     pBuffer)
+    {
+        return hipsparseDcsrsv2_analysis(handle,
+                                         transA,
                                          m,
                                          nnz,
                                          descrA,
@@ -560,255 +350,466 @@ hipsparseStatus_t hipsparseXcsrilu02_bufferSize(hipsparseHandle_t handle,
                                          csrSortedRowPtrA,
                                          csrSortedColIndA,
                                          info,
-                                         pBufferSizeInBytes);
-}
+                                         policy,
+                                         pBuffer);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXcsrilu02_bufferSizeExt(hipsparseHandle_t handle,
-                                                   int m,
-                                                   int nnz,
-                                                   const hipsparseMatDescr_t descrA,
-                                                   float* csrSortedValA,
-                                                   const int* csrSortedRowPtrA,
-                                                   const int* csrSortedColIndA,
-                                                   csrilu02Info_t info,
-                                                   size_t* pBufferSize)
-{
-    return hipsparseScsrilu02_bufferSizeExt(handle,
-                                            m,
-                                            nnz,
-                                            descrA,
-                                            csrSortedValA,
-                                            csrSortedRowPtrA,
-                                            csrSortedColIndA,
-                                            info,
-                                            pBufferSize);
-}
+    template <>
+    hipsparseStatus_t hipsparseXcsrsv2_solve(hipsparseHandle_t         handle,
+                                             hipsparseOperation_t      transA,
+                                             int                       m,
+                                             int                       nnz,
+                                             const float*              alpha,
+                                             const hipsparseMatDescr_t descrA,
+                                             const float*              csrSortedValA,
+                                             const int*                csrSortedRowPtrA,
+                                             const int*                csrSortedColIndA,
+                                             csrsv2Info_t              info,
+                                             const float*              f,
+                                             float*                    x,
+                                             hipsparseSolvePolicy_t    policy,
+                                             void*                     pBuffer)
+    {
+        return hipsparseScsrsv2_solve(handle,
+                                      transA,
+                                      m,
+                                      nnz,
+                                      alpha,
+                                      descrA,
+                                      csrSortedValA,
+                                      csrSortedRowPtrA,
+                                      csrSortedColIndA,
+                                      info,
+                                      f,
+                                      x,
+                                      policy,
+                                      pBuffer);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXcsrilu02_bufferSizeExt(hipsparseHandle_t handle,
-                                                   int m,
-                                                   int nnz,
-                                                   const hipsparseMatDescr_t descrA,
-                                                   double* csrSortedValA,
-                                                   const int* csrSortedRowPtrA,
-                                                   const int* csrSortedColIndA,
-                                                   csrilu02Info_t info,
-                                                   size_t* pBufferSize)
-{
-    return hipsparseDcsrilu02_bufferSizeExt(handle,
-                                            m,
-                                            nnz,
-                                            descrA,
-                                            csrSortedValA,
-                                            csrSortedRowPtrA,
-                                            csrSortedColIndA,
-                                            info,
-                                            pBufferSize);
-}
+    template <>
+    hipsparseStatus_t hipsparseXcsrsv2_solve(hipsparseHandle_t         handle,
+                                             hipsparseOperation_t      transA,
+                                             int                       m,
+                                             int                       nnz,
+                                             const double*             alpha,
+                                             const hipsparseMatDescr_t descrA,
+                                             const double*             csrSortedValA,
+                                             const int*                csrSortedRowPtrA,
+                                             const int*                csrSortedColIndA,
+                                             csrsv2Info_t              info,
+                                             const double*             f,
+                                             double*                   x,
+                                             hipsparseSolvePolicy_t    policy,
+                                             void*                     pBuffer)
+    {
+        return hipsparseDcsrsv2_solve(handle,
+                                      transA,
+                                      m,
+                                      nnz,
+                                      alpha,
+                                      descrA,
+                                      csrSortedValA,
+                                      csrSortedRowPtrA,
+                                      csrSortedColIndA,
+                                      info,
+                                      f,
+                                      x,
+                                      policy,
+                                      pBuffer);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXcsrilu02_analysis(hipsparseHandle_t handle,
-                                              int m,
-                                              int nnz,
-                                              const hipsparseMatDescr_t descrA,
-                                              const float* csrSortedValA,
-                                              const int* csrSortedRowPtrA,
-                                              const int* csrSortedColIndA,
-                                              csrilu02Info_t info,
-                                              hipsparseSolvePolicy_t policy,
-                                              void* pBuffer)
-{
-    return hipsparseScsrilu02_analysis(handle,
-                                       m,
-                                       nnz,
-                                       descrA,
-                                       csrSortedValA,
-                                       csrSortedRowPtrA,
-                                       csrSortedColIndA,
-                                       info,
-                                       policy,
-                                       pBuffer);
-}
+    template <>
+    hipsparseStatus_t hipsparseXhybmv(hipsparseHandle_t         handle,
+                                      hipsparseOperation_t      trans,
+                                      const float*              alpha,
+                                      const hipsparseMatDescr_t descr,
+                                      const hipsparseHybMat_t   hyb,
+                                      const float*              x,
+                                      const float*              beta,
+                                      float*                    y)
+    {
+        return hipsparseShybmv(handle, trans, alpha, descr, hyb, x, beta, y);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXcsrilu02_analysis(hipsparseHandle_t handle,
-                                              int m,
-                                              int nnz,
-                                              const hipsparseMatDescr_t descrA,
-                                              const double* csrSortedValA,
-                                              const int* csrSortedRowPtrA,
-                                              const int* csrSortedColIndA,
-                                              csrilu02Info_t info,
-                                              hipsparseSolvePolicy_t policy,
-                                              void* pBuffer)
-{
-    return hipsparseDcsrilu02_analysis(handle,
-                                       m,
-                                       nnz,
-                                       descrA,
-                                       csrSortedValA,
-                                       csrSortedRowPtrA,
-                                       csrSortedColIndA,
-                                       info,
-                                       policy,
-                                       pBuffer);
-}
+    template <>
+    hipsparseStatus_t hipsparseXhybmv(hipsparseHandle_t         handle,
+                                      hipsparseOperation_t      trans,
+                                      const double*             alpha,
+                                      const hipsparseMatDescr_t descr,
+                                      const hipsparseHybMat_t   hyb,
+                                      const double*             x,
+                                      const double*             beta,
+                                      double*                   y)
+    {
+        return hipsparseDhybmv(handle, trans, alpha, descr, hyb, x, beta, y);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXcsrilu02(hipsparseHandle_t handle,
-                                     int m,
-                                     int nnz,
-                                     const hipsparseMatDescr_t descrA,
-                                     float* csrSortedValA_valM,
-                                     /* matrix A values are updated inplace
+    template <>
+    hipsparseStatus_t hipsparseXcsrmm2(hipsparseHandle_t         handle,
+                                       hipsparseOperation_t      trans_A,
+                                       hipsparseOperation_t      trans_B,
+                                       int                       m,
+                                       int                       n,
+                                       int                       k,
+                                       int                       nnz,
+                                       const float*              alpha,
+                                       const hipsparseMatDescr_t descr,
+                                       const float*              csr_val,
+                                       const int*                csr_row_ptr,
+                                       const int*                csr_col_ind,
+                                       const float*              B,
+                                       int                       ldb,
+                                       const float*              beta,
+                                       float*                    C,
+                                       int                       ldc)
+    {
+        return hipsparseScsrmm2(handle,
+                                trans_A,
+                                trans_B,
+                                m,
+                                n,
+                                k,
+                                nnz,
+                                alpha,
+                                descr,
+                                csr_val,
+                                csr_row_ptr,
+                                csr_col_ind,
+                                B,
+                                ldb,
+                                beta,
+                                C,
+                                ldc);
+    }
+
+    template <>
+    hipsparseStatus_t hipsparseXcsrmm2(hipsparseHandle_t         handle,
+                                       hipsparseOperation_t      trans_A,
+                                       hipsparseOperation_t      trans_B,
+                                       int                       m,
+                                       int                       n,
+                                       int                       k,
+                                       int                       nnz,
+                                       const double*             alpha,
+                                       const hipsparseMatDescr_t descr,
+                                       const double*             csr_val,
+                                       const int*                csr_row_ptr,
+                                       const int*                csr_col_ind,
+                                       const double*             B,
+                                       int                       ldb,
+                                       const double*             beta,
+                                       double*                   C,
+                                       int                       ldc)
+    {
+        return hipsparseDcsrmm2(handle,
+                                trans_A,
+                                trans_B,
+                                m,
+                                n,
+                                k,
+                                nnz,
+                                alpha,
+                                descr,
+                                csr_val,
+                                csr_row_ptr,
+                                csr_col_ind,
+                                B,
+                                ldb,
+                                beta,
+                                C,
+                                ldc);
+    }
+
+    template <>
+    hipsparseStatus_t hipsparseXcsrilu02_bufferSize(hipsparseHandle_t         handle,
+                                                    int                       m,
+                                                    int                       nnz,
+                                                    const hipsparseMatDescr_t descrA,
+                                                    float*                    csrSortedValA,
+                                                    const int*                csrSortedRowPtrA,
+                                                    const int*                csrSortedColIndA,
+                                                    csrilu02Info_t            info,
+                                                    int*                      pBufferSizeInBytes)
+    {
+        return hipsparseScsrilu02_bufferSize(handle,
+                                             m,
+                                             nnz,
+                                             descrA,
+                                             csrSortedValA,
+                                             csrSortedRowPtrA,
+                                             csrSortedColIndA,
+                                             info,
+                                             pBufferSizeInBytes);
+    }
+
+    template <>
+    hipsparseStatus_t hipsparseXcsrilu02_bufferSize(hipsparseHandle_t         handle,
+                                                    int                       m,
+                                                    int                       nnz,
+                                                    const hipsparseMatDescr_t descrA,
+                                                    double*                   csrSortedValA,
+                                                    const int*                csrSortedRowPtrA,
+                                                    const int*                csrSortedColIndA,
+                                                    csrilu02Info_t            info,
+                                                    int*                      pBufferSizeInBytes)
+    {
+        return hipsparseDcsrilu02_bufferSize(handle,
+                                             m,
+                                             nnz,
+                                             descrA,
+                                             csrSortedValA,
+                                             csrSortedRowPtrA,
+                                             csrSortedColIndA,
+                                             info,
+                                             pBufferSizeInBytes);
+    }
+
+    template <>
+    hipsparseStatus_t hipsparseXcsrilu02_bufferSizeExt(hipsparseHandle_t         handle,
+                                                       int                       m,
+                                                       int                       nnz,
+                                                       const hipsparseMatDescr_t descrA,
+                                                       float*                    csrSortedValA,
+                                                       const int*                csrSortedRowPtrA,
+                                                       const int*                csrSortedColIndA,
+                                                       csrilu02Info_t            info,
+                                                       size_t*                   pBufferSize)
+    {
+        return hipsparseScsrilu02_bufferSizeExt(handle,
+                                                m,
+                                                nnz,
+                                                descrA,
+                                                csrSortedValA,
+                                                csrSortedRowPtrA,
+                                                csrSortedColIndA,
+                                                info,
+                                                pBufferSize);
+    }
+
+    template <>
+    hipsparseStatus_t hipsparseXcsrilu02_bufferSizeExt(hipsparseHandle_t         handle,
+                                                       int                       m,
+                                                       int                       nnz,
+                                                       const hipsparseMatDescr_t descrA,
+                                                       double*                   csrSortedValA,
+                                                       const int*                csrSortedRowPtrA,
+                                                       const int*                csrSortedColIndA,
+                                                       csrilu02Info_t            info,
+                                                       size_t*                   pBufferSize)
+    {
+        return hipsparseDcsrilu02_bufferSizeExt(handle,
+                                                m,
+                                                nnz,
+                                                descrA,
+                                                csrSortedValA,
+                                                csrSortedRowPtrA,
+                                                csrSortedColIndA,
+                                                info,
+                                                pBufferSize);
+    }
+
+    template <>
+    hipsparseStatus_t hipsparseXcsrilu02_analysis(hipsparseHandle_t         handle,
+                                                  int                       m,
+                                                  int                       nnz,
+                                                  const hipsparseMatDescr_t descrA,
+                                                  const float*              csrSortedValA,
+                                                  const int*                csrSortedRowPtrA,
+                                                  const int*                csrSortedColIndA,
+                                                  csrilu02Info_t            info,
+                                                  hipsparseSolvePolicy_t    policy,
+                                                  void*                     pBuffer)
+    {
+        return hipsparseScsrilu02_analysis(handle,
+                                           m,
+                                           nnz,
+                                           descrA,
+                                           csrSortedValA,
+                                           csrSortedRowPtrA,
+                                           csrSortedColIndA,
+                                           info,
+                                           policy,
+                                           pBuffer);
+    }
+
+    template <>
+    hipsparseStatus_t hipsparseXcsrilu02_analysis(hipsparseHandle_t         handle,
+                                                  int                       m,
+                                                  int                       nnz,
+                                                  const hipsparseMatDescr_t descrA,
+                                                  const double*             csrSortedValA,
+                                                  const int*                csrSortedRowPtrA,
+                                                  const int*                csrSortedColIndA,
+                                                  csrilu02Info_t            info,
+                                                  hipsparseSolvePolicy_t    policy,
+                                                  void*                     pBuffer)
+    {
+        return hipsparseDcsrilu02_analysis(handle,
+                                           m,
+                                           nnz,
+                                           descrA,
+                                           csrSortedValA,
+                                           csrSortedRowPtrA,
+                                           csrSortedColIndA,
+                                           info,
+                                           policy,
+                                           pBuffer);
+    }
+
+    template <>
+    hipsparseStatus_t hipsparseXcsrilu02(hipsparseHandle_t         handle,
+                                         int                       m,
+                                         int                       nnz,
+                                         const hipsparseMatDescr_t descrA,
+                                         float*                    csrSortedValA_valM,
+                                         /* matrix A values are updated inplace
                                         to be the preconditioner M values */
-                                     const int* csrSortedRowPtrA,
-                                     const int* csrSortedColIndA,
-                                     csrilu02Info_t info,
-                                     hipsparseSolvePolicy_t policy,
-                                     void* pBuffer)
-{
-    return hipsparseScsrilu02(handle,
-                              m,
-                              nnz,
-                              descrA,
-                              csrSortedValA_valM,
-                              csrSortedRowPtrA,
-                              csrSortedColIndA,
-                              info,
-                              policy,
-                              pBuffer);
-}
+                                         const int*             csrSortedRowPtrA,
+                                         const int*             csrSortedColIndA,
+                                         csrilu02Info_t         info,
+                                         hipsparseSolvePolicy_t policy,
+                                         void*                  pBuffer)
+    {
+        return hipsparseScsrilu02(handle,
+                                  m,
+                                  nnz,
+                                  descrA,
+                                  csrSortedValA_valM,
+                                  csrSortedRowPtrA,
+                                  csrSortedColIndA,
+                                  info,
+                                  policy,
+                                  pBuffer);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXcsrilu02(hipsparseHandle_t handle,
-                                     int m,
-                                     int nnz,
-                                     const hipsparseMatDescr_t descrA,
-                                     double* csrSortedValA_valM,
-                                     /* matrix A values are updated inplace
+    template <>
+    hipsparseStatus_t hipsparseXcsrilu02(hipsparseHandle_t         handle,
+                                         int                       m,
+                                         int                       nnz,
+                                         const hipsparseMatDescr_t descrA,
+                                         double*                   csrSortedValA_valM,
+                                         /* matrix A values are updated inplace
                                         to be the preconditioner M values */
-                                     const int* csrSortedRowPtrA,
-                                     const int* csrSortedColIndA,
-                                     csrilu02Info_t info,
-                                     hipsparseSolvePolicy_t policy,
-                                     void* pBuffer)
-{
-    return hipsparseDcsrilu02(handle,
-                              m,
-                              nnz,
-                              descrA,
-                              csrSortedValA_valM,
-                              csrSortedRowPtrA,
-                              csrSortedColIndA,
-                              info,
-                              policy,
-                              pBuffer);
-}
+                                         const int*             csrSortedRowPtrA,
+                                         const int*             csrSortedColIndA,
+                                         csrilu02Info_t         info,
+                                         hipsparseSolvePolicy_t policy,
+                                         void*                  pBuffer)
+    {
+        return hipsparseDcsrilu02(handle,
+                                  m,
+                                  nnz,
+                                  descrA,
+                                  csrSortedValA_valM,
+                                  csrSortedRowPtrA,
+                                  csrSortedColIndA,
+                                  info,
+                                  policy,
+                                  pBuffer);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXcsr2csc(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
-                                    int nnz,
-                                    const float* csr_val,
-                                    const int* csr_row_ptr,
-                                    const int* csr_col_ind,
-                                    float* csc_val,
-                                    int* csc_row_ind,
-                                    int* csc_col_ptr,
-                                    hipsparseAction_t copy_values,
-                                    hipsparseIndexBase_t idx_base)
-{
-    return hipsparseScsr2csc(handle,
-                             m,
-                             n,
-                             nnz,
-                             csr_val,
-                             csr_row_ptr,
-                             csr_col_ind,
-                             csc_val,
-                             csc_row_ind,
-                             csc_col_ptr,
-                             copy_values,
-                             idx_base);
-}
+    template <>
+    hipsparseStatus_t hipsparseXcsr2csc(hipsparseHandle_t    handle,
+                                        int                  m,
+                                        int                  n,
+                                        int                  nnz,
+                                        const float*         csr_val,
+                                        const int*           csr_row_ptr,
+                                        const int*           csr_col_ind,
+                                        float*               csc_val,
+                                        int*                 csc_row_ind,
+                                        int*                 csc_col_ptr,
+                                        hipsparseAction_t    copy_values,
+                                        hipsparseIndexBase_t idx_base)
+    {
+        return hipsparseScsr2csc(handle,
+                                 m,
+                                 n,
+                                 nnz,
+                                 csr_val,
+                                 csr_row_ptr,
+                                 csr_col_ind,
+                                 csc_val,
+                                 csc_row_ind,
+                                 csc_col_ptr,
+                                 copy_values,
+                                 idx_base);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXcsr2csc(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
-                                    int nnz,
-                                    const double* csr_val,
-                                    const int* csr_row_ptr,
-                                    const int* csr_col_ind,
-                                    double* csc_val,
-                                    int* csc_row_ind,
-                                    int* csc_col_ptr,
-                                    hipsparseAction_t copy_values,
-                                    hipsparseIndexBase_t idx_base)
-{
-    return hipsparseDcsr2csc(handle,
-                             m,
-                             n,
-                             nnz,
-                             csr_val,
-                             csr_row_ptr,
-                             csr_col_ind,
-                             csc_val,
-                             csc_row_ind,
-                             csc_col_ptr,
-                             copy_values,
-                             idx_base);
-}
+    template <>
+    hipsparseStatus_t hipsparseXcsr2csc(hipsparseHandle_t    handle,
+                                        int                  m,
+                                        int                  n,
+                                        int                  nnz,
+                                        const double*        csr_val,
+                                        const int*           csr_row_ptr,
+                                        const int*           csr_col_ind,
+                                        double*              csc_val,
+                                        int*                 csc_row_ind,
+                                        int*                 csc_col_ptr,
+                                        hipsparseAction_t    copy_values,
+                                        hipsparseIndexBase_t idx_base)
+    {
+        return hipsparseDcsr2csc(handle,
+                                 m,
+                                 n,
+                                 nnz,
+                                 csr_val,
+                                 csr_row_ptr,
+                                 csr_col_ind,
+                                 csc_val,
+                                 csc_row_ind,
+                                 csc_col_ptr,
+                                 copy_values,
+                                 idx_base);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXcsr2hyb(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
-                                    const hipsparseMatDescr_t descr,
-                                    const float* csr_val,
-                                    const int* csr_row_ptr,
-                                    const int* csr_col_ind,
-                                    hipsparseHybMat_t hyb,
-                                    int user_ell_width,
-                                    hipsparseHybPartition_t partition_type)
-{
-    return hipsparseScsr2hyb(handle,
-                             m,
-                             n,
-                             descr,
-                             csr_val,
-                             csr_row_ptr,
-                             csr_col_ind,
-                             hyb,
-                             user_ell_width,
-                             partition_type);
-}
+    template <>
+    hipsparseStatus_t hipsparseXcsr2hyb(hipsparseHandle_t         handle,
+                                        int                       m,
+                                        int                       n,
+                                        const hipsparseMatDescr_t descr,
+                                        const float*              csr_val,
+                                        const int*                csr_row_ptr,
+                                        const int*                csr_col_ind,
+                                        hipsparseHybMat_t         hyb,
+                                        int                       user_ell_width,
+                                        hipsparseHybPartition_t   partition_type)
+    {
+        return hipsparseScsr2hyb(handle,
+                                 m,
+                                 n,
+                                 descr,
+                                 csr_val,
+                                 csr_row_ptr,
+                                 csr_col_ind,
+                                 hyb,
+                                 user_ell_width,
+                                 partition_type);
+    }
 
-template <>
-hipsparseStatus_t hipsparseXcsr2hyb(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
-                                    const hipsparseMatDescr_t descr,
-                                    const double* csr_val,
-                                    const int* csr_row_ptr,
-                                    const int* csr_col_ind,
-                                    hipsparseHybMat_t hyb,
-                                    int user_ell_width,
-                                    hipsparseHybPartition_t partition_type)
-{
-    return hipsparseDcsr2hyb(handle,
-                             m,
-                             n,
-                             descr,
-                             csr_val,
-                             csr_row_ptr,
-                             csr_col_ind,
-                             hyb,
-                             user_ell_width,
-                             partition_type);
-}
+    template <>
+    hipsparseStatus_t hipsparseXcsr2hyb(hipsparseHandle_t         handle,
+                                        int                       m,
+                                        int                       n,
+                                        const hipsparseMatDescr_t descr,
+                                        const double*             csr_val,
+                                        const int*                csr_row_ptr,
+                                        const int*                csr_col_ind,
+                                        hipsparseHybMat_t         hyb,
+                                        int                       user_ell_width,
+                                        hipsparseHybPartition_t   partition_type)
+    {
+        return hipsparseDcsr2hyb(handle,
+                                 m,
+                                 n,
+                                 descr,
+                                 csr_val,
+                                 csr_row_ptr,
+                                 csr_col_ind,
+                                 hyb,
+                                 user_ell_width,
+                                 partition_type);
+    }
 
 } // namespace hipsparse

--- a/clients/common/unit.cpp
+++ b/clients/common/unit.cpp
@@ -23,9 +23,9 @@
 
 #include "unit.hpp"
 
-#include <hipsparse.h>
-#include <hip/hip_runtime_api.h>
 #include <algorithm>
+#include <hip/hip_runtime_api.h>
+#include <hipsparse.h>
 #include <limits>
 
 #ifdef GOOGLE_TEST

--- a/clients/common/utility.cpp
+++ b/clients/common/utility.cpp
@@ -23,10 +23,10 @@
 
 #include "utility.hpp"
 
+#include <hip/hip_runtime_api.h>
+#include <hipsparse.h>
 #include <stdio.h>
 #include <sys/time.h>
-#include <hipsparse.h>
-#include <hip/hip_runtime_api.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -54,7 +54,7 @@ void query_version(char* version)
 /*  device query and print out their ID and name; return number of compute-capable devices. */
 int query_device_property()
 {
-    int device_count;
+    int               device_count;
     hipsparseStatus_t status = (hipsparseStatus_t)hipGetDeviceCount(&device_count);
     if(status != HIPSPARSE_STATUS_SUCCESS)
     {
@@ -68,7 +68,7 @@ int query_device_property()
 
     for(int i = 0; i < device_count; i++)
     {
-        hipDeviceProp_t props;
+        hipDeviceProp_t   props;
         hipsparseStatus_t status = (hipsparseStatus_t)hipGetDeviceProperties(&props, i);
         if(status != HIPSPARSE_STATUS_SUCCESS)
         {

--- a/clients/include/hipsparse.hpp
+++ b/clients/include/hipsparse.hpp
@@ -27,230 +27,231 @@
 
 #include <hipsparse.h>
 
-namespace hipsparse {
+namespace hipsparse
+{
 
-template <typename T>
-hipsparseStatus_t hipsparseXaxpyi(hipsparseHandle_t handle,
-                                  int nnz,
-                                  const T* alpha,
-                                  const T* x_val,
-                                  const int* x_ind,
-                                  T* y,
-                                  hipsparseIndexBase_t idx_base);
+    template <typename T>
+    hipsparseStatus_t hipsparseXaxpyi(hipsparseHandle_t    handle,
+                                      int                  nnz,
+                                      const T*             alpha,
+                                      const T*             x_val,
+                                      const int*           x_ind,
+                                      T*                   y,
+                                      hipsparseIndexBase_t idx_base);
 
-template <typename T>
-hipsparseStatus_t hipsparseXdoti(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const T* x_val,
-                                 const int* x_ind,
-                                 const T* y,
-                                 T* result,
-                                 hipsparseIndexBase_t idx_base);
+    template <typename T>
+    hipsparseStatus_t hipsparseXdoti(hipsparseHandle_t    handle,
+                                     int                  nnz,
+                                     const T*             x_val,
+                                     const int*           x_ind,
+                                     const T*             y,
+                                     T*                   result,
+                                     hipsparseIndexBase_t idx_base);
 
-template <typename T>
-hipsparseStatus_t hipsparseXgthr(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const T* y,
-                                 T* x_val,
-                                 const int* x_ind,
-                                 hipsparseIndexBase_t idx_base);
+    template <typename T>
+    hipsparseStatus_t hipsparseXgthr(hipsparseHandle_t    handle,
+                                     int                  nnz,
+                                     const T*             y,
+                                     T*                   x_val,
+                                     const int*           x_ind,
+                                     hipsparseIndexBase_t idx_base);
 
-template <typename T>
-hipsparseStatus_t hipsparseXgthrz(hipsparseHandle_t handle,
-                                  int nnz,
-                                  T* y,
-                                  T* x_val,
-                                  const int* x_ind,
-                                  hipsparseIndexBase_t idx_base);
+    template <typename T>
+    hipsparseStatus_t hipsparseXgthrz(hipsparseHandle_t    handle,
+                                      int                  nnz,
+                                      T*                   y,
+                                      T*                   x_val,
+                                      const int*           x_ind,
+                                      hipsparseIndexBase_t idx_base);
 
-template <typename T>
-hipsparseStatus_t hipsparseXroti(hipsparseHandle_t handle,
-                                 int nnz,
-                                 T* x_val,
-                                 const int* x_ind,
-                                 T* y,
-                                 const T* c,
-                                 const T* s,
-                                 hipsparseIndexBase_t idx_base);
+    template <typename T>
+    hipsparseStatus_t hipsparseXroti(hipsparseHandle_t    handle,
+                                     int                  nnz,
+                                     T*                   x_val,
+                                     const int*           x_ind,
+                                     T*                   y,
+                                     const T*             c,
+                                     const T*             s,
+                                     hipsparseIndexBase_t idx_base);
 
-template <typename T>
-hipsparseStatus_t hipsparseXsctr(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const T* x_val,
-                                 const int* x_ind,
-                                 T* y,
-                                 hipsparseIndexBase_t idx_base);
+    template <typename T>
+    hipsparseStatus_t hipsparseXsctr(hipsparseHandle_t    handle,
+                                     int                  nnz,
+                                     const T*             x_val,
+                                     const int*           x_ind,
+                                     T*                   y,
+                                     hipsparseIndexBase_t idx_base);
 
-template <typename T>
-hipsparseStatus_t hipsparseXcsrmv(hipsparseHandle_t handle,
-                                  hipsparseOperation_t trans,
-                                  int m,
-                                  int n,
-                                  int nnz,
-                                  const T* alpha,
-                                  const hipsparseMatDescr_t descr,
-                                  const T* csr_val,
-                                  const int* csr_row_ptr,
-                                  const int* csr_col_ind,
-                                  const T* x,
-                                  const T* beta,
-                                  T* y);
+    template <typename T>
+    hipsparseStatus_t hipsparseXcsrmv(hipsparseHandle_t         handle,
+                                      hipsparseOperation_t      trans,
+                                      int                       m,
+                                      int                       n,
+                                      int                       nnz,
+                                      const T*                  alpha,
+                                      const hipsparseMatDescr_t descr,
+                                      const T*                  csr_val,
+                                      const int*                csr_row_ptr,
+                                      const int*                csr_col_ind,
+                                      const T*                  x,
+                                      const T*                  beta,
+                                      T*                        y);
 
-template <typename T>
-hipsparseStatus_t hipsparseXcsrsv2_bufferSize(hipsparseHandle_t handle,
-                                              hipsparseOperation_t transA,
-                                              int m,
-                                              int nnz,
-                                              const hipsparseMatDescr_t descrA,
-                                              T* csrSortedValA,
-                                              const int* csrSortedRowPtrA,
-                                              const int* csrSortedColIndA,
-                                              csrsv2Info_t info,
-                                              int* pBufferSizeInBytes);
+    template <typename T>
+    hipsparseStatus_t hipsparseXcsrsv2_bufferSize(hipsparseHandle_t         handle,
+                                                  hipsparseOperation_t      transA,
+                                                  int                       m,
+                                                  int                       nnz,
+                                                  const hipsparseMatDescr_t descrA,
+                                                  T*                        csrSortedValA,
+                                                  const int*                csrSortedRowPtrA,
+                                                  const int*                csrSortedColIndA,
+                                                  csrsv2Info_t              info,
+                                                  int*                      pBufferSizeInBytes);
 
-template <typename T>
-hipsparseStatus_t hipsparseXcsrsv2_bufferSizeExt(hipsparseHandle_t handle,
-                                                 hipsparseOperation_t transA,
-                                                 int m,
-                                                 int nnz,
-                                                 const hipsparseMatDescr_t descrA,
-                                                 T* csrSortedValA,
-                                                 const int* csrSortedRowPtrA,
-                                                 const int* csrSortedColIndA,
-                                                 csrsv2Info_t info,
-                                                 size_t* pBufferSize);
+    template <typename T>
+    hipsparseStatus_t hipsparseXcsrsv2_bufferSizeExt(hipsparseHandle_t         handle,
+                                                     hipsparseOperation_t      transA,
+                                                     int                       m,
+                                                     int                       nnz,
+                                                     const hipsparseMatDescr_t descrA,
+                                                     T*                        csrSortedValA,
+                                                     const int*                csrSortedRowPtrA,
+                                                     const int*                csrSortedColIndA,
+                                                     csrsv2Info_t              info,
+                                                     size_t*                   pBufferSize);
 
-template <typename T>
-hipsparseStatus_t hipsparseXcsrsv2_analysis(hipsparseHandle_t handle,
-                                            hipsparseOperation_t transA,
-                                            int m,
-                                            int nnz,
-                                            const hipsparseMatDescr_t descrA,
-                                            const T* csrSortedValA,
-                                            const int* csrSortedRowPtrA,
-                                            const int* csrSortedColIndA,
-                                            csrsv2Info_t info,
-                                            hipsparseSolvePolicy_t policy,
-                                            void* pBuffer);
-
-template <typename T>
-hipsparseStatus_t hipsparseXcsrsv2_solve(hipsparseHandle_t handle,
-                                         hipsparseOperation_t transA,
-                                         int m,
-                                         int nnz,
-                                         const T* alpha,
-                                         const hipsparseMatDescr_t descrA,
-                                         const T* csrSortedValA,
-                                         const int* csrSortedRowPtrA,
-                                         const int* csrSortedColIndA,
-                                         csrsv2Info_t info,
-                                         const T* f,
-                                         T* x,
-                                         hipsparseSolvePolicy_t policy,
-                                         void* pBuffer);
-
-template <typename T>
-hipsparseStatus_t hipsparseXhybmv(hipsparseHandle_t handle,
-                                  hipsparseOperation_t trans,
-                                  const T* alpha,
-                                  const hipsparseMatDescr_t descr,
-                                  const hipsparseHybMat_t hyb,
-                                  const T* x,
-                                  const T* beta,
-                                  T* y);
-
-template <typename T>
-hipsparseStatus_t hipsparseXcsrmm2(hipsparseHandle_t handle,
-                                   hipsparseOperation_t transA,
-                                   hipsparseOperation_t transB,
-                                   int m,
-                                   int n,
-                                   int k,
-                                   int nnz,
-                                   const T* alpha,
-                                   const hipsparseMatDescr_t descr,
-                                   const T* csr_val,
-                                   const int* csr_row_ptr,
-                                   const int* csr_col_ind,
-                                   const T* B,
-                                   int ldb,
-                                   const T* beta,
-                                   T* C,
-                                   int ldc);
-
-template <typename T>
-hipsparseStatus_t hipsparseXcsrilu02_bufferSize(hipsparseHandle_t handle,
-                                                int m,
-                                                int nnz,
+    template <typename T>
+    hipsparseStatus_t hipsparseXcsrsv2_analysis(hipsparseHandle_t         handle,
+                                                hipsparseOperation_t      transA,
+                                                int                       m,
+                                                int                       nnz,
                                                 const hipsparseMatDescr_t descrA,
-                                                T* csrSortedValA,
-                                                const int* csrSortedRowPtrA,
-                                                const int* csrSortedColIndA,
-                                                csrilu02Info_t info,
-                                                int* pBufferSizeInBytes);
+                                                const T*                  csrSortedValA,
+                                                const int*                csrSortedRowPtrA,
+                                                const int*                csrSortedColIndA,
+                                                csrsv2Info_t              info,
+                                                hipsparseSolvePolicy_t    policy,
+                                                void*                     pBuffer);
 
-template <typename T>
-hipsparseStatus_t hipsparseXcsrilu02_bufferSizeExt(hipsparseHandle_t handle,
-                                                   int m,
-                                                   int nnz,
-                                                   const hipsparseMatDescr_t descrA,
-                                                   T* csrSortedValA,
-                                                   const int* csrSortedRowPtrA,
-                                                   const int* csrSortedColIndA,
-                                                   csrilu02Info_t info,
-                                                   size_t* pBufferSize);
+    template <typename T>
+    hipsparseStatus_t hipsparseXcsrsv2_solve(hipsparseHandle_t         handle,
+                                             hipsparseOperation_t      transA,
+                                             int                       m,
+                                             int                       nnz,
+                                             const T*                  alpha,
+                                             const hipsparseMatDescr_t descrA,
+                                             const T*                  csrSortedValA,
+                                             const int*                csrSortedRowPtrA,
+                                             const int*                csrSortedColIndA,
+                                             csrsv2Info_t              info,
+                                             const T*                  f,
+                                             T*                        x,
+                                             hipsparseSolvePolicy_t    policy,
+                                             void*                     pBuffer);
 
-template <typename T>
-hipsparseStatus_t hipsparseXcsrilu02_analysis(hipsparseHandle_t handle,
-                                              int m,
-                                              int nnz,
-                                              const hipsparseMatDescr_t descrA,
-                                              const T* csrSortedValA,
-                                              const int* csrSortedRowPtrA,
-                                              const int* csrSortedColIndA,
-                                              csrilu02Info_t info,
-                                              hipsparseSolvePolicy_t policy,
-                                              void* pBuffer);
+    template <typename T>
+    hipsparseStatus_t hipsparseXhybmv(hipsparseHandle_t         handle,
+                                      hipsparseOperation_t      trans,
+                                      const T*                  alpha,
+                                      const hipsparseMatDescr_t descr,
+                                      const hipsparseHybMat_t   hyb,
+                                      const T*                  x,
+                                      const T*                  beta,
+                                      T*                        y);
 
-template <typename T>
-hipsparseStatus_t hipsparseXcsrilu02(hipsparseHandle_t handle,
-                                     int m,
-                                     int nnz,
-                                     const hipsparseMatDescr_t descrA,
-                                     T* csrSortedValA_valM,
-                                     /* matrix A values are updated inplace
+    template <typename T>
+    hipsparseStatus_t hipsparseXcsrmm2(hipsparseHandle_t         handle,
+                                       hipsparseOperation_t      transA,
+                                       hipsparseOperation_t      transB,
+                                       int                       m,
+                                       int                       n,
+                                       int                       k,
+                                       int                       nnz,
+                                       const T*                  alpha,
+                                       const hipsparseMatDescr_t descr,
+                                       const T*                  csr_val,
+                                       const int*                csr_row_ptr,
+                                       const int*                csr_col_ind,
+                                       const T*                  B,
+                                       int                       ldb,
+                                       const T*                  beta,
+                                       T*                        C,
+                                       int                       ldc);
+
+    template <typename T>
+    hipsparseStatus_t hipsparseXcsrilu02_bufferSize(hipsparseHandle_t         handle,
+                                                    int                       m,
+                                                    int                       nnz,
+                                                    const hipsparseMatDescr_t descrA,
+                                                    T*                        csrSortedValA,
+                                                    const int*                csrSortedRowPtrA,
+                                                    const int*                csrSortedColIndA,
+                                                    csrilu02Info_t            info,
+                                                    int*                      pBufferSizeInBytes);
+
+    template <typename T>
+    hipsparseStatus_t hipsparseXcsrilu02_bufferSizeExt(hipsparseHandle_t         handle,
+                                                       int                       m,
+                                                       int                       nnz,
+                                                       const hipsparseMatDescr_t descrA,
+                                                       T*                        csrSortedValA,
+                                                       const int*                csrSortedRowPtrA,
+                                                       const int*                csrSortedColIndA,
+                                                       csrilu02Info_t            info,
+                                                       size_t*                   pBufferSize);
+
+    template <typename T>
+    hipsparseStatus_t hipsparseXcsrilu02_analysis(hipsparseHandle_t         handle,
+                                                  int                       m,
+                                                  int                       nnz,
+                                                  const hipsparseMatDescr_t descrA,
+                                                  const T*                  csrSortedValA,
+                                                  const int*                csrSortedRowPtrA,
+                                                  const int*                csrSortedColIndA,
+                                                  csrilu02Info_t            info,
+                                                  hipsparseSolvePolicy_t    policy,
+                                                  void*                     pBuffer);
+
+    template <typename T>
+    hipsparseStatus_t hipsparseXcsrilu02(hipsparseHandle_t         handle,
+                                         int                       m,
+                                         int                       nnz,
+                                         const hipsparseMatDescr_t descrA,
+                                         T*                        csrSortedValA_valM,
+                                         /* matrix A values are updated inplace
                                         to be the preconditioner M values */
-                                     const int* csrSortedRowPtrA,
-                                     const int* csrSortedColIndA,
-                                     csrilu02Info_t info,
-                                     hipsparseSolvePolicy_t policy,
-                                     void* pBuffer);
+                                         const int*             csrSortedRowPtrA,
+                                         const int*             csrSortedColIndA,
+                                         csrilu02Info_t         info,
+                                         hipsparseSolvePolicy_t policy,
+                                         void*                  pBuffer);
 
-template <typename T>
-hipsparseStatus_t hipsparseXcsr2csc(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
-                                    int nnz,
-                                    const T* csr_val,
-                                    const int* csr_row_ptr,
-                                    const int* csr_col_ind,
-                                    T* csc_val,
-                                    int* csc_row_ind,
-                                    int* csc_col_ptr,
-                                    hipsparseAction_t copy_values,
-                                    hipsparseIndexBase_t idx_base);
+    template <typename T>
+    hipsparseStatus_t hipsparseXcsr2csc(hipsparseHandle_t    handle,
+                                        int                  m,
+                                        int                  n,
+                                        int                  nnz,
+                                        const T*             csr_val,
+                                        const int*           csr_row_ptr,
+                                        const int*           csr_col_ind,
+                                        T*                   csc_val,
+                                        int*                 csc_row_ind,
+                                        int*                 csc_col_ptr,
+                                        hipsparseAction_t    copy_values,
+                                        hipsparseIndexBase_t idx_base);
 
-template <typename T>
-hipsparseStatus_t hipsparseXcsr2hyb(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
-                                    const hipsparseMatDescr_t descr,
-                                    const T* csr_val,
-                                    const int* csr_row_ptr,
-                                    const int* csr_col_ind,
-                                    hipsparseHybMat_t hyb,
-                                    int user_ell_width,
-                                    hipsparseHybPartition_t partition_type);
+    template <typename T>
+    hipsparseStatus_t hipsparseXcsr2hyb(hipsparseHandle_t         handle,
+                                        int                       m,
+                                        int                       n,
+                                        const hipsparseMatDescr_t descr,
+                                        const T*                  csr_val,
+                                        const int*                csr_row_ptr,
+                                        const int*                csr_col_ind,
+                                        hipsparseHybMat_t         hyb,
+                                        int                       user_ell_width,
+                                        hipsparseHybPartition_t   partition_type);
 
 } // namespace hipsparse
 

--- a/clients/include/hipsparse_test_unique_ptr.hpp
+++ b/clients/include/hipsparse_test_unique_ptr.hpp
@@ -27,9 +27,9 @@
 
 #include "arg_check.hpp"
 
-#include <memory>
 #include <hip/hip_runtime_api.h>
 #include <hipsparse.h>
+#include <memory>
 
 #define PRINT_IF_HIP_ERROR(INPUT_STATUS_FOR_CHECK)                \
     {                                                             \
@@ -44,98 +44,102 @@
         }                                                         \
     }
 
-namespace hipsparse_test {
-
-// device_malloc wraps hipMalloc and provides same API as malloc
-static void* device_malloc(size_t byte_size)
+namespace hipsparse_test
 {
-    void* pointer;
-    PRINT_IF_HIP_ERROR(hipMalloc(&pointer, byte_size));
-    return pointer;
-}
 
-// device_free wraps hipFree and provides same API as free
-static void device_free(void* ptr) { PRINT_IF_HIP_ERROR(hipFree(ptr)); }
-
-struct handle_struct
-{
-    hipsparseHandle_t handle;
-    handle_struct()
+    // device_malloc wraps hipMalloc and provides same API as malloc
+    static void* device_malloc(size_t byte_size)
     {
-        hipsparseStatus_t status = hipsparseCreate(&handle);
-        verify_hipsparse_status_success(status, "ERROR: handle_struct constructor");
+        void* pointer;
+        PRINT_IF_HIP_ERROR(hipMalloc(&pointer, byte_size));
+        return pointer;
     }
 
-    ~handle_struct()
+    // device_free wraps hipFree and provides same API as free
+    static void device_free(void* ptr)
     {
-        hipsparseStatus_t status = hipsparseDestroy(handle);
-        verify_hipsparse_status_success(status, "ERROR: handle_struct destructor");
-    }
-};
-
-struct descr_struct
-{
-    hipsparseMatDescr_t descr;
-    descr_struct()
-    {
-        hipsparseStatus_t status = hipsparseCreateMatDescr(&descr);
-        verify_hipsparse_status_success(status, "ERROR: descr_struct constructor");
+        PRINT_IF_HIP_ERROR(hipFree(ptr));
     }
 
-    ~descr_struct()
+    struct handle_struct
     {
-        hipsparseStatus_t status = hipsparseDestroyMatDescr(descr);
-        verify_hipsparse_status_success(status, "ERROR: descr_struct destructor");
-    }
-};
+        hipsparseHandle_t handle;
+        handle_struct()
+        {
+            hipsparseStatus_t status = hipsparseCreate(&handle);
+            verify_hipsparse_status_success(status, "ERROR: handle_struct constructor");
+        }
 
-struct hyb_struct
-{
-    hipsparseHybMat_t hyb;
-    hyb_struct()
-    {
-        hipsparseStatus_t status = hipsparseCreateHybMat(&hyb);
-        verify_hipsparse_status_success(status, "ERROR: hyb_struct constructor");
-    }
+        ~handle_struct()
+        {
+            hipsparseStatus_t status = hipsparseDestroy(handle);
+            verify_hipsparse_status_success(status, "ERROR: handle_struct destructor");
+        }
+    };
 
-    ~hyb_struct()
+    struct descr_struct
     {
-        hipsparseStatus_t status = hipsparseDestroyHybMat(hyb);
-        verify_hipsparse_status_success(status, "ERROR: hyb_struct destructor");
-    }
-};
+        hipsparseMatDescr_t descr;
+        descr_struct()
+        {
+            hipsparseStatus_t status = hipsparseCreateMatDescr(&descr);
+            verify_hipsparse_status_success(status, "ERROR: descr_struct constructor");
+        }
 
-struct csrsv2_struct
-{
-    csrsv2Info_t info;
-    csrsv2_struct()
-    {
-        hipsparseStatus_t status = hipsparseCreateCsrsv2Info(&info);
-        verify_hipsparse_status_success(status, "ERROR: csrsv2_struct constructor");
-    }
+        ~descr_struct()
+        {
+            hipsparseStatus_t status = hipsparseDestroyMatDescr(descr);
+            verify_hipsparse_status_success(status, "ERROR: descr_struct destructor");
+        }
+    };
 
-    ~csrsv2_struct()
+    struct hyb_struct
     {
-        hipsparseStatus_t status = hipsparseDestroyCsrsv2Info(info);
-        verify_hipsparse_status_success(status, "ERROR: csrsv2_struct destructor");
-    }
-};
+        hipsparseHybMat_t hyb;
+        hyb_struct()
+        {
+            hipsparseStatus_t status = hipsparseCreateHybMat(&hyb);
+            verify_hipsparse_status_success(status, "ERROR: hyb_struct constructor");
+        }
 
-struct csrilu02_struct
-{
-    csrilu02Info_t info;
-    csrilu02_struct()
-    {
-        hipsparseStatus_t status = hipsparseCreateCsrilu02Info(&info);
-        verify_hipsparse_status_success(status, "ERROR: csrilu02_struct constructor");
-    }
+        ~hyb_struct()
+        {
+            hipsparseStatus_t status = hipsparseDestroyHybMat(hyb);
+            verify_hipsparse_status_success(status, "ERROR: hyb_struct destructor");
+        }
+    };
 
-    ~csrilu02_struct()
+    struct csrsv2_struct
     {
-        hipsparseStatus_t status = hipsparseDestroyCsrilu02Info(info);
-        verify_hipsparse_status_success(status, "ERROR: csrilu02_struct destructor");
-    }
-};
+        csrsv2Info_t info;
+        csrsv2_struct()
+        {
+            hipsparseStatus_t status = hipsparseCreateCsrsv2Info(&info);
+            verify_hipsparse_status_success(status, "ERROR: csrsv2_struct constructor");
+        }
+
+        ~csrsv2_struct()
+        {
+            hipsparseStatus_t status = hipsparseDestroyCsrsv2Info(info);
+            verify_hipsparse_status_success(status, "ERROR: csrsv2_struct destructor");
+        }
+    };
+
+    struct csrilu02_struct
+    {
+        csrilu02Info_t info;
+        csrilu02_struct()
+        {
+            hipsparseStatus_t status = hipsparseCreateCsrilu02Info(&info);
+            verify_hipsparse_status_success(status, "ERROR: csrilu02_struct constructor");
+        }
+
+        ~csrilu02_struct()
+        {
+            hipsparseStatus_t status = hipsparseDestroyCsrilu02Info(info);
+            verify_hipsparse_status_success(status, "ERROR: csrilu02_struct destructor");
+        }
+    };
 
 } // namespace hipsparse_test
 

--- a/clients/include/testing_axpyi.hpp
+++ b/clients/include/testing_axpyi.hpp
@@ -25,10 +25,10 @@
 #ifndef TESTING_AXPYI_HPP
 #define TESTING_AXPYI_HPP
 
-#include "hipsparse_test_unique_ptr.hpp"
 #include "hipsparse.hpp"
-#include "utility.hpp"
+#include "hipsparse_test_unique_ptr.hpp"
 #include "unit.hpp"
+#include "utility.hpp"
 
 #include <hipsparse.h>
 
@@ -44,21 +44,21 @@ void testing_axpyi_bad_arg(void)
 #endif
     int nnz       = 100;
     int safe_size = 100;
-    T alpha       = 0.6;
+    T   alpha     = 0.6;
 
     hipsparseIndexBase_t idx_base = HIPSPARSE_INDEX_BASE_ZERO;
-    hipsparseStatus_t status;
+    hipsparseStatus_t    status;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
-    auto dxVal_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-    auto dxInd_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto dy_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dxVal_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dxInd_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto dy_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
-    T* dxVal   = (T*)dxVal_managed.get();
+    T*   dxVal = (T*)dxVal_managed.get();
     int* dxInd = (int*)dxInd_managed.get();
-    T* dy      = (T*)dy_managed.get();
+    T*   dy    = (T*)dy_managed.get();
 
     if(!dxInd || !dxVal || !dy)
     {
@@ -106,15 +106,15 @@ void testing_axpyi_bad_arg(void)
 template <typename T>
 hipsparseStatus_t testing_axpyi(Arguments argus)
 {
-    int N                         = argus.N;
-    int nnz                       = argus.nnz;
-    int safe_size                 = 100;
-    T h_alpha                     = argus.alpha;
-    hipsparseIndexBase_t idx_base = argus.idx_base;
-    hipsparseStatus_t status;
+    int                  N         = argus.N;
+    int                  nnz       = argus.nnz;
+    int                  safe_size = 100;
+    T                    h_alpha   = argus.alpha;
+    hipsparseIndexBase_t idx_base  = argus.idx_base;
+    hipsparseStatus_t    status;
 
     std::unique_ptr<handle_struct> test_handle(new handle_struct);
-    hipsparseHandle_t handle = test_handle->handle;
+    hipsparseHandle_t              handle = test_handle->handle;
 
     // Argument sanity check before allocating invalid memory
     if(nnz <= 0)
@@ -123,15 +123,15 @@ hipsparseStatus_t testing_axpyi(Arguments argus)
         // Do not test args in cusparse
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
-        auto dxInd_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto dxVal_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dxInd_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto dxVal_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
         int* dxInd = (int*)dxInd_managed.get();
-        T* dxVal   = (T*)dxVal_managed.get();
-        T* dy      = (T*)dy_managed.get();
+        T*   dxVal = (T*)dxVal_managed.get();
+        T*   dy    = (T*)dy_managed.get();
 
         if(!dxInd || !dxVal || !dy)
         {
@@ -157,10 +157,10 @@ hipsparseStatus_t testing_axpyi(Arguments argus)
 
     // Host structures
     std::vector<int> hxInd(nnz);
-    std::vector<T> hxVal(nnz);
-    std::vector<T> hy_1(N);
-    std::vector<T> hy_2(N);
-    std::vector<T> hy_gold(N);
+    std::vector<T>   hxVal(nnz);
+    std::vector<T>   hy_1(N);
+    std::vector<T>   hy_2(N);
+    std::vector<T>   hy_gold(N);
 
     // Initial Data on CPU
     srand(12345ULL);
@@ -173,17 +173,17 @@ hipsparseStatus_t testing_axpyi(Arguments argus)
     hy_gold = hy_1;
 
     // allocate memory on device
-    auto dxInd_managed   = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
-    auto dxVal_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
-    auto dy_1_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
-    auto dy_2_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
-    auto d_alpha_managed = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
+    auto dxInd_managed   = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+    auto dxVal_managed   = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+    auto dy_1_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
+    auto dy_2_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
+    auto d_alpha_managed = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
 
-    int* dxInd = (int*)dxInd_managed.get();
-    T* dxVal   = (T*)dxVal_managed.get();
-    T* dy_1    = (T*)dy_1_managed.get();
-    T* dy_2    = (T*)dy_2_managed.get();
-    T* d_alpha = (T*)d_alpha_managed.get();
+    int* dxInd   = (int*)dxInd_managed.get();
+    T*   dxVal   = (T*)dxVal_managed.get();
+    T*   dy_1    = (T*)dy_1_managed.get();
+    T*   dy_2    = (T*)dy_2_managed.get();
+    T*   d_alpha = (T*)d_alpha_managed.get();
 
     if(!dxInd || !dxVal || !dy_1 || !dy_2 || !d_alpha)
     {

--- a/clients/include/testing_coo2csr.hpp
+++ b/clients/include/testing_coo2csr.hpp
@@ -25,13 +25,13 @@
 #ifndef TESTING_COO2CSR_HPP
 #define TESTING_COO2CSR_HPP
 
-#include "hipsparse_test_unique_ptr.hpp"
 #include "hipsparse.hpp"
-#include "utility.hpp"
+#include "hipsparse_test_unique_ptr.hpp"
 #include "unit.hpp"
+#include "utility.hpp"
 
-#include <hipsparse.h>
 #include <algorithm>
+#include <hipsparse.h>
 #include <string>
 
 using namespace hipsparse;
@@ -43,18 +43,18 @@ void testing_coo2csr_bad_arg(void)
     // do not test for bad args
     return;
 #endif
-    int m         = 100;
-    int nnz       = 100;
-    int safe_size = 100;
+    int               m         = 100;
+    int               nnz       = 100;
+    int               safe_size = 100;
     hipsparseStatus_t status;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
-    auto coo_row_ind_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto csr_row_ptr_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto coo_row_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto csr_row_ptr_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
 
     int* coo_row_ind = (int*)coo_row_ind_managed.get();
     int* csr_row_ptr = (int*)csr_row_ptr_managed.get();
@@ -93,13 +93,13 @@ void testing_coo2csr_bad_arg(void)
 
 hipsparseStatus_t testing_coo2csr(Arguments argus)
 {
-    int m                         = argus.M;
-    int n                         = argus.N;
-    int safe_size                 = 100;
-    hipsparseIndexBase_t idx_base = argus.idx_base;
-    std::string binfile           = "";
-    std::string filename          = "";
-    hipsparseStatus_t status;
+    int                  m         = argus.M;
+    int                  n         = argus.N;
+    int                  safe_size = 100;
+    hipsparseIndexBase_t idx_base  = argus.idx_base;
+    std::string          binfile   = "";
+    std::string          filename  = "";
+    hipsparseStatus_t    status;
 
     // When in testing mode, M == N == -99 indicates that we are testing with a real
     // matrix from cise.ufl.edu
@@ -122,7 +122,7 @@ hipsparseStatus_t testing_coo2csr(Arguments argus)
     int nnz = m * scale * n;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
     // Argument sanity check before allocating invalid memory
     if(m <= 0 || n <= 0 || nnz <= 0)
@@ -131,10 +131,10 @@ hipsparseStatus_t testing_coo2csr(Arguments argus)
         // Do not test args in cusparse
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
-        auto coo_row_ind_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto csr_row_ptr_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+        auto coo_row_ind_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto csr_row_ptr_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
 
         int* coo_row_ind = (int*)coo_row_ind_managed.get();
         int* csr_row_ptr = (int*)csr_row_ptr_managed.get();
@@ -161,8 +161,8 @@ hipsparseStatus_t testing_coo2csr(Arguments argus)
     }
 
     // Host structures
-    std::vector<int> hcoo_row_ind;
-    std::vector<int> hcoo_col_ind;
+    std::vector<int>   hcoo_row_ind;
+    std::vector<int>   hcoo_col_ind;
     std::vector<float> hcoo_val;
 
     // Sample initial COO matrix on CPU
@@ -208,8 +208,8 @@ hipsparseStatus_t testing_coo2csr(Arguments argus)
         if(filename != "")
         {
             if(read_mtx_matrix(
-                   filename.c_str(), m, n, nnz, hcoo_row_ind, hcoo_col_ind, hcoo_val, idx_base) !=
-               0)
+                   filename.c_str(), m, n, nnz, hcoo_row_ind, hcoo_col_ind, hcoo_val, idx_base)
+               != 0)
             {
                 fprintf(stderr, "Cannot open [read] %s\n", filename.c_str());
                 return HIPSPARSE_STATUS_INTERNAL_ERROR;
@@ -225,9 +225,10 @@ hipsparseStatus_t testing_coo2csr(Arguments argus)
     std::vector<int> hcsr_row_ptr_gold(m + 1, 0);
 
     // Allocate memory on the device
-    auto dcoo_row_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
-    auto dcsr_row_ptr_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};
+    auto dcoo_row_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+    auto dcsr_row_ptr_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * (m + 1)), device_free};
 
     int* dcoo_row_ind = (int*)dcoo_row_ind_managed.get();
     int* dcsr_row_ptr = (int*)dcsr_row_ptr_managed.get();

--- a/clients/include/testing_coosort.hpp
+++ b/clients/include/testing_coosort.hpp
@@ -25,13 +25,13 @@
 #ifndef TESTING_COOSORT_HPP
 #define TESTING_COOSORT_HPP
 
-#include "hipsparse_test_unique_ptr.hpp"
 #include "hipsparse.hpp"
-#include "utility.hpp"
+#include "hipsparse_test_unique_ptr.hpp"
 #include "unit.hpp"
+#include "utility.hpp"
 
-#include <hipsparse.h>
 #include <algorithm>
+#include <hipsparse.h>
 #include <string>
 
 using namespace hipsparse;
@@ -43,29 +43,29 @@ void testing_coosort_bad_arg(void)
     // do not test for bad args
     return;
 #endif
-    int m         = 100;
-    int n         = 100;
-    int nnz       = 100;
-    int safe_size = 100;
+    int               m         = 100;
+    int               n         = 100;
+    int               nnz       = 100;
+    int               safe_size = 100;
     hipsparseStatus_t status;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
     size_t buffer_size = 0;
 
-    auto coo_row_ind_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto coo_col_ind_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto perm_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto buffer_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
+    auto coo_row_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto coo_col_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto perm_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto buffer_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
 
-    int* coo_row_ind = (int*)coo_row_ind_managed.get();
-    int* coo_col_ind = (int*)coo_col_ind_managed.get();
-    int* perm        = (int*)perm_managed.get();
-    void* buffer     = (void*)buffer_managed.get();
+    int*  coo_row_ind = (int*)coo_row_ind_managed.get();
+    int*  coo_col_ind = (int*)coo_col_ind_managed.get();
+    int*  perm        = (int*)perm_managed.get();
+    void* buffer      = (void*)buffer_managed.get();
 
     if(!coo_row_ind || !coo_col_ind || !perm || !buffer)
     {
@@ -117,8 +117,8 @@ void testing_coosort_bad_arg(void)
     {
         int* coo_row_ind_null = nullptr;
 
-        status =
-            hipsparseXcoosortByRow(handle, m, n, nnz, coo_row_ind_null, coo_col_ind, perm, buffer);
+        status = hipsparseXcoosortByRow(
+            handle, m, n, nnz, coo_row_ind_null, coo_col_ind, perm, buffer);
         verify_hipsparse_status_invalid_pointer(status, "Error: coo_row_ind is nullptr");
     }
 
@@ -126,8 +126,8 @@ void testing_coosort_bad_arg(void)
     {
         int* coo_col_ind_null = nullptr;
 
-        status =
-            hipsparseXcoosortByRow(handle, m, n, nnz, coo_row_ind, coo_col_ind_null, perm, buffer);
+        status = hipsparseXcoosortByRow(
+            handle, m, n, nnz, coo_row_ind, coo_col_ind_null, perm, buffer);
         verify_hipsparse_status_invalid_pointer(status, "Error: coo_col_ind is nullptr");
     }
 
@@ -135,8 +135,8 @@ void testing_coosort_bad_arg(void)
     {
         int* buffer_null = nullptr;
 
-        status =
-            hipsparseXcoosortByRow(handle, m, n, nnz, coo_row_ind, coo_col_ind, perm, buffer_null);
+        status = hipsparseXcoosortByRow(
+            handle, m, n, nnz, coo_row_ind, coo_col_ind, perm, buffer_null);
         verify_hipsparse_status_invalid_pointer(status, "Error: buffer is nullptr");
     }
 
@@ -144,8 +144,8 @@ void testing_coosort_bad_arg(void)
     {
         hipsparseHandle_t handle_null = nullptr;
 
-        status =
-            hipsparseXcoosortByRow(handle_null, m, n, nnz, coo_row_ind, coo_col_ind, perm, buffer);
+        status = hipsparseXcoosortByRow(
+            handle_null, m, n, nnz, coo_row_ind, coo_col_ind, perm, buffer);
         verify_hipsparse_status_invalid_handle(status);
     }
 
@@ -190,15 +190,15 @@ void testing_coosort_bad_arg(void)
 
 hipsparseStatus_t testing_coosort(Arguments argus)
 {
-    int m                         = argus.M;
-    int n                         = argus.N;
-    int safe_size                 = 100;
-    int by_row                    = argus.transA == HIPSPARSE_OPERATION_NON_TRANSPOSE;
-    int permute                   = argus.temp;
-    hipsparseIndexBase_t idx_base = argus.idx_base;
-    std::string binfile           = "";
-    std::string filename          = "";
-    hipsparseStatus_t status;
+    int                  m         = argus.M;
+    int                  n         = argus.N;
+    int                  safe_size = 100;
+    int                  by_row    = argus.transA == HIPSPARSE_OPERATION_NON_TRANSPOSE;
+    int                  permute   = argus.temp;
+    hipsparseIndexBase_t idx_base  = argus.idx_base;
+    std::string          binfile   = "";
+    std::string          filename  = "";
+    hipsparseStatus_t    status;
 
     // When in testing mode, M == N == -99 indicates that we are testing with a real
     // matrix from cise.ufl.edu
@@ -223,7 +223,7 @@ hipsparseStatus_t testing_coosort(Arguments argus)
     int nnz = m * scale * n;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
     // Argument sanity check before allocating invalid memory
     if(m <= 0 || n <= 0 || nnz <= 0)
@@ -232,19 +232,19 @@ hipsparseStatus_t testing_coosort(Arguments argus)
         // Do not test args in cusparse
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
-        auto coo_row_ind_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto coo_col_ind_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto perm_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto buffer_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
+        auto coo_row_ind_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto coo_col_ind_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto perm_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto buffer_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
 
-        int* coo_row_ind = (int*)coo_row_ind_managed.get();
-        int* coo_col_ind = (int*)coo_col_ind_managed.get();
-        int* perm        = (int*)perm_managed.get();
-        void* buffer     = (void*)buffer_managed.get();
+        int*  coo_row_ind = (int*)coo_row_ind_managed.get();
+        int*  coo_col_ind = (int*)coo_col_ind_managed.get();
+        int*  perm        = (int*)perm_managed.get();
+        void* buffer      = (void*)buffer_managed.get();
 
         if(!coo_row_ind || !coo_col_ind || !perm || !buffer)
         {
@@ -271,8 +271,8 @@ hipsparseStatus_t testing_coosort(Arguments argus)
 
         if(by_row)
         {
-            status =
-                hipsparseXcoosortByRow(handle, m, n, nnz, coo_row_ind, coo_col_ind, perm, buffer);
+            status
+                = hipsparseXcoosortByRow(handle, m, n, nnz, coo_row_ind, coo_col_ind, perm, buffer);
         }
         else
         {
@@ -295,8 +295,8 @@ hipsparseStatus_t testing_coosort(Arguments argus)
     // For testing, assemble a COO matrix and convert it to CSR first (on host)
 
     // Host structures
-    std::vector<int> hcoo_row_ind;
-    std::vector<int> hcoo_col_ind;
+    std::vector<int>   hcoo_row_ind;
+    std::vector<int>   hcoo_col_ind;
     std::vector<float> hcoo_val;
 
     // Sample initial COO matrix on CPU
@@ -305,7 +305,8 @@ hipsparseStatus_t testing_coosort(Arguments argus)
     {
         std::vector<int> hcsr_row_ptr;
         if(read_bin_matrix(
-               binfile.c_str(), m, n, nnz, hcsr_row_ptr, hcoo_col_ind, hcoo_val, idx_base) != 0)
+               binfile.c_str(), m, n, nnz, hcsr_row_ptr, hcoo_col_ind, hcoo_val, idx_base)
+           != 0)
         {
             fprintf(stderr, "Cannot open [read] %s\n", binfile.c_str());
             return HIPSPARSE_STATUS_INTERNAL_ERROR;
@@ -342,8 +343,8 @@ hipsparseStatus_t testing_coosort(Arguments argus)
         if(filename != "")
         {
             if(read_mtx_matrix(
-                   filename.c_str(), m, n, nnz, hcoo_row_ind, hcoo_col_ind, hcoo_val, idx_base) !=
-               0)
+                   filename.c_str(), m, n, nnz, hcoo_row_ind, hcoo_col_ind, hcoo_val, idx_base)
+               != 0)
             {
                 fprintf(stderr, "Cannot open [read] %s\n", filename.c_str());
                 return HIPSPARSE_STATUS_INTERNAL_ERROR;
@@ -356,8 +357,8 @@ hipsparseStatus_t testing_coosort(Arguments argus)
     }
 
     // Unsort COO columns
-    std::vector<int> hcoo_row_ind_unsorted(nnz);
-    std::vector<int> hcoo_col_ind_unsorted(nnz);
+    std::vector<int>   hcoo_row_ind_unsorted(nnz);
+    std::vector<int>   hcoo_col_ind_unsorted(nnz);
     std::vector<float> hcoo_val_unsorted(nnz);
 
     hcoo_row_ind_unsorted = hcoo_row_ind;
@@ -368,8 +369,8 @@ hipsparseStatus_t testing_coosort(Arguments argus)
     {
         int rng = rand() % nnz;
 
-        int temp_row   = hcoo_row_ind_unsorted[i];
-        int temp_col   = hcoo_col_ind_unsorted[i];
+        int   temp_row = hcoo_row_ind_unsorted[i];
+        int   temp_col = hcoo_col_ind_unsorted[i];
         float temp_val = hcoo_val_unsorted[i];
 
         hcoo_row_ind_unsorted[i] = hcoo_row_ind_unsorted[rng];
@@ -414,15 +415,17 @@ hipsparseStatus_t testing_coosort(Arguments argus)
     }
 
     // Allocate memory on the device
-    auto dcoo_row_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
-    auto dcoo_col_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
-    auto dcoo_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(float) * nnz), device_free};
-    auto dcoo_val_sorted_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(float) * nnz), device_free};
-    auto dperm_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
+    auto dcoo_row_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+    auto dcoo_col_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+    auto dcoo_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(float) * nnz), device_free};
+    auto dcoo_val_sorted_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(float) * nnz), device_free};
+    auto dperm_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
 
-    int* dcoo_row_ind      = (int*)dcoo_row_ind_managed.get();
-    int* dcoo_col_ind      = (int*)dcoo_col_ind_managed.get();
+    int*   dcoo_row_ind    = (int*)dcoo_row_ind_managed.get();
+    int*   dcoo_col_ind    = (int*)dcoo_col_ind_managed.get();
     float* dcoo_val        = (float*)dcoo_val_managed.get();
     float* dcoo_val_sorted = (float*)dcoo_val_sorted_managed.get();
 
@@ -452,8 +455,8 @@ hipsparseStatus_t testing_coosort(Arguments argus)
             handle, m, n, nnz, dcoo_row_ind, dcoo_col_ind, &buffer_size));
 
         // Allocate buffer on the device
-        auto dbuffer_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(char) * buffer_size), device_free};
+        auto dbuffer_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(char) * buffer_size), device_free};
 
         void* dbuffer = (void*)dbuffer_managed.get();
 
@@ -521,8 +524,8 @@ hipsparseStatus_t testing_coosort(Arguments argus)
         hipsparseXcoosort_bufferSizeExt(
             handle, m, n, nnz, dcoo_row_ind, dcoo_col_ind, &buffer_size);
 
-        auto dbuffer_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(char) * buffer_size), device_free};
+        auto dbuffer_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(char) * buffer_size), device_free};
         void* dbuffer = (void*)dbuffer_managed.get();
 
         for(int iter = 0; iter < number_cold_calls; ++iter)

--- a/clients/include/testing_csr2coo.hpp
+++ b/clients/include/testing_csr2coo.hpp
@@ -25,13 +25,13 @@
 #ifndef TESTING_CSR2COO_HPP
 #define TESTING_CSR2COO_HPP
 
-#include "hipsparse_test_unique_ptr.hpp"
 #include "hipsparse.hpp"
-#include "utility.hpp"
+#include "hipsparse_test_unique_ptr.hpp"
 #include "unit.hpp"
+#include "utility.hpp"
 
-#include <hipsparse.h>
 #include <algorithm>
+#include <hipsparse.h>
 #include <string>
 
 using namespace hipsparse;
@@ -43,18 +43,18 @@ void testing_csr2coo_bad_arg(void)
     // do not test for bad args
     return;
 #endif
-    int m         = 100;
-    int nnz       = 100;
-    int safe_size = 100;
+    int               m         = 100;
+    int               nnz       = 100;
+    int               safe_size = 100;
     hipsparseStatus_t status;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
-    auto csr_row_ptr_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto coo_row_ind_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto csr_row_ptr_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto coo_row_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
 
     int* csr_row_ptr = (int*)csr_row_ptr_managed.get();
     int* coo_row_ind = (int*)coo_row_ind_managed.get();
@@ -93,13 +93,13 @@ void testing_csr2coo_bad_arg(void)
 
 hipsparseStatus_t testing_csr2coo(Arguments argus)
 {
-    int m                         = argus.M;
-    int n                         = argus.N;
-    int safe_size                 = 100;
-    hipsparseIndexBase_t idx_base = argus.idx_base;
-    std::string binfile           = "";
-    std::string filename          = "";
-    hipsparseStatus_t status;
+    int                  m         = argus.M;
+    int                  n         = argus.N;
+    int                  safe_size = 100;
+    hipsparseIndexBase_t idx_base  = argus.idx_base;
+    std::string          binfile   = "";
+    std::string          filename  = "";
+    hipsparseStatus_t    status;
 
     // When in testing mode, M == N == -99 indicates that we are testing with a real
     // matrix from cise.ufl.edu
@@ -122,7 +122,7 @@ hipsparseStatus_t testing_csr2coo(Arguments argus)
     int nnz = m * scale * n;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
     // Argument sanity check before allocating invalid memory
     if(m <= 0 || n <= 0 || nnz <= 0)
@@ -131,10 +131,10 @@ hipsparseStatus_t testing_csr2coo(Arguments argus)
         // Do not test args in cusparse
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
-        auto csr_row_ptr_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto coo_row_ind_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+        auto csr_row_ptr_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto coo_row_ind_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
 
         int* csr_row_ptr = (int*)csr_row_ptr_managed.get();
         int* coo_row_ind = (int*)coo_row_ind_managed.get();
@@ -161,9 +161,9 @@ hipsparseStatus_t testing_csr2coo(Arguments argus)
     }
 
     // Host structures
-    std::vector<int> hcsr_row_ptr;
-    std::vector<int> hcoo_row_ind;
-    std::vector<int> hcol_ind;
+    std::vector<int>   hcsr_row_ptr;
+    std::vector<int>   hcoo_row_ind;
+    std::vector<int>   hcol_ind;
     std::vector<float> hval(nnz);
 
     // Initial data on CPU
@@ -185,8 +185,8 @@ hipsparseStatus_t testing_csr2coo(Arguments argus)
     {
         if(filename != "")
         {
-            if(read_mtx_matrix(
-                   filename.c_str(), m, n, nnz, hcoo_row_ind, hcol_ind, hval, idx_base) != 0)
+            if(read_mtx_matrix(filename.c_str(), m, n, nnz, hcoo_row_ind, hcol_ind, hval, idx_base)
+               != 0)
             {
                 fprintf(stderr, "Cannot open [read] %s\n", filename.c_str());
                 return HIPSPARSE_STATUS_INTERNAL_ERROR;
@@ -212,9 +212,10 @@ hipsparseStatus_t testing_csr2coo(Arguments argus)
     }
 
     // Allocate memory on the device
-    auto dcsr_row_ptr_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};
-    auto dcoo_row_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
+    auto dcsr_row_ptr_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * (m + 1)), device_free};
+    auto dcoo_row_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
 
     int* dcsr_row_ptr = (int*)dcsr_row_ptr_managed.get();
     int* dcoo_row_ind = (int*)dcoo_row_ind_managed.get();

--- a/clients/include/testing_csr2csc.hpp
+++ b/clients/include/testing_csr2csc.hpp
@@ -25,13 +25,13 @@
 #ifndef TESTING_CSR2CSC_HPP
 #define TESTING_CSR2CSC_HPP
 
-#include "hipsparse_test_unique_ptr.hpp"
 #include "hipsparse.hpp"
-#include "utility.hpp"
+#include "hipsparse_test_unique_ptr.hpp"
 #include "unit.hpp"
+#include "utility.hpp"
 
-#include <hipsparse.h>
 #include <algorithm>
+#include <hipsparse.h>
 #include <string>
 
 using namespace hipsparse;
@@ -44,32 +44,32 @@ void testing_csr2csc_bad_arg(void)
     // do not test for bad args
     return;
 #endif
-    int m         = 100;
-    int n         = 100;
-    int nnz       = 100;
-    int safe_size = 100;
+    int               m         = 100;
+    int               n         = 100;
+    int               nnz       = 100;
+    int               safe_size = 100;
     hipsparseStatus_t status;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
-    auto csr_row_ptr_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto csr_col_ind_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto csr_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-    auto csc_row_ind_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto csc_col_ptr_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto csc_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto csr_row_ptr_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto csr_col_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto csr_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto csc_row_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto csc_col_ptr_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto csc_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
     int* csr_row_ptr = (int*)csr_row_ptr_managed.get();
     int* csr_col_ind = (int*)csr_col_ind_managed.get();
-    T* csr_val       = (T*)csr_val_managed.get();
+    T*   csr_val     = (T*)csr_val_managed.get();
     int* csc_row_ind = (int*)csc_row_ind_managed.get();
     int* csc_col_ptr = (int*)csc_col_ptr_managed.get();
-    T* csc_val       = (T*)csc_val_managed.get();
+    T*   csc_val     = (T*)csc_val_managed.get();
 
     if(!csr_row_ptr || !csr_col_ind || !csr_val || !csc_row_ind || !csc_col_ptr || !csc_val)
     {
@@ -216,14 +216,14 @@ void testing_csr2csc_bad_arg(void)
 template <typename T>
 hipsparseStatus_t testing_csr2csc(Arguments argus)
 {
-    int m                         = argus.M;
-    int n                         = argus.N;
-    int safe_size                 = 100;
-    hipsparseIndexBase_t idx_base = argus.idx_base;
-    hipsparseAction_t action      = argus.action;
-    std::string binfile           = "";
-    std::string filename          = "";
-    hipsparseStatus_t status;
+    int                  m         = argus.M;
+    int                  n         = argus.N;
+    int                  safe_size = 100;
+    hipsparseIndexBase_t idx_base  = argus.idx_base;
+    hipsparseAction_t    action    = argus.action;
+    std::string          binfile   = "";
+    std::string          filename  = "";
+    hipsparseStatus_t    status;
 
     // When in testing mode, M == N == -99 indicates that we are testing with a real
     // matrix from cise.ufl.edu
@@ -246,7 +246,7 @@ hipsparseStatus_t testing_csr2csc(Arguments argus)
     int nnz = m * scale * n;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
     // Argument sanity check before allocating invalid memory
     if(m <= 0 || n <= 0 || nnz <= 0)
@@ -255,25 +255,25 @@ hipsparseStatus_t testing_csr2csc(Arguments argus)
         // Do not test args in cusparse
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
-        auto csr_row_ptr_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto csr_col_ind_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto csr_val_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-        auto csc_row_ind_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto csc_col_ptr_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto csc_val_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto csr_row_ptr_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto csr_col_ind_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto csr_val_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        auto csc_row_ind_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto csc_col_ptr_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto csc_val_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
         int* csr_row_ptr = (int*)csr_row_ptr_managed.get();
         int* csr_col_ind = (int*)csr_col_ind_managed.get();
-        T* csr_val       = (T*)csr_val_managed.get();
+        T*   csr_val     = (T*)csr_val_managed.get();
         int* csc_row_ind = (int*)csc_row_ind_managed.get();
         int* csc_col_ptr = (int*)csc_col_ptr_managed.get();
-        T* csc_val       = (T*)csc_val_managed.get();
+        T*   csc_val     = (T*)csc_val_managed.get();
 
         if(!csr_row_ptr || !csr_col_ind || !csr_val || !csc_row_ind || !csc_col_ptr || !csc_val)
         {
@@ -311,14 +311,15 @@ hipsparseStatus_t testing_csr2csc(Arguments argus)
     // Host structures
     std::vector<int> hcsr_row_ptr;
     std::vector<int> hcsr_col_ind;
-    std::vector<T> hcsr_val;
+    std::vector<T>   hcsr_val;
 
     // Sample initial COO matrix on CPU
     srand(12345ULL);
     if(binfile != "")
     {
         if(read_bin_matrix(
-               binfile.c_str(), m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base) != 0)
+               binfile.c_str(), m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base)
+           != 0)
         {
             fprintf(stderr, "Cannot open [read] %s\n", binfile.c_str());
             return HIPSPARSE_STATUS_INTERNAL_ERROR;
@@ -336,8 +337,8 @@ hipsparseStatus_t testing_csr2csc(Arguments argus)
         if(filename != "")
         {
             if(read_mtx_matrix(
-                   filename.c_str(), m, n, nnz, hcoo_row_ind, hcsr_col_ind, hcsr_val, idx_base) !=
-               0)
+                   filename.c_str(), m, n, nnz, hcoo_row_ind, hcsr_col_ind, hcsr_val, idx_base)
+               != 0)
             {
                 fprintf(stderr, "Cannot open [read] %s\n", filename.c_str());
                 return HIPSPARSE_STATUS_INTERNAL_ERROR;
@@ -363,21 +364,23 @@ hipsparseStatus_t testing_csr2csc(Arguments argus)
     }
 
     // Allocate memory on the device
-    auto dcsr_row_ptr_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};
-    auto dcsr_col_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
-    auto dcsr_val_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
-    auto dcsc_row_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
-    auto dcsc_col_ptr_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * (n + 1)), device_free};
-    auto dcsc_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dcsr_row_ptr_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * (m + 1)), device_free};
+    auto dcsr_col_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+    auto dcsr_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+    auto dcsc_row_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+    auto dcsc_col_ptr_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * (n + 1)), device_free};
+    auto dcsc_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
 
     int* dcsr_row_ptr = (int*)dcsr_row_ptr_managed.get();
     int* dcsr_col_ind = (int*)dcsr_col_ind_managed.get();
-    T* dcsr_val       = (T*)dcsr_val_managed.get();
+    T*   dcsr_val     = (T*)dcsr_val_managed.get();
     int* dcsc_row_ind = (int*)dcsc_row_ind_managed.get();
     int* dcsc_col_ptr = (int*)dcsc_col_ptr_managed.get();
-    T* dcsc_val       = (T*)dcsc_val_managed.get();
+    T*   dcsc_val     = (T*)dcsc_val_managed.get();
 
     if(!dcsr_row_ptr || !dcsr_col_ind || !dcsr_val || !dcsc_row_ind || !dcsc_col_ptr || !dcsc_val)
     {
@@ -417,7 +420,7 @@ hipsparseStatus_t testing_csr2csc(Arguments argus)
         // Copy output from device to host
         std::vector<int> hcsc_row_ind(nnz);
         std::vector<int> hcsc_col_ptr(n + 1);
-        std::vector<T> hcsc_val(nnz);
+        std::vector<T>   hcsc_val(nnz);
 
         CHECK_HIP_ERROR(
             hipMemcpy(hcsc_row_ind.data(), dcsc_row_ind, sizeof(int) * nnz, hipMemcpyDeviceToHost));
@@ -429,7 +432,7 @@ hipsparseStatus_t testing_csr2csc(Arguments argus)
         // Host csr2csc conversion
         std::vector<int> hcsc_row_ind_gold(nnz);
         std::vector<int> hcsc_col_ptr_gold(n + 1, 0);
-        std::vector<T> hcsc_val_gold(nnz);
+        std::vector<T>   hcsc_val_gold(nnz);
 
         // Determine nnz per column
         for(int i = 0; i < nnz; ++i)

--- a/clients/include/testing_csr2hyb.hpp
+++ b/clients/include/testing_csr2hyb.hpp
@@ -25,13 +25,13 @@
 #ifndef TESTING_CSR2HYB_HPP
 #define TESTING_CSR2HYB_HPP
 
-#include "hipsparse_test_unique_ptr.hpp"
 #include "hipsparse.hpp"
-#include "utility.hpp"
+#include "hipsparse_test_unique_ptr.hpp"
 #include "unit.hpp"
+#include "utility.hpp"
 
-#include <hipsparse.h>
 #include <algorithm>
+#include <hipsparse.h>
 #include <string>
 
 using namespace hipsparse;
@@ -43,45 +43,45 @@ using namespace hipsparse_test;
 
 struct test_hyb
 {
-    int m;
-    int n;
+    int                     m;
+    int                     n;
     hipsparseHybPartition_t partition;
-    int ell_nnz;
-    int ell_width;
-    int* ell_col_ind;
-    void* ell_val;
-    int coo_nnz;
-    int* coo_row_ind;
-    int* coo_col_ind;
-    void* coo_val;
+    int                     ell_nnz;
+    int                     ell_width;
+    int*                    ell_col_ind;
+    void*                   ell_val;
+    int                     coo_nnz;
+    int*                    coo_row_ind;
+    int*                    coo_col_ind;
+    void*                   coo_val;
 };
 
 template <typename T>
 void testing_csr2hyb_bad_arg(void)
 {
-    int m         = 100;
-    int n         = 100;
-    int safe_size = 100;
+    int               m         = 100;
+    int               n         = 100;
+    int               safe_size = 100;
     hipsparseStatus_t status;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
     std::unique_ptr<descr_struct> unique_ptr_descr(new descr_struct);
-    hipsparseMatDescr_t descr = unique_ptr_descr->descr;
+    hipsparseMatDescr_t           descr = unique_ptr_descr->descr;
 
     std::unique_ptr<hyb_struct> unique_ptr_hyb(new hyb_struct);
-    hipsparseHybMat_t hyb = unique_ptr_hyb->hyb;
+    hipsparseHybMat_t           hyb = unique_ptr_hyb->hyb;
 
-    auto csr_row_ptr_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto csr_col_ind_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto csr_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto csr_row_ptr_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto csr_col_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto csr_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
     int* csr_row_ptr = (int*)csr_row_ptr_managed.get();
     int* csr_col_ind = (int*)csr_col_ind_managed.get();
-    T* csr_val       = (T*)csr_val_managed.get();
+    T*   csr_val     = (T*)csr_val_managed.get();
 
     if(!csr_row_ptr || !csr_col_ind || !csr_val)
     {
@@ -158,15 +158,15 @@ void testing_csr2hyb_bad_arg(void)
 template <typename T>
 hipsparseStatus_t testing_csr2hyb(Arguments argus)
 {
-    int m                         = argus.M;
-    int n                         = argus.N;
-    int safe_size                 = 100;
-    hipsparseIndexBase_t idx_base = argus.idx_base;
-    hipsparseHybPartition_t part  = argus.part;
-    int user_ell_width            = argus.ell_width;
-    std::string binfile           = "";
-    std::string filename          = "";
-    hipsparseStatus_t status;
+    int                     m              = argus.M;
+    int                     n              = argus.N;
+    int                     safe_size      = 100;
+    hipsparseIndexBase_t    idx_base       = argus.idx_base;
+    hipsparseHybPartition_t part           = argus.part;
+    int                     user_ell_width = argus.ell_width;
+    std::string             binfile        = "";
+    std::string             filename       = "";
+    hipsparseStatus_t       status;
 
     // When in testing mode, M == N == -99 indicates that we are testing with a real
     // matrix from cise.ufl.edu
@@ -189,30 +189,30 @@ hipsparseStatus_t testing_csr2hyb(Arguments argus)
     int nnz = m * scale * n;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
     std::unique_ptr<descr_struct> unique_ptr_descr(new descr_struct);
-    hipsparseMatDescr_t descr = unique_ptr_descr->descr;
+    hipsparseMatDescr_t           descr = unique_ptr_descr->descr;
 
     // Set matrix index base
     CHECK_HIPSPARSE_ERROR(hipsparseSetMatIndexBase(descr, idx_base));
 
     std::unique_ptr<hyb_struct> unique_ptr_hyb(new hyb_struct);
-    hipsparseHybMat_t hyb = unique_ptr_hyb->hyb;
+    hipsparseHybMat_t           hyb = unique_ptr_hyb->hyb;
 
     // Argument sanity check before allocating invalid memory
     if(m <= 0 || n <= 0 || nnz <= 0)
     {
-        auto csr_row_ptr_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto csr_col_ind_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto csr_val_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto csr_row_ptr_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto csr_col_ind_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto csr_val_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
         int* csr_row_ptr = (int*)csr_row_ptr_managed.get();
         int* csr_col_ind = (int*)csr_col_ind_managed.get();
-        T* csr_val       = (T*)csr_val_managed.get();
+        T*   csr_val     = (T*)csr_val_managed.get();
 
         if(!csr_row_ptr || !csr_col_ind || !csr_val)
         {
@@ -242,14 +242,15 @@ hipsparseStatus_t testing_csr2hyb(Arguments argus)
     std::vector<int> hcsr_row_ptr;
     std::vector<int> hcoo_row_ind;
     std::vector<int> hcsr_col_ind;
-    std::vector<T> hcsr_val;
+    std::vector<T>   hcsr_val;
 
     // Sample initial COO matrix on CPU
     srand(12345ULL);
     if(binfile != "")
     {
         if(read_bin_matrix(
-               binfile.c_str(), m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base) != 0)
+               binfile.c_str(), m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base)
+           != 0)
         {
             fprintf(stderr, "Cannot open [read] %s\n", binfile.c_str());
             return HIPSPARSE_STATUS_INTERNAL_ERROR;
@@ -265,8 +266,8 @@ hipsparseStatus_t testing_csr2hyb(Arguments argus)
         if(filename != "")
         {
             if(read_mtx_matrix(
-                   filename.c_str(), m, n, nnz, hcoo_row_ind, hcsr_col_ind, hcsr_val, idx_base) !=
-               0)
+                   filename.c_str(), m, n, nnz, hcoo_row_ind, hcsr_col_ind, hcsr_val, idx_base)
+               != 0)
             {
                 fprintf(stderr, "Cannot open [read] %s\n", filename.c_str());
                 return HIPSPARSE_STATUS_INTERNAL_ERROR;
@@ -292,14 +293,15 @@ hipsparseStatus_t testing_csr2hyb(Arguments argus)
     }
 
     // Allocate memory on the device
-    auto dcsr_row_ptr_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};
-    auto dcsr_col_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
-    auto dcsr_val_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dcsr_row_ptr_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * (m + 1)), device_free};
+    auto dcsr_col_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+    auto dcsr_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
 
     int* dcsr_row_ptr = (int*)dcsr_row_ptr_managed.get();
     int* dcsr_col_ind = (int*)dcsr_col_ind_managed.get();
-    T* dcsr_val       = (T*)dcsr_val_managed.get();
+    T*   dcsr_val     = (T*)dcsr_val_managed.get();
 
     if(!dcsr_row_ptr || !dcsr_col_ind || !dcsr_val)
     {
@@ -377,10 +379,10 @@ hipsparseStatus_t testing_csr2hyb(Arguments argus)
 
     // Host structures for verification
     std::vector<int> hhyb_ell_col_ind_gold;
-    std::vector<T> hhyb_ell_val_gold;
+    std::vector<T>   hhyb_ell_val_gold;
     std::vector<int> hhyb_coo_row_ind_gold;
     std::vector<int> hhyb_coo_col_ind_gold;
-    std::vector<T> hhyb_coo_val_gold;
+    std::vector<T>   hhyb_coo_val_gold;
 
     // Host csr2hyb conversion
     int ell_width = 0;
@@ -463,10 +465,10 @@ hipsparseStatus_t testing_csr2hyb(Arguments argus)
 
     // Allocate verification structures
     std::vector<int> hhyb_ell_col_ind(ell_nnz);
-    std::vector<T> hhyb_ell_val(ell_nnz);
+    std::vector<T>   hhyb_ell_val(ell_nnz);
     std::vector<int> hhyb_coo_row_ind(coo_nnz);
     std::vector<int> hhyb_coo_col_ind(coo_nnz);
-    std::vector<T> hhyb_coo_val(coo_nnz);
+    std::vector<T>   hhyb_coo_val(coo_nnz);
 
     if(argus.unit_check)
     {

--- a/clients/include/testing_csrilu02.hpp
+++ b/clients/include/testing_csrilu02.hpp
@@ -25,14 +25,14 @@
 #ifndef TESTING_CSRILU0_HPP
 #define TESTING_CSRILU0_HPP
 
-#include "hipsparse_test_unique_ptr.hpp"
 #include "hipsparse.hpp"
-#include "utility.hpp"
+#include "hipsparse_test_unique_ptr.hpp"
 #include "unit.hpp"
+#include "utility.hpp"
 
-#include <string>
 #include <cmath>
 #include <hipsparse.h>
+#include <string>
 
 using namespace hipsparse;
 using namespace hipsparse_test;
@@ -44,30 +44,30 @@ void testing_csrilu02_bad_arg(void)
     // do not test for bad args
     return;
 #endif
-    int m                         = 100;
-    int nnz                       = 100;
-    int safe_size                 = 100;
-    hipsparseSolvePolicy_t policy = HIPSPARSE_SOLVE_POLICY_USE_LEVEL;
-    hipsparseStatus_t status;
+    int                    m         = 100;
+    int                    nnz       = 100;
+    int                    safe_size = 100;
+    hipsparseSolvePolicy_t policy    = HIPSPARSE_SOLVE_POLICY_USE_LEVEL;
+    hipsparseStatus_t      status;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
     std::unique_ptr<descr_struct> unique_ptr_descr(new descr_struct);
-    hipsparseMatDescr_t descr = unique_ptr_descr->descr;
+    hipsparseMatDescr_t           descr = unique_ptr_descr->descr;
 
     std::unique_ptr<csrilu02_struct> unique_ptr_csrilu02(new csrilu02_struct);
-    csrilu02Info_t info = unique_ptr_csrilu02->info;
+    csrilu02Info_t                   info = unique_ptr_csrilu02->info;
 
-    auto dptr_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto dcol_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-    auto dbuffer_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
+    auto dptr_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto dcol_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto dval_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dbuffer_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
 
-    int* dptr     = (int*)dptr_managed.get();
-    int* dcol     = (int*)dcol_managed.get();
-    T* dval       = (T*)dval_managed.get();
+    int*  dptr    = (int*)dptr_managed.get();
+    int*  dcol    = (int*)dcol_managed.get();
+    T*    dval    = (T*)dval_managed.get();
     void* dbuffer = (void*)dbuffer_managed.get();
 
     if(!dval || !dptr || !dcol || !dbuffer)
@@ -201,56 +201,56 @@ void testing_csrilu02_bad_arg(void)
     {
         int* dptr_null = nullptr;
 
-        status =
-            hipsparseXcsrilu02(handle, m, nnz, descr, dval, dptr_null, dcol, info, policy, dbuffer);
+        status = hipsparseXcsrilu02(
+            handle, m, nnz, descr, dval, dptr_null, dcol, info, policy, dbuffer);
         verify_hipsparse_status_invalid_pointer(status, "Error: dptr is nullptr");
     }
     // testing for(nullptr == dcol)
     {
         int* dcol_null = nullptr;
 
-        status =
-            hipsparseXcsrilu02(handle, m, nnz, descr, dval, dptr, dcol_null, info, policy, dbuffer);
+        status = hipsparseXcsrilu02(
+            handle, m, nnz, descr, dval, dptr, dcol_null, info, policy, dbuffer);
         verify_hipsparse_status_invalid_pointer(status, "Error: dcol is nullptr");
     }
     // testing for(nullptr == dval)
     {
         T* dval_null = nullptr;
 
-        status =
-            hipsparseXcsrilu02(handle, m, nnz, descr, dval_null, dptr, dcol, info, policy, dbuffer);
+        status = hipsparseXcsrilu02(
+            handle, m, nnz, descr, dval_null, dptr, dcol, info, policy, dbuffer);
         verify_hipsparse_status_invalid_pointer(status, "Error: dval is nullptr");
     }
     // testing for(nullptr == dbuffer)
     {
         void* dbuffer_null = nullptr;
 
-        status =
-            hipsparseXcsrilu02(handle, m, nnz, descr, dval, dptr, dcol, info, policy, dbuffer_null);
+        status = hipsparseXcsrilu02(
+            handle, m, nnz, descr, dval, dptr, dcol, info, policy, dbuffer_null);
         verify_hipsparse_status_invalid_pointer(status, "Error: dbuffer is nullptr");
     }
     // testing for(nullptr == descr)
     {
         hipsparseMatDescr_t descr_null = nullptr;
 
-        status =
-            hipsparseXcsrilu02(handle, m, nnz, descr_null, dval, dptr, dcol, info, policy, dbuffer);
+        status = hipsparseXcsrilu02(
+            handle, m, nnz, descr_null, dval, dptr, dcol, info, policy, dbuffer);
         verify_hipsparse_status_invalid_pointer(status, "Error: descr is nullptr");
     }
     // testing for(nullptr == info)
     {
         csrilu02Info_t info_null = nullptr;
 
-        status =
-            hipsparseXcsrilu02(handle, m, nnz, descr, dval, dptr, dcol, info_null, policy, dbuffer);
+        status = hipsparseXcsrilu02(
+            handle, m, nnz, descr, dval, dptr, dcol, info_null, policy, dbuffer);
         verify_hipsparse_status_invalid_pointer(status, "Error: info is nullptr");
     }
     // testing for(nullptr == handle)
     {
         hipsparseHandle_t handle_null = nullptr;
 
-        status =
-            hipsparseXcsrilu02(handle_null, m, nnz, descr, dval, dptr, dcol, info, policy, dbuffer);
+        status = hipsparseXcsrilu02(
+            handle_null, m, nnz, descr, dval, dptr, dcol, info, policy, dbuffer);
         verify_hipsparse_status_invalid_handle(status);
     }
 
@@ -283,14 +283,14 @@ void testing_csrilu02_bad_arg(void)
 template <typename T>
 hipsparseStatus_t testing_csrilu02(Arguments argus)
 {
-    int safe_size                 = 100;
-    int m                         = argus.M;
-    hipsparseIndexBase_t idx_base = argus.idx_base;
-    hipsparseSolvePolicy_t policy = HIPSPARSE_SOLVE_POLICY_USE_LEVEL;
-    std::string binfile           = "";
-    std::string filename          = "";
-    hipsparseStatus_t status;
-    size_t size;
+    int                    safe_size = 100;
+    int                    m         = argus.M;
+    hipsparseIndexBase_t   idx_base  = argus.idx_base;
+    hipsparseSolvePolicy_t policy    = HIPSPARSE_SOLVE_POLICY_USE_LEVEL;
+    std::string            binfile   = "";
+    std::string            filename  = "";
+    hipsparseStatus_t      status;
+    size_t                 size;
 
     // When in testing mode, M == N == -99 indicates that we are testing with a real
     // matrix from cise.ufl.edu
@@ -306,13 +306,13 @@ hipsparseStatus_t testing_csrilu02(Arguments argus)
     }
 
     std::unique_ptr<handle_struct> test_handle(new handle_struct);
-    hipsparseHandle_t handle = test_handle->handle;
+    hipsparseHandle_t              handle = test_handle->handle;
 
     std::unique_ptr<descr_struct> test_descr(new descr_struct);
-    hipsparseMatDescr_t descr = test_descr->descr;
+    hipsparseMatDescr_t           descr = test_descr->descr;
 
     std::unique_ptr<csrilu02_struct> unique_ptr_csrilu02(new csrilu02_struct);
-    csrilu02Info_t info = unique_ptr_csrilu02->info;
+    csrilu02Info_t                   info = unique_ptr_csrilu02->info;
 
     // Set matrix index base
     CHECK_HIPSPARSE_ERROR(hipsparseSetMatIndexBase(descr, idx_base));
@@ -332,17 +332,18 @@ hipsparseStatus_t testing_csrilu02(Arguments argus)
         // Do not test args in cusparse
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
-        auto dptr_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto dcol_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-        auto buffer_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
+        auto dptr_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto dcol_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto dval_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        auto buffer_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
 
-        int* dptr    = (int*)dptr_managed.get();
-        int* dcol    = (int*)dcol_managed.get();
-        T* dval      = (T*)dval_managed.get();
+        int*  dptr   = (int*)dptr_managed.get();
+        int*  dcol   = (int*)dcol_managed.get();
+        T*    dval   = (T*)dval_managed.get();
         void* buffer = (void*)buffer_managed.get();
 
         if(!dval || !dptr || !dcol || !buffer)
@@ -353,8 +354,8 @@ hipsparseStatus_t testing_csrilu02(Arguments argus)
         }
 
         // Test hipsparseXcsrilu02_bufferSizeExt
-        status =
-            hipsparseXcsrilu02_bufferSizeExt(handle, m, nnz, descr, dval, dptr, dcol, info, &size);
+        status = hipsparseXcsrilu02_bufferSizeExt(
+            handle, m, nnz, descr, dval, dptr, dcol, info, &size);
 
         if(m < 0 || nnz < 0)
         {
@@ -404,14 +405,15 @@ hipsparseStatus_t testing_csrilu02(Arguments argus)
     // Host structures
     std::vector<int> hcsr_row_ptr;
     std::vector<int> hcsr_col_ind;
-    std::vector<T> hcsr_val;
+    std::vector<T>   hcsr_val;
 
     // Initial Data on CPU
     srand(12345ULL);
     if(binfile != "")
     {
         if(read_bin_matrix(
-               binfile.c_str(), m, m, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base) != 0)
+               binfile.c_str(), m, m, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base)
+           != 0)
         {
             fprintf(stderr, "Cannot open [read] %s\n", binfile.c_str());
             return HIPSPARSE_STATUS_INTERNAL_ERROR;
@@ -429,8 +431,8 @@ hipsparseStatus_t testing_csrilu02(Arguments argus)
         if(filename != "")
         {
             if(read_mtx_matrix(
-                   filename.c_str(), m, m, nnz, hcoo_row_ind, hcsr_col_ind, hcsr_val, idx_base) !=
-               0)
+                   filename.c_str(), m, m, nnz, hcoo_row_ind, hcsr_col_ind, hcsr_val, idx_base)
+               != 0)
             {
                 fprintf(stderr, "Cannot open [read] %s\n", filename.c_str());
                 return HIPSPARSE_STATUS_INTERNAL_ERROR;
@@ -456,14 +458,14 @@ hipsparseStatus_t testing_csrilu02(Arguments argus)
     }
 
     // Allocate memory on device
-    auto dptr_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};
-    auto dcol_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
-    auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
-    auto d_position_managed = hipsparse_unique_ptr{device_malloc(sizeof(int)), device_free};
+    auto dptr_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * (m + 1)), device_free};
+    auto dcol_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+    auto dval_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+    auto d_position_managed = hipsparse_unique_ptr {device_malloc(sizeof(int)), device_free};
 
     int* dptr       = (int*)dptr_managed.get();
     int* dcol       = (int*)dcol_managed.get();
-    T* dval         = (T*)dval_managed.get();
+    T*   dval       = (T*)dval_managed.get();
     int* d_position = (int*)d_position_managed.get();
 
     if(!dval || !dptr || !dcol || !d_position)
@@ -484,7 +486,7 @@ hipsparseStatus_t testing_csrilu02(Arguments argus)
         hipsparseXcsrilu02_bufferSizeExt(handle, m, nnz, descr, dval, dptr, dcol, info, &size));
 
     // Allocate buffer on the device
-    auto dbuffer_managed = hipsparse_unique_ptr{device_malloc(sizeof(char) * size), device_free};
+    auto dbuffer_managed = hipsparse_unique_ptr {device_malloc(sizeof(char) * size), device_free};
 
     void* dbuffer = (void*)dbuffer_managed.get();
 
@@ -506,7 +508,7 @@ hipsparseStatus_t testing_csrilu02(Arguments argus)
         // Pointer mode host
         CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_HOST));
 
-        int hposition_1;
+        int               hposition_1;
         hipsparseStatus_t pivot_status_1;
         pivot_status_1 = hipsparseXcsrilu02_zeroPivot(handle, info, &hposition_1);
 
@@ -517,7 +519,7 @@ hipsparseStatus_t testing_csrilu02(Arguments argus)
         pivot_status_2 = hipsparseXcsrilu02_zeroPivot(handle, info, d_position);
 
         // Copy output from device to CPU
-        int hposition_2;
+        int            hposition_2;
         std::vector<T> result(nnz);
         CHECK_HIP_ERROR(hipMemcpy(result.data(), dval, sizeof(T) * nnz, hipMemcpyDeviceToHost));
         CHECK_HIP_ERROR(hipMemcpy(&hposition_2, d_position, sizeof(int), hipMemcpyDeviceToHost));
@@ -525,8 +527,8 @@ hipsparseStatus_t testing_csrilu02(Arguments argus)
         // Host csrilu02
         double cpu_time_used = get_time_us();
 
-        int position_gold =
-            csrilu0(m, hcsr_row_ptr.data(), hcsr_col_ind.data(), hcsr_val.data(), idx_base);
+        int position_gold
+            = csrilu0(m, hcsr_row_ptr.data(), hcsr_col_ind.data(), hcsr_val.data(), idx_base);
 
         cpu_time_used = get_time_us() - cpu_time_used;
 

--- a/clients/include/testing_csrilusv.hpp
+++ b/clients/include/testing_csrilusv.hpp
@@ -25,16 +25,16 @@
 #ifndef TESTING_CSRILUSV_HPP
 #define TESTING_CSRILUSV_HPP
 
-#include "hipsparse_test_unique_ptr.hpp"
 #include "hipsparse.hpp"
-#include "utility.hpp"
+#include "hipsparse_test_unique_ptr.hpp"
 #include "unit.hpp"
+#include "utility.hpp"
 
-#include <string>
-#include <cmath>
-#include <limits>
 #include <algorithm>
+#include <cmath>
 #include <hipsparse.h>
+#include <limits>
+#include <string>
 
 using namespace hipsparse;
 using namespace hipsparse_test;
@@ -45,13 +45,13 @@ hipsparseStatus_t testing_csrilusv(Arguments argus)
     hipsparseIndexBase_t idx_base = argus.idx_base;
 
     std::unique_ptr<handle_struct> test_handle(new handle_struct);
-    hipsparseHandle_t handle = test_handle->handle;
+    hipsparseHandle_t              handle = test_handle->handle;
 
     std::unique_ptr<descr_struct> test_descr_M(new descr_struct);
-    hipsparseMatDescr_t descr_M = test_descr_M->descr;
+    hipsparseMatDescr_t           descr_M = test_descr_M->descr;
 
     std::unique_ptr<csrilu02_struct> test_csrilu02_info(new csrilu02_struct);
-    csrilu02Info_t info_M = test_csrilu02_info->info;
+    csrilu02Info_t                   info_M = test_csrilu02_info->info;
 
     // Initialize the matrix descriptor
     CHECK_HIPSPARSE_ERROR(hipsparseSetMatIndexBase(descr_M, idx_base));
@@ -59,7 +59,7 @@ hipsparseStatus_t testing_csrilusv(Arguments argus)
     // Host structures
     std::vector<int> hcsr_row_ptr;
     std::vector<int> hcsr_col_ind;
-    std::vector<T> hcsr_val;
+    std::vector<T>   hcsr_val;
 
     // Initial Data on CPU
     int m;
@@ -67,21 +67,22 @@ hipsparseStatus_t testing_csrilusv(Arguments argus)
     int nnz;
 
     if(read_bin_matrix(
-           argus.filename.c_str(), m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base) != 0)
+           argus.filename.c_str(), m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base)
+       != 0)
     {
         fprintf(stderr, "Cannot open [read] %s\n", argus.filename.c_str());
         return HIPSPARSE_STATUS_INTERNAL_ERROR;
     }
 
     // Allocate memory on device
-    auto dptr_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};
-    auto dcol_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
-    auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
-    auto d_position_managed = hipsparse_unique_ptr{device_malloc(sizeof(int)), device_free};
+    auto dptr_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * (m + 1)), device_free};
+    auto dcol_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+    auto dval_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+    auto d_position_managed = hipsparse_unique_ptr {device_malloc(sizeof(int)), device_free};
 
     int* dptr       = (int*)dptr_managed.get();
     int* dcol       = (int*)dcol_managed.get();
-    T* dval         = (T*)dval_managed.get();
+    T*   dval       = (T*)dval_managed.get();
     int* d_position = (int*)d_position_managed.get();
 
     if(!dval || !dptr || !dcol || !d_position)
@@ -103,7 +104,7 @@ hipsparseStatus_t testing_csrilusv(Arguments argus)
         hipsparseXcsrilu02_bufferSizeExt(handle, m, nnz, descr_M, dval, dptr, dcol, info_M, &size));
 
     // Allocate buffer on the device
-    auto dbuffer_managed = hipsparse_unique_ptr{device_malloc(sizeof(char) * size), device_free};
+    auto dbuffer_managed = hipsparse_unique_ptr {device_malloc(sizeof(char) * size), device_free};
 
     void* dbuffer = (void*)dbuffer_managed.get();
 
@@ -138,7 +139,7 @@ hipsparseStatus_t testing_csrilusv(Arguments argus)
                                              dbuffer));
 
     // Check for zero pivot
-    int hposition_1, hposition_2;
+    int               hposition_1, hposition_2;
     hipsparseStatus_t pivot_status_1, pivot_status_2;
 
     // Host pointer mode
@@ -155,8 +156,8 @@ hipsparseStatus_t testing_csrilusv(Arguments argus)
     CHECK_HIP_ERROR(hipMemcpy(&hposition_2, d_position, sizeof(int), hipMemcpyDeviceToHost));
 
     // Compute host reference csrilu0
-    int position_gold =
-        csrilu0(m, hcsr_row_ptr.data(), hcsr_col_ind.data(), hcsr_val.data(), idx_base);
+    int position_gold
+        = csrilu0(m, hcsr_row_ptr.data(), hcsr_col_ind.data(), hcsr_val.data(), idx_base);
 
     // Check zero pivot results
     unit_check_general(1, 1, 1, &position_gold, &hposition_1);
@@ -191,14 +192,14 @@ hipsparseStatus_t testing_csrilusv(Arguments argus)
 
     // Create matrix descriptors for csrsv
     std::unique_ptr<descr_struct> test_descr_L(new descr_struct);
-    hipsparseMatDescr_t descr_L = test_descr_L->descr;
+    hipsparseMatDescr_t           descr_L = test_descr_L->descr;
 
     CHECK_HIPSPARSE_ERROR(hipsparseSetMatIndexBase(descr_L, idx_base));
     CHECK_HIPSPARSE_ERROR(hipsparseSetMatFillMode(descr_L, HIPSPARSE_FILL_MODE_LOWER));
     CHECK_HIPSPARSE_ERROR(hipsparseSetMatDiagType(descr_L, HIPSPARSE_DIAG_TYPE_UNIT));
 
     std::unique_ptr<descr_struct> test_descr_U(new descr_struct);
-    hipsparseMatDescr_t descr_U = test_descr_U->descr;
+    hipsparseMatDescr_t           descr_U = test_descr_U->descr;
 
     CHECK_HIPSPARSE_ERROR(hipsparseSetMatIndexBase(descr_U, idx_base));
     CHECK_HIPSPARSE_ERROR(hipsparseSetMatFillMode(descr_U, HIPSPARSE_FILL_MODE_UPPER));
@@ -231,7 +232,8 @@ hipsparseStatus_t testing_csrilusv(Arguments argus)
     size = std::max(size_lower, size_upper);
 
     // Allocate buffer on the device
-    auto dbuffer_sv_managed = hipsparse_unique_ptr{device_malloc(sizeof(char) * size), device_free};
+    auto dbuffer_sv_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(char) * size), device_free};
 
     void* dbuffer_sv = (void*)dbuffer_sv_managed.get();
 
@@ -274,12 +276,12 @@ hipsparseStatus_t testing_csrilusv(Arguments argus)
     std::vector<T> hz_gold(m);
 
     // Allocate device memory
-    auto dx_managed      = hipsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
-    auto dy_1_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
-    auto dy_2_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
-    auto dz_1_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
-    auto dz_2_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
-    auto d_alpha_managed = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
+    auto dx_managed      = hipsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
+    auto dy_1_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
+    auto dy_2_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
+    auto dz_1_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
+    auto dz_2_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
+    auto d_alpha_managed = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
 
     T* dx      = (T*)dx_managed.get();
     T* dy_1    = (T*)dy_1_managed.get();

--- a/clients/include/testing_csrmm.hpp
+++ b/clients/include/testing_csrmm.hpp
@@ -25,13 +25,13 @@
 #ifndef TESTING_CSRMM_HPP
 #define TESTING_CSRMM_HPP
 
-#include "hipsparse_test_unique_ptr.hpp"
 #include "hipsparse.hpp"
-#include "utility.hpp"
+#include "hipsparse_test_unique_ptr.hpp"
 #include "unit.hpp"
+#include "utility.hpp"
 
-#include <string>
 #include <hipsparse.h>
+#include <string>
 
 using namespace hipsparse;
 using namespace hipsparse_test;
@@ -43,36 +43,36 @@ void testing_csrmm_bad_arg(void)
     // do not test for bad args
     return;
 #endif
-    int N                       = 100;
-    int M                       = 100;
-    int K                       = 100;
-    int ldb                     = 100;
-    int ldc                     = 100;
-    int nnz                     = 100;
-    int safe_size               = 100;
-    T alpha                     = 0.6;
-    T beta                      = 0.2;
-    hipsparseOperation_t transA = HIPSPARSE_OPERATION_NON_TRANSPOSE;
-    hipsparseOperation_t transB = HIPSPARSE_OPERATION_NON_TRANSPOSE;
-    hipsparseStatus_t status;
+    int                  N         = 100;
+    int                  M         = 100;
+    int                  K         = 100;
+    int                  ldb       = 100;
+    int                  ldc       = 100;
+    int                  nnz       = 100;
+    int                  safe_size = 100;
+    T                    alpha     = 0.6;
+    T                    beta      = 0.2;
+    hipsparseOperation_t transA    = HIPSPARSE_OPERATION_NON_TRANSPOSE;
+    hipsparseOperation_t transB    = HIPSPARSE_OPERATION_NON_TRANSPOSE;
+    hipsparseStatus_t    status;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
     std::unique_ptr<descr_struct> unique_ptr_descr(new descr_struct);
-    hipsparseMatDescr_t descr = unique_ptr_descr->descr;
+    hipsparseMatDescr_t           descr = unique_ptr_descr->descr;
 
-    auto dptr_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto dcol_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-    auto dB_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-    auto dC_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dptr_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto dcol_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto dval_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dB_managed   = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dC_managed   = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
     int* dptr = (int*)dptr_managed.get();
     int* dcol = (int*)dcol_managed.get();
-    T* dval   = (T*)dval_managed.get();
-    T* dB     = (T*)dB_managed.get();
-    T* dC     = (T*)dC_managed.get();
+    T*   dval = (T*)dval_managed.get();
+    T*   dB   = (T*)dB_managed.get();
+    T*   dC   = (T*)dC_managed.get();
 
     if(!dval || !dptr || !dcol || !dB || !dC)
     {
@@ -292,20 +292,20 @@ void testing_csrmm_bad_arg(void)
 template <typename T>
 hipsparseStatus_t testing_csrmm(Arguments argus)
 {
-    int safe_size                 = 100;
-    int M                         = argus.M;
-    int N                         = argus.N;
-    int K                         = argus.K;
-    int ldb                       = argus.ldb;
-    int ldc                       = argus.ldc;
-    T h_alpha                     = argus.alpha;
-    T h_beta                      = argus.beta;
-    hipsparseOperation_t transA   = argus.transA;
-    hipsparseOperation_t transB   = argus.transB;
-    hipsparseIndexBase_t idx_base = argus.idx_base;
-    std::string binfile           = "";
-    std::string filename          = "";
-    hipsparseStatus_t status;
+    int                  safe_size = 100;
+    int                  M         = argus.M;
+    int                  N         = argus.N;
+    int                  K         = argus.K;
+    int                  ldb       = argus.ldb;
+    int                  ldc       = argus.ldc;
+    T                    h_alpha   = argus.alpha;
+    T                    h_beta    = argus.beta;
+    hipsparseOperation_t transA    = argus.transA;
+    hipsparseOperation_t transB    = argus.transB;
+    hipsparseIndexBase_t idx_base  = argus.idx_base;
+    std::string          binfile   = "";
+    std::string          filename  = "";
+    hipsparseStatus_t    status;
 
     // When in testing mode, M == N == -99 indicates that we are testing with a real
     // matrix from cise.ufl.edu
@@ -321,10 +321,10 @@ hipsparseStatus_t testing_csrmm(Arguments argus)
     }
 
     std::unique_ptr<handle_struct> test_handle(new handle_struct);
-    hipsparseHandle_t handle = test_handle->handle;
+    hipsparseHandle_t              handle = test_handle->handle;
 
     std::unique_ptr<descr_struct> test_descr(new descr_struct);
-    hipsparseMatDescr_t descr = test_descr->descr;
+    hipsparseMatDescr_t           descr = test_descr->descr;
 
     // Set matrix index base
     CHECK_HIPSPARSE_ERROR(hipsparseSetMatIndexBase(descr, idx_base));
@@ -344,19 +344,20 @@ hipsparseStatus_t testing_csrmm(Arguments argus)
         // Do not test args in cusparse
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
-        auto dptr_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto dcol_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-        auto dB_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-        auto dC_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dptr_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto dcol_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto dval_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        auto dB_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        auto dC_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
         int* dptr = (int*)dptr_managed.get();
         int* dcol = (int*)dcol_managed.get();
-        T* dval   = (T*)dval_managed.get();
-        T* dB     = (T*)dB_managed.get();
-        T* dC     = (T*)dC_managed.get();
+        T*   dval = (T*)dval_managed.get();
+        T*   dB   = (T*)dB_managed.get();
+        T*   dC   = (T*)dC_managed.get();
 
         if(!dval || !dptr || !dcol || !dB || !dC)
         {
@@ -403,13 +404,14 @@ hipsparseStatus_t testing_csrmm(Arguments argus)
     // Host structures - CSR matrix A
     std::vector<int> hcsr_row_ptrA;
     std::vector<int> hcsr_col_indA;
-    std::vector<T> hcsr_valA;
+    std::vector<T>   hcsr_valA;
 
     // Initial Data on CPU
     if(binfile != "")
     {
         if(read_bin_matrix(
-               binfile.c_str(), M, K, nnz, hcsr_row_ptrA, hcsr_col_indA, hcsr_valA, idx_base) != 0)
+               binfile.c_str(), M, K, nnz, hcsr_row_ptrA, hcsr_col_indA, hcsr_valA, idx_base)
+           != 0)
         {
             fprintf(stderr, "Cannot open [read] %s\n", binfile.c_str());
             return HIPSPARSE_STATUS_INTERNAL_ERROR;
@@ -417,8 +419,8 @@ hipsparseStatus_t testing_csrmm(Arguments argus)
     }
     else if(argus.laplacian)
     {
-        M = K =
-            gen_2d_laplacian(argus.laplacian, hcsr_row_ptrA, hcsr_col_indA, hcsr_valA, idx_base);
+        M = K
+            = gen_2d_laplacian(argus.laplacian, hcsr_row_ptrA, hcsr_col_indA, hcsr_valA, idx_base);
         nnz = hcsr_row_ptrA[M];
     }
     else
@@ -427,14 +429,9 @@ hipsparseStatus_t testing_csrmm(Arguments argus)
 
         if(filename != "")
         {
-            if(read_mtx_matrix(filename.c_str(),
-                               M,
-                               K,
-                               nnz,
-                               hcoo_row_indA,
-                               hcsr_col_indA,
-                               hcsr_valA,
-                               idx_base) != 0)
+            if(read_mtx_matrix(
+                   filename.c_str(), M, K, nnz, hcoo_row_indA, hcsr_col_indA, hcsr_valA, idx_base)
+               != 0)
             {
                 fprintf(stderr, "Cannot open [read] %s\n", filename.c_str());
                 return HIPSPARSE_STATUS_INTERNAL_ERROR;
@@ -494,25 +491,25 @@ hipsparseStatus_t testing_csrmm(Arguments argus)
     hC_2    = hC_1;
 
     // allocate memory on device
-    auto dcsr_row_ptrA_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * (M + 1)), device_free};
-    auto dcsr_col_indA_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
-    auto dcsr_valA_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
-    auto dB_managed        = hipsparse_unique_ptr{device_malloc(sizeof(T) * Bnnz), device_free};
-    auto dC_1_managed      = hipsparse_unique_ptr{device_malloc(sizeof(T) * Cnnz), device_free};
-    auto dC_2_managed      = hipsparse_unique_ptr{device_malloc(sizeof(T) * Cnnz), device_free};
-    auto d_alpha_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
-    auto d_beta_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
+    auto dcsr_row_ptrA_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * (M + 1)), device_free};
+    auto dcsr_col_indA_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+    auto dcsr_valA_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+    auto dB_managed        = hipsparse_unique_ptr {device_malloc(sizeof(T) * Bnnz), device_free};
+    auto dC_1_managed      = hipsparse_unique_ptr {device_malloc(sizeof(T) * Cnnz), device_free};
+    auto dC_2_managed      = hipsparse_unique_ptr {device_malloc(sizeof(T) * Cnnz), device_free};
+    auto d_alpha_managed   = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+    auto d_beta_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
 
     int* dcsr_row_ptrA = (int*)dcsr_row_ptrA_managed.get();
     int* dcsr_col_indA = (int*)dcsr_col_indA_managed.get();
-    T* dcsr_valA       = (T*)dcsr_valA_managed.get();
-    T* dB              = (T*)dB_managed.get();
-    T* dC_1            = (T*)dC_1_managed.get();
-    T* dC_2            = (T*)dC_2_managed.get();
-    T* d_alpha         = (T*)d_alpha_managed.get();
-    T* d_beta          = (T*)d_beta_managed.get();
+    T*   dcsr_valA     = (T*)dcsr_valA_managed.get();
+    T*   dB            = (T*)dB_managed.get();
+    T*   dC_1          = (T*)dC_1_managed.get();
+    T*   dC_2          = (T*)dC_2_managed.get();
+    T*   d_alpha       = (T*)d_alpha_managed.get();
+    T*   d_beta        = (T*)d_beta_managed.get();
 
     if(!dcsr_valA || !dcsr_row_ptrA || !dcsr_col_indA || !dB || !dC_1 || !d_alpha || !d_beta)
     {
@@ -589,7 +586,7 @@ hipsparseStatus_t testing_csrmm(Arguments argus)
             for(int j = 0; j < Cncol; ++j)
             {
                 int Cidx = i + j * ldc;
-                T sum    = hC_gold[Cidx] * h_beta;
+                T   sum  = hC_gold[Cidx] * h_beta;
 
                 for(int k = hcsr_row_ptrA[i] - idx_base; k < hcsr_row_ptrA[i + 1] - idx_base; ++k)
                 {
@@ -666,8 +663,8 @@ hipsparseStatus_t testing_csrmm(Arguments argus)
         double gpu_gflops = flops / gpu_time_used / 1e6;
         size_t memtrans   = nnz + Cnnz + Bnnz;
         memtrans          = (h_beta != 0.0) ? memtrans + Cnnz : memtrans;
-        double bandwidth =
-            (memtrans * sizeof(T) + (M + 1 + nnz) * sizeof(int)) / gpu_time_used / 1e6;
+        double bandwidth
+            = (memtrans * sizeof(T) + (M + 1 + nnz) * sizeof(int)) / gpu_time_used / 1e6;
 
         printf("m\t\tn\t\tk\t\tnnz\t\talpha\tbeta\tGFlops\tGB/s\tmsec\n");
         printf("%8d\t%8d\t%8d\t%9d\t%0.2lf\t%0.2lf\t%0.2lf\t%0.2lf\t%0.2lf\n",

--- a/clients/include/testing_csrmv.hpp
+++ b/clients/include/testing_csrmv.hpp
@@ -25,14 +25,14 @@
 #ifndef TESTING_CSRMV_HPP
 #define TESTING_CSRMV_HPP
 
-#include "hipsparse_test_unique_ptr.hpp"
 #include "hipsparse.hpp"
-#include "utility.hpp"
+#include "hipsparse_test_unique_ptr.hpp"
 #include "unit.hpp"
+#include "utility.hpp"
 
-#include <string>
 #include <cmath>
 #include <hipsparse.h>
+#include <string>
 
 using namespace hipsparse;
 using namespace hipsparse_test;
@@ -44,32 +44,32 @@ void testing_csrmv_bad_arg(void)
     // do not test for bad args
     return;
 #endif
-    int n                       = 100;
-    int m                       = 100;
-    int nnz                     = 100;
-    int safe_size               = 100;
-    T alpha                     = 0.6;
-    T beta                      = 0.2;
-    hipsparseOperation_t transA = HIPSPARSE_OPERATION_NON_TRANSPOSE;
-    hipsparseStatus_t status;
+    int                  n         = 100;
+    int                  m         = 100;
+    int                  nnz       = 100;
+    int                  safe_size = 100;
+    T                    alpha     = 0.6;
+    T                    beta      = 0.2;
+    hipsparseOperation_t transA    = HIPSPARSE_OPERATION_NON_TRANSPOSE;
+    hipsparseStatus_t    status;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
     std::unique_ptr<descr_struct> unique_ptr_descr(new descr_struct);
-    hipsparseMatDescr_t descr = unique_ptr_descr->descr;
+    hipsparseMatDescr_t           descr = unique_ptr_descr->descr;
 
-    auto dptr_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto dcol_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-    auto dx_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-    auto dy_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dptr_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto dcol_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto dval_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_managed   = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dy_managed   = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
     int* dptr = (int*)dptr_managed.get();
     int* dcol = (int*)dcol_managed.get();
-    T* dval   = (T*)dval_managed.get();
-    T* dx     = (T*)dx_managed.get();
-    T* dy     = (T*)dy_managed.get();
+    T*   dval = (T*)dval_managed.get();
+    T*   dx   = (T*)dx_managed.get();
+    T*   dy   = (T*)dy_managed.get();
 
     if(!dval || !dptr || !dcol || !dx || !dy)
     {
@@ -154,16 +154,16 @@ void testing_csrmv_bad_arg(void)
 template <typename T>
 hipsparseStatus_t testing_csrmv(Arguments argus)
 {
-    int safe_size                 = 100;
-    int m                         = argus.M;
-    int n                         = argus.N;
-    T h_alpha                     = argus.alpha;
-    T h_beta                      = argus.beta;
-    hipsparseOperation_t transA   = argus.transA;
-    hipsparseIndexBase_t idx_base = argus.idx_base;
-    std::string binfile           = "";
-    std::string filename          = "";
-    hipsparseStatus_t status;
+    int                  safe_size = 100;
+    int                  m         = argus.M;
+    int                  n         = argus.N;
+    T                    h_alpha   = argus.alpha;
+    T                    h_beta    = argus.beta;
+    hipsparseOperation_t transA    = argus.transA;
+    hipsparseIndexBase_t idx_base  = argus.idx_base;
+    std::string          binfile   = "";
+    std::string          filename  = "";
+    hipsparseStatus_t    status;
 
     // When in testing mode, M == N == -99 indicates that we are testing with a real
     // matrix from cise.ufl.edu
@@ -179,10 +179,10 @@ hipsparseStatus_t testing_csrmv(Arguments argus)
     }
 
     std::unique_ptr<handle_struct> test_handle(new handle_struct);
-    hipsparseHandle_t handle = test_handle->handle;
+    hipsparseHandle_t              handle = test_handle->handle;
 
     std::unique_ptr<descr_struct> test_descr(new descr_struct);
-    hipsparseMatDescr_t descr = test_descr->descr;
+    hipsparseMatDescr_t           descr = test_descr->descr;
 
     // Set matrix index base
     CHECK_HIPSPARSE_ERROR(hipsparseSetMatIndexBase(descr, idx_base));
@@ -202,19 +202,20 @@ hipsparseStatus_t testing_csrmv(Arguments argus)
         // Do not test args in cusparse
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
-        auto dptr_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto dcol_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-        auto dx_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dptr_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto dcol_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto dval_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        auto dx_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
         int* dptr = (int*)dptr_managed.get();
         int* dcol = (int*)dcol_managed.get();
-        T* dval   = (T*)dval_managed.get();
-        T* dx     = (T*)dx_managed.get();
-        T* dy     = (T*)dy_managed.get();
+        T*   dval = (T*)dval_managed.get();
+        T*   dx   = (T*)dx_managed.get();
+        T*   dy   = (T*)dy_managed.get();
 
         if(!dval || !dptr || !dcol || !dx || !dy)
         {
@@ -243,7 +244,7 @@ hipsparseStatus_t testing_csrmv(Arguments argus)
     std::vector<int> hcsr_row_ptr;
     std::vector<int> hcoo_row_ind;
     std::vector<int> hcol_ind;
-    std::vector<T> hval;
+    std::vector<T>   hval;
 
     // Initial Data on CPU
     srand(12345ULL);
@@ -264,8 +265,8 @@ hipsparseStatus_t testing_csrmv(Arguments argus)
     {
         if(filename != "")
         {
-            if(read_mtx_matrix(
-                   filename.c_str(), m, n, nnz, hcoo_row_ind, hcol_ind, hval, idx_base) != 0)
+            if(read_mtx_matrix(filename.c_str(), m, n, nnz, hcoo_row_ind, hcol_ind, hval, idx_base)
+               != 0)
             {
                 fprintf(stderr, "Cannot open [read] %s\n", filename.c_str());
                 return HIPSPARSE_STATUS_INTERNAL_ERROR;
@@ -306,23 +307,23 @@ hipsparseStatus_t testing_csrmv(Arguments argus)
     hy_gold = hy_1;
 
     // allocate memory on device
-    auto dptr_managed    = hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};
-    auto dcol_managed    = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
-    auto dval_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
-    auto dx_managed      = hipsparse_unique_ptr{device_malloc(sizeof(T) * n), device_free};
-    auto dy_1_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
-    auto dy_2_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
-    auto d_alpha_managed = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
-    auto d_beta_managed  = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
+    auto dptr_managed    = hipsparse_unique_ptr {device_malloc(sizeof(int) * (m + 1)), device_free};
+    auto dcol_managed    = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+    auto dval_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+    auto dx_managed      = hipsparse_unique_ptr {device_malloc(sizeof(T) * n), device_free};
+    auto dy_1_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
+    auto dy_2_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
+    auto d_alpha_managed = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+    auto d_beta_managed  = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
 
-    int* dptr  = (int*)dptr_managed.get();
-    int* dcol  = (int*)dcol_managed.get();
-    T* dval    = (T*)dval_managed.get();
-    T* dx      = (T*)dx_managed.get();
-    T* dy_1    = (T*)dy_1_managed.get();
-    T* dy_2    = (T*)dy_2_managed.get();
-    T* d_alpha = (T*)d_alpha_managed.get();
-    T* d_beta  = (T*)d_beta_managed.get();
+    int* dptr    = (int*)dptr_managed.get();
+    int* dcol    = (int*)dcol_managed.get();
+    T*   dval    = (T*)dval_managed.get();
+    T*   dx      = (T*)dx_managed.get();
+    T*   dy_1    = (T*)dy_1_managed.get();
+    T*   dy_2    = (T*)dy_2_managed.get();
+    T*   d_alpha = (T*)d_alpha_managed.get();
+    T*   d_beta  = (T*)d_beta_managed.get();
 
     if(!dval || !dptr || !dcol || !dx || !dy_1 || !dy_2 || !d_alpha || !d_beta)
     {
@@ -476,8 +477,8 @@ hipsparseStatus_t testing_csrmv(Arguments argus)
         double gpu_gflops = flops / gpu_time_used / 1e6;
         size_t memtrans   = 2.0 * m + nnz;
         memtrans          = (h_beta != 0.0) ? memtrans + m : memtrans;
-        double bandwidth =
-            (memtrans * sizeof(T) + (m + 1 + nnz) * sizeof(int)) / gpu_time_used / 1e6;
+        double bandwidth
+            = (memtrans * sizeof(T) + (m + 1 + nnz) * sizeof(int)) / gpu_time_used / 1e6;
 
         printf("m\t\tn\t\tnnz\t\talpha\tbeta\tGFlops\tGB/s\tmsec\n");
         printf("%8d\t%8d\t%9d\t%0.2lf\t%0.2lf\t%0.2lf\t%0.2lf\t%0.2lf\n",

--- a/clients/include/testing_csrsort.hpp
+++ b/clients/include/testing_csrsort.hpp
@@ -25,13 +25,13 @@
 #ifndef TESTING_CSRSORT_HPP
 #define TESTING_CSRSORT_HPP
 
-#include "hipsparse_test_unique_ptr.hpp"
 #include "hipsparse.hpp"
-#include "utility.hpp"
+#include "hipsparse_test_unique_ptr.hpp"
 #include "unit.hpp"
+#include "utility.hpp"
 
-#include <hipsparse.h>
 #include <algorithm>
+#include <hipsparse.h>
 #include <string>
 
 using namespace hipsparse;
@@ -43,32 +43,32 @@ void testing_csrsort_bad_arg(void)
     // do not test for bad args
     return;
 #endif
-    int m         = 100;
-    int n         = 100;
-    int nnz       = 100;
-    int safe_size = 100;
+    int               m         = 100;
+    int               n         = 100;
+    int               nnz       = 100;
+    int               safe_size = 100;
     hipsparseStatus_t status;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
     std::unique_ptr<descr_struct> unique_ptr_descr(new descr_struct);
-    hipsparseMatDescr_t descr = unique_ptr_descr->descr;
+    hipsparseMatDescr_t           descr = unique_ptr_descr->descr;
 
     size_t buffer_size = 0;
 
-    auto csr_row_ptr_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto csr_col_ind_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto perm_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto buffer_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
+    auto csr_row_ptr_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto csr_col_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto perm_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto buffer_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
 
-    int* csr_row_ptr = (int*)csr_row_ptr_managed.get();
-    int* csr_col_ind = (int*)csr_col_ind_managed.get();
-    int* perm        = (int*)perm_managed.get();
-    void* buffer     = (void*)buffer_managed.get();
+    int*  csr_row_ptr = (int*)csr_row_ptr_managed.get();
+    int*  csr_col_ind = (int*)csr_col_ind_managed.get();
+    int*  perm        = (int*)perm_managed.get();
+    void* buffer      = (void*)buffer_managed.get();
 
     if(!csr_row_ptr || !csr_col_ind || !perm || !buffer)
     {
@@ -164,14 +164,14 @@ void testing_csrsort_bad_arg(void)
 
 hipsparseStatus_t testing_csrsort(Arguments argus)
 {
-    int m                         = argus.M;
-    int n                         = argus.N;
-    int safe_size                 = 100;
-    int permute                   = argus.temp;
-    hipsparseIndexBase_t idx_base = argus.idx_base;
-    std::string binfile           = "";
-    std::string filename          = "";
-    hipsparseStatus_t status;
+    int                  m         = argus.M;
+    int                  n         = argus.N;
+    int                  safe_size = 100;
+    int                  permute   = argus.temp;
+    hipsparseIndexBase_t idx_base  = argus.idx_base;
+    std::string          binfile   = "";
+    std::string          filename  = "";
+    hipsparseStatus_t    status;
 
     // When in testing mode, M == N == -99 indicates that we are testing with a real
     // matrix from cise.ufl.edu
@@ -196,10 +196,10 @@ hipsparseStatus_t testing_csrsort(Arguments argus)
     int nnz = m * scale * n;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
     std::unique_ptr<descr_struct> unique_ptr_descr(new descr_struct);
-    hipsparseMatDescr_t descr = unique_ptr_descr->descr;
+    hipsparseMatDescr_t           descr = unique_ptr_descr->descr;
 
     // Set matrix index base
     CHECK_HIPSPARSE_ERROR(hipsparseSetMatIndexBase(descr, idx_base));
@@ -211,19 +211,19 @@ hipsparseStatus_t testing_csrsort(Arguments argus)
         // Do not test args in cusparse
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
-        auto csr_row_ptr_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto csr_col_ind_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto perm_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto buffer_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
+        auto csr_row_ptr_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto csr_col_ind_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto perm_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto buffer_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
 
-        int* csr_row_ptr = (int*)csr_row_ptr_managed.get();
-        int* csr_col_ind = (int*)csr_col_ind_managed.get();
-        int* perm        = (int*)perm_managed.get();
-        void* buffer     = (void*)buffer_managed.get();
+        int*  csr_row_ptr = (int*)csr_row_ptr_managed.get();
+        int*  csr_col_ind = (int*)csr_col_ind_managed.get();
+        int*  perm        = (int*)perm_managed.get();
+        void* buffer      = (void*)buffer_managed.get();
 
         if(!csr_row_ptr || !csr_col_ind || !perm || !buffer)
         {
@@ -248,8 +248,8 @@ hipsparseStatus_t testing_csrsort(Arguments argus)
             unit_check_general(1, 1, 1, &zero, &buffer_size);
         }
 
-        status =
-            hipsparseXcsrsort(handle, m, n, nnz, descr, csr_row_ptr, csr_col_ind, perm, buffer);
+        status
+            = hipsparseXcsrsort(handle, m, n, nnz, descr, csr_row_ptr, csr_col_ind, perm, buffer);
 
         if(m < 0 || n < 0 || nnz < 0)
         {
@@ -266,9 +266,9 @@ hipsparseStatus_t testing_csrsort(Arguments argus)
     // For testing, assemble a COO matrix and convert it to CSR first (on host)
 
     // Host structures
-    std::vector<int> hcsr_row_ptr;
-    std::vector<int> hcoo_row_ind;
-    std::vector<int> hcsr_col_ind;
+    std::vector<int>   hcsr_row_ptr;
+    std::vector<int>   hcoo_row_ind;
+    std::vector<int>   hcsr_col_ind;
     std::vector<float> hcsr_val;
 
     // Sample initial COO matrix on CPU
@@ -276,7 +276,8 @@ hipsparseStatus_t testing_csrsort(Arguments argus)
     if(binfile != "")
     {
         if(read_bin_matrix(
-               binfile.c_str(), m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base) != 0)
+               binfile.c_str(), m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base)
+           != 0)
         {
             fprintf(stderr, "Cannot open [read] %s\n", binfile.c_str());
             return HIPSPARSE_STATUS_INTERNAL_ERROR;
@@ -292,8 +293,8 @@ hipsparseStatus_t testing_csrsort(Arguments argus)
         if(filename != "")
         {
             if(read_mtx_matrix(
-                   filename.c_str(), m, n, nnz, hcoo_row_ind, hcsr_col_ind, hcsr_val, idx_base) !=
-               0)
+                   filename.c_str(), m, n, nnz, hcoo_row_ind, hcsr_col_ind, hcsr_val, idx_base)
+               != 0)
             {
                 fprintf(stderr, "Cannot open [read] %s\n", filename.c_str());
                 return HIPSPARSE_STATUS_INTERNAL_ERROR;
@@ -319,8 +320,8 @@ hipsparseStatus_t testing_csrsort(Arguments argus)
     }
 
     // Unsort CSR columns
-    std::vector<int> hperm(nnz);
-    std::vector<int> hcsr_col_ind_unsorted(nnz);
+    std::vector<int>   hperm(nnz);
+    std::vector<int>   hcsr_col_ind_unsorted(nnz);
     std::vector<float> hcsr_val_unsorted(nnz);
 
     hcsr_col_ind_unsorted = hcsr_col_ind;
@@ -336,7 +337,7 @@ hipsparseStatus_t testing_csrsort(Arguments argus)
         {
             int rng = row_begin + rand() % row_nnz;
 
-            int temp_col   = hcsr_col_ind_unsorted[j];
+            int   temp_col = hcsr_col_ind_unsorted[j];
             float temp_val = hcsr_val_unsorted[j];
 
             hcsr_col_ind_unsorted[j] = hcsr_col_ind_unsorted[rng];
@@ -348,16 +349,17 @@ hipsparseStatus_t testing_csrsort(Arguments argus)
     }
 
     // Allocate memory on the device
-    auto dcsr_row_ptr_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};
-    auto dcsr_col_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
-    auto dcsr_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(float) * nnz), device_free};
-    auto dcsr_val_sorted_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(float) * nnz), device_free};
-    auto dperm_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
+    auto dcsr_row_ptr_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * (m + 1)), device_free};
+    auto dcsr_col_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+    auto dcsr_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(float) * nnz), device_free};
+    auto dcsr_val_sorted_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(float) * nnz), device_free};
+    auto dperm_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
 
-    int* dcsr_row_ptr      = (int*)dcsr_row_ptr_managed.get();
-    int* dcsr_col_ind      = (int*)dcsr_col_ind_managed.get();
+    int*   dcsr_row_ptr    = (int*)dcsr_row_ptr_managed.get();
+    int*   dcsr_col_ind    = (int*)dcsr_col_ind_managed.get();
     float* dcsr_val        = (float*)dcsr_val_managed.get();
     float* dcsr_val_sorted = (float*)dcsr_val_sorted_managed.get();
 
@@ -387,8 +389,8 @@ hipsparseStatus_t testing_csrsort(Arguments argus)
             handle, m, n, nnz, dcsr_row_ptr, dcsr_col_ind, &buffer_size));
 
         // Allocate buffer on the device
-        auto dbuffer_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(char) * buffer_size), device_free};
+        auto dbuffer_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(char) * buffer_size), device_free};
 
         void* dbuffer = (void*)dbuffer_managed.get();
 
@@ -445,8 +447,8 @@ hipsparseStatus_t testing_csrsort(Arguments argus)
         hipsparseXcsrsort_bufferSizeExt(
             handle, m, n, nnz, dcsr_row_ptr, dcsr_col_ind, &buffer_size);
 
-        auto dbuffer_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(char) * buffer_size), device_free};
+        auto dbuffer_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(char) * buffer_size), device_free};
         void* dbuffer = (void*)dbuffer_managed.get();
 
         for(int iter = 0; iter < number_cold_calls; ++iter)

--- a/clients/include/testing_csrsv2.hpp
+++ b/clients/include/testing_csrsv2.hpp
@@ -25,16 +25,16 @@
 #ifndef TESTING_CSRSV2_HPP
 #define TESTING_CSRSV2_HPP
 
-#include "hipsparse_test_unique_ptr.hpp"
 #include "hipsparse.hpp"
-#include "utility.hpp"
+#include "hipsparse_test_unique_ptr.hpp"
 #include "unit.hpp"
+#include "utility.hpp"
 
-#include <string>
-#include <cmath>
-#include <limits>
 #include <algorithm>
+#include <cmath>
 #include <hipsparse.h>
+#include <limits>
+#include <string>
 
 using namespace hipsparse;
 using namespace hipsparse_test;
@@ -46,36 +46,36 @@ void testing_csrsv2_bad_arg(void)
     // do not test for bad args
     return;
 #endif
-    int m                         = 100;
-    int nnz                       = 100;
-    int safe_size                 = 100;
-    T h_alpha                     = 0.6;
-    hipsparseOperation_t transA   = HIPSPARSE_OPERATION_NON_TRANSPOSE;
-    hipsparseSolvePolicy_t policy = HIPSPARSE_SOLVE_POLICY_USE_LEVEL;
-    hipsparseStatus_t status;
+    int                    m         = 100;
+    int                    nnz       = 100;
+    int                    safe_size = 100;
+    T                      h_alpha   = 0.6;
+    hipsparseOperation_t   transA    = HIPSPARSE_OPERATION_NON_TRANSPOSE;
+    hipsparseSolvePolicy_t policy    = HIPSPARSE_SOLVE_POLICY_USE_LEVEL;
+    hipsparseStatus_t      status;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
     std::unique_ptr<descr_struct> unique_ptr_descr(new descr_struct);
-    hipsparseMatDescr_t descr = unique_ptr_descr->descr;
+    hipsparseMatDescr_t           descr = unique_ptr_descr->descr;
 
     std::unique_ptr<csrsv2_struct> unique_ptr_csrsv2_info(new csrsv2_struct);
-    csrsv2Info_t info = unique_ptr_csrsv2_info->info;
+    csrsv2Info_t                   info = unique_ptr_csrsv2_info->info;
 
-    auto dptr_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto dcol_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-    auto dx_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-    auto dy_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-    auto dbuffer_managed =
-        hipsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
+    auto dptr_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto dcol_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto dval_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_managed   = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dy_managed   = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dbuffer_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
 
-    int* dptr     = (int*)dptr_managed.get();
-    int* dcol     = (int*)dcol_managed.get();
-    T* dval       = (T*)dval_managed.get();
-    T* dx         = (T*)dx_managed.get();
-    T* dy         = (T*)dy_managed.get();
+    int*  dptr    = (int*)dptr_managed.get();
+    int*  dcol    = (int*)dcol_managed.get();
+    T*    dval    = (T*)dval_managed.get();
+    T*    dx      = (T*)dx_managed.get();
+    T*    dy      = (T*)dy_managed.get();
     void* dbuffer = (void*)dbuffer_managed.get();
 
     if(!dval || !dptr || !dcol || !dx || !dy || !dbuffer)
@@ -435,19 +435,19 @@ void testing_csrsv2_bad_arg(void)
 template <typename T>
 hipsparseStatus_t testing_csrsv2(Arguments argus)
 {
-    int safe_size                 = 100;
-    int m                         = argus.M;
-    int n                         = argus.M;
-    hipsparseIndexBase_t idx_base = argus.idx_base;
-    hipsparseOperation_t trans    = argus.transA;
-    hipsparseDiagType_t diag_type = argus.diag_type;
-    hipsparseFillMode_t fill_mode = argus.fill_mode;
-    hipsparseSolvePolicy_t policy = HIPSPARSE_SOLVE_POLICY_USE_LEVEL;
-    T h_alpha                     = argus.alpha;
-    std::string binfile           = "";
-    std::string filename          = "";
-    hipsparseStatus_t status;
-    size_t size;
+    int                    safe_size = 100;
+    int                    m         = argus.M;
+    int                    n         = argus.M;
+    hipsparseIndexBase_t   idx_base  = argus.idx_base;
+    hipsparseOperation_t   trans     = argus.transA;
+    hipsparseDiagType_t    diag_type = argus.diag_type;
+    hipsparseFillMode_t    fill_mode = argus.fill_mode;
+    hipsparseSolvePolicy_t policy    = HIPSPARSE_SOLVE_POLICY_USE_LEVEL;
+    T                      h_alpha   = argus.alpha;
+    std::string            binfile   = "";
+    std::string            filename  = "";
+    hipsparseStatus_t      status;
+    size_t                 size;
 
     // When in testing mode, M == N == -99 indicates that we are testing with a real
     // matrix from cise.ufl.edu
@@ -463,13 +463,13 @@ hipsparseStatus_t testing_csrsv2(Arguments argus)
     }
 
     std::unique_ptr<handle_struct> test_handle(new handle_struct);
-    hipsparseHandle_t handle = test_handle->handle;
+    hipsparseHandle_t              handle = test_handle->handle;
 
     std::unique_ptr<descr_struct> test_descr(new descr_struct);
-    hipsparseMatDescr_t descr = test_descr->descr;
+    hipsparseMatDescr_t           descr = test_descr->descr;
 
     std::unique_ptr<csrsv2_struct> unique_ptr_csrsv2_info(new csrsv2_struct);
-    csrsv2Info_t info = unique_ptr_csrsv2_info->info;
+    csrsv2Info_t                   info = unique_ptr_csrsv2_info->info;
 
     // Set matrix index base
     CHECK_HIPSPARSE_ERROR(hipsparseSetMatIndexBase(descr, idx_base));
@@ -495,21 +495,22 @@ hipsparseStatus_t testing_csrsv2(Arguments argus)
         // Do not test args in cusparse
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
-        auto dptr_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto dcol_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-        auto dx_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-        auto buffer_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
+        auto dptr_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto dcol_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto dval_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        auto dx_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        auto buffer_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
 
-        int* dptr    = (int*)dptr_managed.get();
-        int* dcol    = (int*)dcol_managed.get();
-        T* dval      = (T*)dval_managed.get();
-        T* dx        = (T*)dx_managed.get();
-        T* dy        = (T*)dy_managed.get();
+        int*  dptr   = (int*)dptr_managed.get();
+        int*  dcol   = (int*)dcol_managed.get();
+        T*    dval   = (T*)dval_managed.get();
+        T*    dx     = (T*)dx_managed.get();
+        T*    dy     = (T*)dy_managed.get();
         void* buffer = (void*)buffer_managed.get();
 
         if(!dval || !dptr || !dcol || !dx || !dy || !buffer)
@@ -573,14 +574,15 @@ hipsparseStatus_t testing_csrsv2(Arguments argus)
     // Host structures
     std::vector<int> hcsr_row_ptr;
     std::vector<int> hcsr_col_ind;
-    std::vector<T> hcsr_val;
+    std::vector<T>   hcsr_val;
 
     // Initial Data on CPU
     srand(12345ULL);
     if(binfile != "")
     {
         if(read_bin_matrix(
-               binfile.c_str(), m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base) != 0)
+               binfile.c_str(), m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base)
+           != 0)
         {
             fprintf(stderr, "Cannot open [read] %s\n", binfile.c_str());
             return HIPSPARSE_STATUS_INTERNAL_ERROR;
@@ -598,8 +600,8 @@ hipsparseStatus_t testing_csrsv2(Arguments argus)
         if(filename != "")
         {
             if(read_mtx_matrix(
-                   filename.c_str(), m, n, nnz, hcoo_row_ind, hcsr_col_ind, hcsr_val, idx_base) !=
-               0)
+                   filename.c_str(), m, n, nnz, hcoo_row_ind, hcsr_col_ind, hcsr_val, idx_base)
+               != 0)
             {
                 fprintf(stderr, "Cannot open [read] %s\n", filename.c_str());
                 return HIPSPARSE_STATUS_INTERNAL_ERROR;
@@ -632,22 +634,22 @@ hipsparseStatus_t testing_csrsv2(Arguments argus)
     hipsparseInit<T>(hx, 1, m);
 
     // Allocate memory on device
-    auto dptr_managed    = hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};
-    auto dcol_managed    = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
-    auto dval_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
-    auto dx_managed      = hipsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
-    auto dy_1_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * n), device_free};
-    auto dy_2_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * n), device_free};
-    auto d_alpha_managed = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
-    auto d_position_managed = hipsparse_unique_ptr{device_malloc(sizeof(int)), device_free};
+    auto dptr_managed    = hipsparse_unique_ptr {device_malloc(sizeof(int) * (m + 1)), device_free};
+    auto dcol_managed    = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+    auto dval_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+    auto dx_managed      = hipsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
+    auto dy_1_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * n), device_free};
+    auto dy_2_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * n), device_free};
+    auto d_alpha_managed = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+    auto d_position_managed = hipsparse_unique_ptr {device_malloc(sizeof(int)), device_free};
 
     int* dptr       = (int*)dptr_managed.get();
     int* dcol       = (int*)dcol_managed.get();
-    T* dval         = (T*)dval_managed.get();
-    T* dx           = (T*)dx_managed.get();
-    T* dy_1         = (T*)dy_1_managed.get();
-    T* dy_2         = (T*)dy_2_managed.get();
-    T* d_alpha      = (T*)d_alpha_managed.get();
+    T*   dval       = (T*)dval_managed.get();
+    T*   dx         = (T*)dx_managed.get();
+    T*   dy_1       = (T*)dy_1_managed.get();
+    T*   dy_2       = (T*)dy_2_managed.get();
+    T*   d_alpha    = (T*)d_alpha_managed.get();
     int* d_position = (int*)d_position_managed.get();
 
     if(!dval || !dptr || !dcol || !dx || !dy_1 || !dy_2 || !d_alpha || !d_position)
@@ -672,7 +674,7 @@ hipsparseStatus_t testing_csrsv2(Arguments argus)
         handle, trans, m, nnz, descr, dval, dptr, dcol, info, &size));
 
     // Allocate buffer on the device
-    auto dbuffer_managed = hipsparse_unique_ptr{device_malloc(sizeof(char) * size), device_free};
+    auto dbuffer_managed = hipsparse_unique_ptr {device_malloc(sizeof(char) * size), device_free};
 
     void* dbuffer = (void*)dbuffer_managed.get();
 
@@ -707,7 +709,7 @@ hipsparseStatus_t testing_csrsv2(Arguments argus)
                                                      policy,
                                                      dbuffer));
 
-        int hposition_1;
+        int               hposition_1;
         hipsparseStatus_t pivot_status_1;
         pivot_status_1 = hipsparseXcsrsv2_zeroPivot(handle, info, &hposition_1);
 

--- a/clients/include/testing_doti.hpp
+++ b/clients/include/testing_doti.hpp
@@ -25,10 +25,10 @@
 #ifndef TESTING_DOTI_HPP
 #define TESTING_DOTI_HPP
 
-#include "hipsparse_test_unique_ptr.hpp"
 #include "hipsparse.hpp"
-#include "utility.hpp"
+#include "hipsparse_test_unique_ptr.hpp"
 #include "unit.hpp"
+#include "utility.hpp"
 
 #include <hipsparse.h>
 
@@ -46,18 +46,19 @@ void testing_doti_bad_arg(void)
     int safe_size = 100;
 
     hipsparseIndexBase_t idx_base = HIPSPARSE_INDEX_BASE_ZERO;
-    hipsparseStatus_t status;
+    hipsparseStatus_t    status;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
-    auto dx_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-    auto dx_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto dy_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
-    T* dx_val   = (T*)dx_val_managed.get();
+    T*   dx_val = (T*)dx_val_managed.get();
     int* dx_ind = (int*)dx_ind_managed.get();
-    T* dy       = (T*)dy_managed.get();
+    T*   dy     = (T*)dy_managed.get();
 
     if(!dx_ind || !dx_val || !dy)
     {
@@ -111,14 +112,14 @@ void testing_doti_bad_arg(void)
 template <typename T>
 hipsparseStatus_t testing_doti(Arguments argus)
 {
-    int N                         = argus.N;
-    int nnz                       = argus.nnz;
-    int safe_size                 = 100;
-    hipsparseIndexBase_t idx_base = argus.idx_base;
-    hipsparseStatus_t status;
+    int                  N         = argus.N;
+    int                  nnz       = argus.nnz;
+    int                  safe_size = 100;
+    hipsparseIndexBase_t idx_base  = argus.idx_base;
+    hipsparseStatus_t    status;
 
     std::unique_ptr<handle_struct> test_handle(new handle_struct);
-    hipsparseHandle_t handle = test_handle->handle;
+    hipsparseHandle_t              handle = test_handle->handle;
 
     // Argument sanity check before allocating invalid memory
     if(nnz <= 0)
@@ -127,15 +128,15 @@ hipsparseStatus_t testing_doti(Arguments argus)
         // Do not test args in cusparse
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
-        auto dx_ind_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto dx_val_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dx_ind_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto dx_val_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
         int* dx_ind = (int*)dx_ind_managed.get();
-        T* dx_val   = (T*)dx_val_managed.get();
-        T* dy       = (T*)dy_managed.get();
+        T*   dx_val = (T*)dx_val_managed.get();
+        T*   dy     = (T*)dy_managed.get();
 
         if(!dx_ind || !dx_val || !dy)
         {
@@ -163,8 +164,8 @@ hipsparseStatus_t testing_doti(Arguments argus)
 
     // Host structures
     std::vector<int> hx_ind(nnz);
-    std::vector<T> hx_val(nnz);
-    std::vector<T> hy(N);
+    std::vector<T>   hx_val(nnz);
+    std::vector<T>   hy(N);
 
     T hresult_1;
     T hresult_2;
@@ -177,15 +178,15 @@ hipsparseStatus_t testing_doti(Arguments argus)
     hipsparseInit<T>(hy, 1, N);
 
     // allocate memory on device
-    auto dx_ind_managed    = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
-    auto dx_val_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
-    auto dy_managed        = hipsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
-    auto dresult_2_managed = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
+    auto dx_ind_managed    = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+    auto dx_val_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+    auto dy_managed        = hipsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
+    auto dresult_2_managed = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
 
-    int* dx_ind  = (int*)dx_ind_managed.get();
-    T* dx_val    = (T*)dx_val_managed.get();
-    T* dy        = (T*)dy_managed.get();
-    T* dresult_2 = (T*)dresult_2_managed.get();
+    int* dx_ind    = (int*)dx_ind_managed.get();
+    T*   dx_val    = (T*)dx_val_managed.get();
+    T*   dy        = (T*)dy_managed.get();
+    T*   dresult_2 = (T*)dresult_2_managed.get();
 
     if(!dx_ind || !dx_val || !dy || !dresult_2)
     {

--- a/clients/include/testing_gthr.hpp
+++ b/clients/include/testing_gthr.hpp
@@ -25,10 +25,10 @@
 #ifndef TESTING_GTHR_HPP
 #define TESTING_GTHR_HPP
 
-#include "hipsparse_test_unique_ptr.hpp"
 #include "hipsparse.hpp"
-#include "utility.hpp"
+#include "hipsparse_test_unique_ptr.hpp"
 #include "unit.hpp"
+#include "utility.hpp"
 
 #include <hipsparse.h>
 
@@ -46,18 +46,19 @@ void testing_gthr_bad_arg(void)
     int safe_size = 100;
 
     hipsparseIndexBase_t idx_base = HIPSPARSE_INDEX_BASE_ZERO;
-    hipsparseStatus_t status;
+    hipsparseStatus_t    status;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
-    auto dx_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-    auto dx_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto dy_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
-    T* dx_val   = (T*)dx_val_managed.get();
+    T*   dx_val = (T*)dx_val_managed.get();
     int* dx_ind = (int*)dx_ind_managed.get();
-    T* dy       = (T*)dy_managed.get();
+    T*   dy     = (T*)dy_managed.get();
 
     if(!dx_ind || !dx_val || !dy)
     {
@@ -98,14 +99,14 @@ void testing_gthr_bad_arg(void)
 template <typename T>
 hipsparseStatus_t testing_gthr(Arguments argus)
 {
-    int N                         = argus.N;
-    int nnz                       = argus.nnz;
-    int safe_size                 = 100;
-    hipsparseIndexBase_t idx_base = argus.idx_base;
-    hipsparseStatus_t status;
+    int                  N         = argus.N;
+    int                  nnz       = argus.nnz;
+    int                  safe_size = 100;
+    hipsparseIndexBase_t idx_base  = argus.idx_base;
+    hipsparseStatus_t    status;
 
     std::unique_ptr<handle_struct> test_handle(new handle_struct);
-    hipsparseHandle_t handle = test_handle->handle;
+    hipsparseHandle_t              handle = test_handle->handle;
 
     // Argument sanity check before allocating invalid memory
     if(nnz <= 0)
@@ -114,15 +115,15 @@ hipsparseStatus_t testing_gthr(Arguments argus)
         // Do not test args in cusparse
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
-        auto dx_ind_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto dx_val_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dx_ind_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto dx_val_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
         int* dx_ind = (int*)dx_ind_managed.get();
-        T* dx_val   = (T*)dx_val_managed.get();
-        T* dy       = (T*)dy_managed.get();
+        T*   dx_val = (T*)dx_val_managed.get();
+        T*   dy     = (T*)dy_managed.get();
 
         if(!dx_ind || !dx_val || !dy)
         {
@@ -148,9 +149,9 @@ hipsparseStatus_t testing_gthr(Arguments argus)
 
     // Host structures
     std::vector<int> hx_ind(nnz);
-    std::vector<T> hx_val(nnz);
-    std::vector<T> hx_val_gold(nnz);
-    std::vector<T> hy(N);
+    std::vector<T>   hx_val(nnz);
+    std::vector<T>   hx_val_gold(nnz);
+    std::vector<T>   hy(N);
 
     // Initial Data on CPU
     srand(12345ULL);
@@ -158,13 +159,13 @@ hipsparseStatus_t testing_gthr(Arguments argus)
     hipsparseInit<T>(hy, 1, N);
 
     // allocate memory on device
-    auto dx_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
-    auto dx_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
-    auto dy_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
+    auto dx_ind_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+    auto dx_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+    auto dy_managed     = hipsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
 
     int* dx_ind = (int*)dx_ind_managed.get();
-    T* dx_val   = (T*)dx_val_managed.get();
-    T* dy       = (T*)dy_managed.get();
+    T*   dx_val = (T*)dx_val_managed.get();
+    T*   dy     = (T*)dy_managed.get();
 
     if(!dx_ind || !dx_val || !dy)
     {

--- a/clients/include/testing_gthrz.hpp
+++ b/clients/include/testing_gthrz.hpp
@@ -25,10 +25,10 @@
 #ifndef TESTING_GTHRZ_HPP
 #define TESTING_GTHRZ_HPP
 
-#include "hipsparse_test_unique_ptr.hpp"
 #include "hipsparse.hpp"
-#include "utility.hpp"
+#include "hipsparse_test_unique_ptr.hpp"
 #include "unit.hpp"
+#include "utility.hpp"
 
 #include <hipsparse.h>
 
@@ -46,18 +46,19 @@ void testing_gthrz_bad_arg(void)
     int safe_size = 100;
 
     hipsparseIndexBase_t idx_base = HIPSPARSE_INDEX_BASE_ZERO;
-    hipsparseStatus_t status;
+    hipsparseStatus_t    status;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
-    auto dx_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-    auto dx_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto dy_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
-    T* dx_val   = (T*)dx_val_managed.get();
+    T*   dx_val = (T*)dx_val_managed.get();
     int* dx_ind = (int*)dx_ind_managed.get();
-    T* dy       = (T*)dy_managed.get();
+    T*   dy     = (T*)dy_managed.get();
 
     if(!dx_ind || !dx_val || !dy)
     {
@@ -98,14 +99,14 @@ void testing_gthrz_bad_arg(void)
 template <typename T>
 hipsparseStatus_t testing_gthrz(Arguments argus)
 {
-    int N                         = argus.N;
-    int nnz                       = argus.nnz;
-    int safe_size                 = 100;
-    hipsparseIndexBase_t idx_base = argus.idx_base;
-    hipsparseStatus_t status;
+    int                  N         = argus.N;
+    int                  nnz       = argus.nnz;
+    int                  safe_size = 100;
+    hipsparseIndexBase_t idx_base  = argus.idx_base;
+    hipsparseStatus_t    status;
 
     std::unique_ptr<handle_struct> test_handle(new handle_struct);
-    hipsparseHandle_t handle = test_handle->handle;
+    hipsparseHandle_t              handle = test_handle->handle;
 
     // Argument sanity check before allocating invalid memory
     if(nnz <= 0)
@@ -114,15 +115,15 @@ hipsparseStatus_t testing_gthrz(Arguments argus)
         // Do not test args in cusparse
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
-        auto dx_ind_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto dx_val_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dx_ind_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto dx_val_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
         int* dx_ind = (int*)dx_ind_managed.get();
-        T* dx_val   = (T*)dx_val_managed.get();
-        T* dy       = (T*)dy_managed.get();
+        T*   dx_val = (T*)dx_val_managed.get();
+        T*   dy     = (T*)dy_managed.get();
 
         if(!dx_ind || !dx_val || !dy)
         {
@@ -148,10 +149,10 @@ hipsparseStatus_t testing_gthrz(Arguments argus)
 
     // Host structures
     std::vector<int> hx_ind(nnz);
-    std::vector<T> hx_val(nnz);
-    std::vector<T> hx_val_gold(nnz);
-    std::vector<T> hy(N);
-    std::vector<T> hy_gold(N);
+    std::vector<T>   hx_val(nnz);
+    std::vector<T>   hx_val_gold(nnz);
+    std::vector<T>   hy(N);
+    std::vector<T>   hy_gold(N);
 
     // Initial Data on CPU
     srand(12345ULL);
@@ -161,13 +162,13 @@ hipsparseStatus_t testing_gthrz(Arguments argus)
     hy_gold = hy;
 
     // allocate memory on device
-    auto dx_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
-    auto dx_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
-    auto dy_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
+    auto dx_ind_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+    auto dx_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+    auto dy_managed     = hipsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
 
     int* dx_ind = (int*)dx_ind_managed.get();
-    T* dx_val   = (T*)dx_val_managed.get();
-    T* dy       = (T*)dy_managed.get();
+    T*   dx_val = (T*)dx_val_managed.get();
+    T*   dy     = (T*)dy_managed.get();
 
     if(!dx_ind || !dx_val || !dy)
     {

--- a/clients/include/testing_hybmv.hpp
+++ b/clients/include/testing_hybmv.hpp
@@ -25,13 +25,13 @@
 #ifndef TESTING_HYBMV_HPP
 #define TESTING_HYBMV_HPP
 
-#include "hipsparse_test_unique_ptr.hpp"
 #include "hipsparse.hpp"
-#include "utility.hpp"
+#include "hipsparse_test_unique_ptr.hpp"
 #include "unit.hpp"
+#include "utility.hpp"
 
-#include <string>
 #include <hipsparse.h>
+#include <string>
 
 using namespace hipsparse;
 using namespace hipsparse_test;
@@ -42,39 +42,39 @@ using namespace hipsparse_test;
 
 struct testhyb
 {
-    int m;
-    int n;
+    int                     m;
+    int                     n;
     hipsparseHybPartition_t partition;
-    int ell_nnz;
-    int ell_width;
-    int* ell_col_ind;
-    void* ell_val;
-    int coo_nnz;
-    int* coo_row_ind;
-    int* coo_col_ind;
-    void* coo_val;
+    int                     ell_nnz;
+    int                     ell_width;
+    int*                    ell_col_ind;
+    void*                   ell_val;
+    int                     coo_nnz;
+    int*                    coo_row_ind;
+    int*                    coo_col_ind;
+    void*                   coo_val;
 };
 
 template <typename T>
 void testing_hybmv_bad_arg(void)
 {
-    int safe_size               = 100;
-    T alpha                     = 0.6;
-    T beta                      = 0.2;
-    hipsparseOperation_t transA = HIPSPARSE_OPERATION_NON_TRANSPOSE;
-    hipsparseStatus_t status;
+    int                  safe_size = 100;
+    T                    alpha     = 0.6;
+    T                    beta      = 0.2;
+    hipsparseOperation_t transA    = HIPSPARSE_OPERATION_NON_TRANSPOSE;
+    hipsparseStatus_t    status;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
     std::unique_ptr<descr_struct> unique_ptr_descr(new descr_struct);
-    hipsparseMatDescr_t descr = unique_ptr_descr->descr;
+    hipsparseMatDescr_t           descr = unique_ptr_descr->descr;
 
     std::unique_ptr<hyb_struct> unique_ptr_hyb(new hyb_struct);
-    hipsparseHybMat_t hyb = unique_ptr_hyb->hyb;
+    hipsparseHybMat_t           hyb = unique_ptr_hyb->hyb;
 
-    auto dx_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-    auto dy_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
     T* dx = (T*)dx_managed.get();
     T* dy = (T*)dy_managed.get();
@@ -139,18 +139,18 @@ void testing_hybmv_bad_arg(void)
 template <typename T>
 hipsparseStatus_t testing_hybmv(Arguments argus)
 {
-    int safe_size                 = 100;
-    int m                         = argus.M;
-    int n                         = argus.N;
-    T h_alpha                     = argus.alpha;
-    T h_beta                      = argus.beta;
-    hipsparseOperation_t transA   = argus.transA;
-    hipsparseIndexBase_t idx_base = argus.idx_base;
-    hipsparseHybPartition_t part  = argus.part;
-    int user_ell_width            = argus.ell_width;
-    std::string binfile           = "";
-    std::string filename          = "";
-    hipsparseStatus_t status;
+    int                     safe_size      = 100;
+    int                     m              = argus.M;
+    int                     n              = argus.N;
+    T                       h_alpha        = argus.alpha;
+    T                       h_beta         = argus.beta;
+    hipsparseOperation_t    transA         = argus.transA;
+    hipsparseIndexBase_t    idx_base       = argus.idx_base;
+    hipsparseHybPartition_t part           = argus.part;
+    int                     user_ell_width = argus.ell_width;
+    std::string             binfile        = "";
+    std::string             filename       = "";
+    hipsparseStatus_t       status;
 
     // When in testing mode, M == N == -99 indicates that we are testing with a real
     // matrix from cise.ufl.edu
@@ -166,16 +166,16 @@ hipsparseStatus_t testing_hybmv(Arguments argus)
     }
 
     std::unique_ptr<handle_struct> test_handle(new handle_struct);
-    hipsparseHandle_t handle = test_handle->handle;
+    hipsparseHandle_t              handle = test_handle->handle;
 
     std::unique_ptr<descr_struct> test_descr(new descr_struct);
-    hipsparseMatDescr_t descr = test_descr->descr;
+    hipsparseMatDescr_t           descr = test_descr->descr;
 
     // Set matrix index base
     CHECK_HIPSPARSE_ERROR(hipsparseSetMatIndexBase(descr, idx_base));
 
     std::unique_ptr<hyb_struct> test_hyb(new hyb_struct);
-    hipsparseHybMat_t hyb = test_hyb->hyb;
+    hipsparseHybMat_t           hyb = test_hyb->hyb;
 
     // Determine number of non-zero elements
     double scale = 0.02;
@@ -188,19 +188,20 @@ hipsparseStatus_t testing_hybmv(Arguments argus)
     // Argument sanity check before allocating invalid memory
     if(m <= 0 || n <= 0 || nnz <= 0)
     {
-        auto dptr_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto dcol_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-        auto dx_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dptr_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto dcol_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto dval_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        auto dx_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
         int* dptr = (int*)dptr_managed.get();
         int* dcol = (int*)dcol_managed.get();
-        T* dval   = (T*)dval_managed.get();
-        T* dx     = (T*)dx_managed.get();
-        T* dy     = (T*)dy_managed.get();
+        T*   dval = (T*)dval_managed.get();
+        T*   dx   = (T*)dx_managed.get();
+        T*   dy   = (T*)dy_managed.get();
 
         if(!dval || !dptr || !dcol || !dx || !dy)
         {
@@ -210,8 +211,8 @@ hipsparseStatus_t testing_hybmv(Arguments argus)
         }
 
         CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_HOST));
-        status =
-            hipsparseXcsr2hyb(handle, m, n, descr, dval, dptr, dcol, hyb, user_ell_width, part);
+        status
+            = hipsparseXcsr2hyb(handle, m, n, descr, dval, dptr, dcol, hyb, user_ell_width, part);
 
         if(m < 0 || n < 0 || nnz < 0)
         {
@@ -230,7 +231,7 @@ hipsparseStatus_t testing_hybmv(Arguments argus)
     std::vector<int> hcsr_row_ptr;
     std::vector<int> hcoo_row_ind;
     std::vector<int> hcol_ind;
-    std::vector<T> hval;
+    std::vector<T>   hval;
 
     // Initial Data on CPU
     srand(12345ULL);
@@ -251,8 +252,8 @@ hipsparseStatus_t testing_hybmv(Arguments argus)
     {
         if(filename != "")
         {
-            if(read_mtx_matrix(
-                   filename.c_str(), m, n, nnz, hcoo_row_ind, hcol_ind, hval, idx_base) != 0)
+            if(read_mtx_matrix(filename.c_str(), m, n, nnz, hcoo_row_ind, hcol_ind, hval, idx_base)
+               != 0)
             {
                 fprintf(stderr, "Cannot open [read] %s\n", filename.c_str());
                 return HIPSPARSE_STATUS_INTERNAL_ERROR;
@@ -290,23 +291,23 @@ hipsparseStatus_t testing_hybmv(Arguments argus)
     hy_gold = hy_1;
 
     // allocate memory on device
-    auto dptr_managed    = hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};
-    auto dcol_managed    = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
-    auto dval_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
-    auto dx_managed      = hipsparse_unique_ptr{device_malloc(sizeof(T) * n), device_free};
-    auto dy_1_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
-    auto dy_2_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
-    auto d_alpha_managed = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
-    auto d_beta_managed  = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
+    auto dptr_managed    = hipsparse_unique_ptr {device_malloc(sizeof(int) * (m + 1)), device_free};
+    auto dcol_managed    = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+    auto dval_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+    auto dx_managed      = hipsparse_unique_ptr {device_malloc(sizeof(T) * n), device_free};
+    auto dy_1_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
+    auto dy_2_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
+    auto d_alpha_managed = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+    auto d_beta_managed  = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
 
-    int* dptr  = (int*)dptr_managed.get();
-    int* dcol  = (int*)dcol_managed.get();
-    T* dval    = (T*)dval_managed.get();
-    T* dx      = (T*)dx_managed.get();
-    T* dy_1    = (T*)dy_1_managed.get();
-    T* dy_2    = (T*)dy_2_managed.get();
-    T* d_alpha = (T*)d_alpha_managed.get();
-    T* d_beta  = (T*)d_beta_managed.get();
+    int* dptr    = (int*)dptr_managed.get();
+    int* dcol    = (int*)dcol_managed.get();
+    T*   dval    = (T*)dval_managed.get();
+    T*   dx      = (T*)dx_managed.get();
+    T*   dy_1    = (T*)dy_1_managed.get();
+    T*   dy_2    = (T*)dy_2_managed.get();
+    T*   d_alpha = (T*)d_alpha_managed.get();
+    T*   d_beta  = (T*)d_beta_managed.get();
 
     if(!dval || !dptr || !dcol || !dx || !dy_1 || !dy_2 || !d_alpha || !d_beta)
     {
@@ -364,10 +365,10 @@ hipsparseStatus_t testing_hybmv(Arguments argus)
         int coo_nnz = dhyb->coo_nnz;
 
         std::vector<int> hell_col(ell_nnz);
-        std::vector<T> hell_val(ell_nnz);
+        std::vector<T>   hell_val(ell_nnz);
         std::vector<int> hcoo_row(coo_nnz);
         std::vector<int> hcoo_col(coo_nnz);
-        std::vector<T> hcoo_val(coo_nnz);
+        std::vector<T>   hcoo_val(coo_nnz);
 
         if(ell_nnz > 0)
         {

--- a/clients/include/testing_identity.hpp
+++ b/clients/include/testing_identity.hpp
@@ -25,13 +25,13 @@
 #ifndef TESTING_IDENTITY_HPP
 #define TESTING_IDENTITY_HPP
 
-#include "hipsparse_test_unique_ptr.hpp"
 #include "hipsparse.hpp"
-#include "utility.hpp"
+#include "hipsparse_test_unique_ptr.hpp"
 #include "unit.hpp"
+#include "utility.hpp"
 
-#include <hipsparse.h>
 #include <algorithm>
+#include <hipsparse.h>
 
 using namespace hipsparse;
 using namespace hipsparse_test;
@@ -42,14 +42,14 @@ void testing_identity_bad_arg(void)
     // do not test for bad args
     return;
 #endif
-    int n         = 100;
-    int safe_size = 100;
+    int               n         = 100;
+    int               safe_size = 100;
     hipsparseStatus_t status;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
-    auto p_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto p_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
 
     int* p = (int*)p_managed.get();
 
@@ -78,12 +78,12 @@ void testing_identity_bad_arg(void)
 
 hipsparseStatus_t testing_identity(Arguments argus)
 {
-    int n         = argus.N;
-    int safe_size = 100;
+    int               n         = argus.N;
+    int               safe_size = 100;
     hipsparseStatus_t status;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
     // Argument sanity check before allocating invalid memory
     if(n <= 0)
@@ -92,7 +92,7 @@ hipsparseStatus_t testing_identity(Arguments argus)
         // Do not test args in cusparse
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
-        auto p_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+        auto p_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
 
         int* p = (int*)p_managed.get();
 
@@ -127,7 +127,7 @@ hipsparseStatus_t testing_identity(Arguments argus)
     }
 
     // Allocate memory on the device
-    auto dp_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * n), device_free};
+    auto dp_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * n), device_free};
 
     int* dp = (int*)dp_managed.get();
 

--- a/clients/include/testing_roti.hpp
+++ b/clients/include/testing_roti.hpp
@@ -25,10 +25,10 @@
 #ifndef TESTING_ROTI_HPP
 #define TESTING_ROTI_HPP
 
-#include "hipsparse_test_unique_ptr.hpp"
 #include "hipsparse.hpp"
-#include "utility.hpp"
+#include "hipsparse_test_unique_ptr.hpp"
 #include "unit.hpp"
+#include "utility.hpp"
 
 #include <hipsparse.h>
 
@@ -44,22 +44,23 @@ void testing_roti_bad_arg(void)
 #endif
     int nnz       = 100;
     int safe_size = 100;
-    T c           = 3.7;
-    T s           = 1.2;
+    T   c         = 3.7;
+    T   s         = 1.2;
 
     hipsparseIndexBase_t idx_base = HIPSPARSE_INDEX_BASE_ZERO;
-    hipsparseStatus_t status;
+    hipsparseStatus_t    status;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
-    auto dx_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-    auto dx_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto dy_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
-    T* dx_val   = (T*)dx_val_managed.get();
+    T*   dx_val = (T*)dx_val_managed.get();
     int* dx_ind = (int*)dx_ind_managed.get();
-    T* dy       = (T*)dy_managed.get();
+    T*   dy     = (T*)dy_managed.get();
 
     if(!dx_ind || !dx_val || !dy)
     {
@@ -114,16 +115,16 @@ void testing_roti_bad_arg(void)
 template <typename T>
 hipsparseStatus_t testing_roti(Arguments argus)
 {
-    int N                         = argus.N;
-    int nnz                       = argus.nnz;
-    T c                           = argus.alpha;
-    T s                           = argus.beta;
-    int safe_size                 = 100;
-    hipsparseIndexBase_t idx_base = argus.idx_base;
-    hipsparseStatus_t status;
+    int                  N         = argus.N;
+    int                  nnz       = argus.nnz;
+    T                    c         = argus.alpha;
+    T                    s         = argus.beta;
+    int                  safe_size = 100;
+    hipsparseIndexBase_t idx_base  = argus.idx_base;
+    hipsparseStatus_t    status;
 
     std::unique_ptr<handle_struct> test_handle(new handle_struct);
-    hipsparseHandle_t handle = test_handle->handle;
+    hipsparseHandle_t              handle = test_handle->handle;
 
     // Argument sanity check before allocating invalid memory
     if(nnz <= 0)
@@ -132,15 +133,15 @@ hipsparseStatus_t testing_roti(Arguments argus)
         // Do not test args in cusparse
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
-        auto dx_ind_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto dx_val_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dx_ind_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto dx_val_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
         int* dx_ind = (int*)dx_ind_managed.get();
-        T* dx_val   = (T*)dx_val_managed.get();
-        T* dy       = (T*)dy_managed.get();
+        T*   dx_val = (T*)dx_val_managed.get();
+        T*   dy     = (T*)dy_managed.get();
 
         if(!dx_ind || !dx_val || !dy)
         {
@@ -166,12 +167,12 @@ hipsparseStatus_t testing_roti(Arguments argus)
 
     // Host structures
     std::vector<int> hx_ind(nnz);
-    std::vector<T> hx_val_1(nnz);
-    std::vector<T> hx_val_2(nnz);
-    std::vector<T> hx_val_gold(nnz);
-    std::vector<T> hy_1(N);
-    std::vector<T> hy_2(N);
-    std::vector<T> hy_gold(N);
+    std::vector<T>   hx_val_1(nnz);
+    std::vector<T>   hx_val_2(nnz);
+    std::vector<T>   hx_val_gold(nnz);
+    std::vector<T>   hy_1(N);
+    std::vector<T>   hy_2(N);
+    std::vector<T>   hy_gold(N);
 
     // Initial Data on CPU
     srand(12345ULL);
@@ -185,21 +186,21 @@ hipsparseStatus_t testing_roti(Arguments argus)
     hy_gold     = hy_1;
 
     // allocate memory on device
-    auto dx_ind_managed   = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
-    auto dx_val_1_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
-    auto dx_val_2_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
-    auto dy_1_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
-    auto dy_2_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
-    auto dc_managed       = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
-    auto ds_managed       = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
+    auto dx_ind_managed   = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+    auto dx_val_1_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+    auto dx_val_2_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+    auto dy_1_managed     = hipsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
+    auto dy_2_managed     = hipsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
+    auto dc_managed       = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+    auto ds_managed       = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
 
-    int* dx_ind = (int*)dx_ind_managed.get();
-    T* dx_val_1 = (T*)dx_val_1_managed.get();
-    T* dx_val_2 = (T*)dx_val_2_managed.get();
-    T* dy_1     = (T*)dy_1_managed.get();
-    T* dy_2     = (T*)dy_2_managed.get();
-    T* dc       = (T*)dc_managed.get();
-    T* ds       = (T*)ds_managed.get();
+    int* dx_ind   = (int*)dx_ind_managed.get();
+    T*   dx_val_1 = (T*)dx_val_1_managed.get();
+    T*   dx_val_2 = (T*)dx_val_2_managed.get();
+    T*   dy_1     = (T*)dy_1_managed.get();
+    T*   dy_2     = (T*)dy_2_managed.get();
+    T*   dc       = (T*)dc_managed.get();
+    T*   ds       = (T*)ds_managed.get();
 
     if(!dx_ind || !dx_val_1 || !dx_val_2 || !dy_1 || !dy_2 || !dc || !ds)
     {

--- a/clients/include/testing_sctr.hpp
+++ b/clients/include/testing_sctr.hpp
@@ -25,10 +25,10 @@
 #ifndef TESTING_SCTR_HPP
 #define TESTING_SCTR_HPP
 
-#include "hipsparse_test_unique_ptr.hpp"
 #include "hipsparse.hpp"
-#include "utility.hpp"
+#include "hipsparse_test_unique_ptr.hpp"
 #include "unit.hpp"
+#include "utility.hpp"
 
 #include <hipsparse.h>
 
@@ -46,18 +46,19 @@ void testing_sctr_bad_arg(void)
     int safe_size = 100;
 
     hipsparseIndexBase_t idx_base = HIPSPARSE_INDEX_BASE_ZERO;
-    hipsparseStatus_t status;
+    hipsparseStatus_t    status;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
-    hipsparseHandle_t handle = unique_ptr_handle->handle;
+    hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
-    auto dx_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-    auto dx_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-    auto dy_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_ind_managed
+        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
-    T* dx_val   = (T*)dx_val_managed.get();
+    T*   dx_val = (T*)dx_val_managed.get();
     int* dx_ind = (int*)dx_ind_managed.get();
-    T* dy       = (T*)dy_managed.get();
+    T*   dy     = (T*)dy_managed.get();
 
     if(!dx_ind || !dx_val || !dy)
     {
@@ -98,14 +99,14 @@ void testing_sctr_bad_arg(void)
 template <typename T>
 hipsparseStatus_t testing_sctr(Arguments argus)
 {
-    int N                         = argus.N;
-    int nnz                       = argus.nnz;
-    int safe_size                 = 100;
-    hipsparseIndexBase_t idx_base = argus.idx_base;
-    hipsparseStatus_t status;
+    int                  N         = argus.N;
+    int                  nnz       = argus.nnz;
+    int                  safe_size = 100;
+    hipsparseIndexBase_t idx_base  = argus.idx_base;
+    hipsparseStatus_t    status;
 
     std::unique_ptr<handle_struct> test_handle(new handle_struct);
-    hipsparseHandle_t handle = test_handle->handle;
+    hipsparseHandle_t              handle = test_handle->handle;
 
     // Argument sanity check before allocating invalid memory
     if(nnz <= 0)
@@ -114,15 +115,15 @@ hipsparseStatus_t testing_sctr(Arguments argus)
         // Do not test args in cusparse
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
-        auto dx_ind_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
-        auto dx_val_managed =
-            hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dx_ind_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto dx_val_managed
+            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
 
         int* dx_ind = (int*)dx_ind_managed.get();
-        T* dx_val   = (T*)dx_val_managed.get();
-        T* dy       = (T*)dy_managed.get();
+        T*   dx_val = (T*)dx_val_managed.get();
+        T*   dy     = (T*)dy_managed.get();
 
         if(!dx_ind || !dx_val || !dy)
         {
@@ -148,9 +149,9 @@ hipsparseStatus_t testing_sctr(Arguments argus)
 
     // Host structures
     std::vector<int> hx_ind(nnz);
-    std::vector<T> hx_val(nnz);
-    std::vector<T> hy(N);
-    std::vector<T> hy_gold(N);
+    std::vector<T>   hx_val(nnz);
+    std::vector<T>   hy(N);
+    std::vector<T>   hy_gold(N);
 
     // Initial Data on CPU
     srand(12345ULL);
@@ -161,13 +162,13 @@ hipsparseStatus_t testing_sctr(Arguments argus)
     hy_gold = hy;
 
     // allocate memory on device
-    auto dx_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
-    auto dx_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
-    auto dy_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
+    auto dx_ind_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+    auto dx_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+    auto dy_managed     = hipsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
 
     int* dx_ind = (int*)dx_ind_managed.get();
-    T* dx_val   = (T*)dx_val_managed.get();
-    T* dy       = (T*)dy_managed.get();
+    T*   dx_val = (T*)dx_val_managed.get();
+    T*   dy     = (T*)dy_managed.get();
 
     if(!dx_ind || !dx_val || !dy)
     {

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -25,15 +25,15 @@
 #ifndef TESTING_UTILITY_HPP
 #define TESTING_UTILITY_HPP
 
-#include <stdlib.h>
-#include <stdio.h>
+#include "hipsparse.h"
+#include <algorithm>
+#include <hip/hip_runtime_api.h>
 #include <math.h>
+#include <sstream>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string>
 #include <vector>
-#include <algorithm>
-#include <sstream>
-#include "hipsparse.h"
-#include <hip/hip_runtime_api.h>
 
 /*!\file
  * \brief provide data initialization and timing utilities.
@@ -113,7 +113,7 @@ template <typename I>
 void hipsparseInitIndex(I* x, int nnz, int start, int end)
 {
     std::vector<bool> check(end - start, false);
-    int num = 0;
+    int               num = 0;
     while(num < nnz)
     {
         int val = start + rand() % (end - start);
@@ -160,10 +160,10 @@ void hipsparseInitCSR(
 /* ============================================================================================ */
 /*! \brief  Generate 2D laplacian on unit square in CSR format */
 template <typename T>
-int gen_2d_laplacian(int ndim,
-                     std::vector<int>& rowptr,
-                     std::vector<int>& col,
-                     std::vector<T>& val,
+int gen_2d_laplacian(int                  ndim,
+                     std::vector<int>&    rowptr,
+                     std::vector<int>&    col,
+                     std::vector<T>&      val,
                      hipsparseIndexBase_t idx_base)
 {
     if(ndim == 0)
@@ -229,12 +229,12 @@ int gen_2d_laplacian(int ndim,
 /* ============================================================================================ */
 /*! \brief  Generate a random sparse matrix in COO format */
 template <typename T>
-void gen_matrix_coo(int m,
-                    int n,
-                    int nnz,
-                    std::vector<int>& row_ind,
-                    std::vector<int>& col_ind,
-                    std::vector<T>& val,
+void gen_matrix_coo(int                  m,
+                    int                  n,
+                    int                  nnz,
+                    std::vector<int>&    row_ind,
+                    std::vector<int>&    col_ind,
+                    std::vector<T>&      val,
                     hipsparseIndexBase_t idx_base)
 {
     if((int)row_ind.size() != nnz)
@@ -280,8 +280,8 @@ void gen_matrix_coo(int m,
         while(idx < i)
         {
             // Normal distribution around the diagonal
-            int rng = (i - begin) * sqrt(-2.0 * log((double)rand() / RAND_MAX)) *
-                      cos(2.0 * M_PI * (double)rand() / RAND_MAX);
+            int rng = (i - begin) * sqrt(-2.0 * log((double)rand() / RAND_MAX))
+                      * cos(2.0 * M_PI * (double)rand() / RAND_MAX);
 
             if(m <= n)
             {
@@ -333,13 +333,13 @@ void gen_matrix_coo(int m,
 /* ============================================================================================ */
 /*! \brief  Read matrix from mtx file in COO format */
 template <typename T>
-int read_mtx_matrix(const char* filename,
-                    int& nrow,
-                    int& ncol,
-                    int& nnz,
-                    std::vector<int>& row,
-                    std::vector<int>& col,
-                    std::vector<T>& val,
+int read_mtx_matrix(const char*          filename,
+                    int&                 nrow,
+                    int&                 ncol,
+                    int&                 nnz,
+                    std::vector<int>&    row,
+                    std::vector<int>&    col,
+                    std::vector<T>&      val,
                     hipsparseIndexBase_t idx_base)
 {
     printf("Reading matrix %s...", filename);
@@ -372,13 +372,13 @@ int read_mtx_matrix(const char* filename,
     }
 
     // Convert to lower case
-    for(char *p = array; *p != '\0'; *p = tolower(*p), p++)
+    for(char* p = array; *p != '\0'; *p = tolower(*p), p++)
         ;
-    for(char *p = coord; *p != '\0'; *p = tolower(*p), p++)
+    for(char* p = coord; *p != '\0'; *p = tolower(*p), p++)
         ;
-    for(char *p = data; *p != '\0'; *p = tolower(*p), p++)
+    for(char* p = data; *p != '\0'; *p = tolower(*p), p++)
         ;
-    for(char *p = type; *p != '\0'; *p = tolower(*p), p++)
+    for(char* p = type; *p != '\0'; *p = tolower(*p), p++)
         ;
 
     // Check banner
@@ -431,7 +431,7 @@ int read_mtx_matrix(const char* filename,
 
     std::vector<int> unsorted_row(nnz);
     std::vector<int> unsorted_col(nnz);
-    std::vector<T> unsorted_val(nnz);
+    std::vector<T>   unsorted_val(nnz);
 
     // Read entries
     int idx = 0;
@@ -444,7 +444,7 @@ int read_mtx_matrix(const char* filename,
 
         int irow;
         int icol;
-        T ival;
+        T   ival;
 
         std::istringstream ss(line);
 
@@ -527,13 +527,13 @@ int read_mtx_matrix(const char* filename,
 /* ============================================================================================ */
 /*! \brief  Read matrix from binary file in CSR format */
 template <typename T>
-int read_bin_matrix(const char* filename,
-                    int& nrow,
-                    int& ncol,
-                    int& nnz,
-                    std::vector<int>& ptr,
-                    std::vector<int>& col,
-                    std::vector<T>& val,
+int read_bin_matrix(const char*          filename,
+                    int&                 nrow,
+                    int&                 ncol,
+                    int&                 nnz,
+                    std::vector<int>&    ptr,
+                    std::vector<int>&    col,
+                    std::vector<T>&      val,
                     hipsparseIndexBase_t idx_base)
 {
     printf("Reading matrix %s...", filename);
@@ -679,18 +679,18 @@ int csrilu0(int m, const int* ptr, const int* col, T* val, hipsparseIndexBase_t 
 /* ============================================================================================ */
 /*! \brief  Sparse triangular lower solve using CSR storage format. */
 template <typename T>
-int lsolve(int m,
-           const int* ptr,
-           const int* col,
-           const T* val,
-           T alpha,
-           const T* x,
-           T* y,
+int lsolve(int                  m,
+           const int*           ptr,
+           const int*           col,
+           const T*             val,
+           T                    alpha,
+           const T*             x,
+           T*                   y,
            hipsparseIndexBase_t idx_base,
-           hipsparseDiagType_t diag_type,
-           unsigned int wf_size)
+           hipsparseDiagType_t  diag_type,
+           unsigned int         wf_size)
 {
-    int pivot = std::numeric_limits<int>::max();
+    int            pivot = std::numeric_limits<int>::max();
     std::vector<T> temp(wf_size);
 
     for(int i = 0; i < m; ++i)
@@ -717,7 +717,7 @@ int lsolve(int m,
                 }
 
                 int col_j = col[j] - idx_base;
-                T val_j   = val[j];
+                T   val_j = val[j];
 
                 if(col_j < i)
                 {
@@ -784,18 +784,18 @@ int lsolve(int m,
 /* ============================================================================================ */
 /*! \brief  Sparse triangular upper solve using CSR storage format. */
 template <typename T>
-int usolve(int m,
-           const int* ptr,
-           const int* col,
-           const T* val,
-           T alpha,
-           const T* x,
-           T* y,
+int usolve(int                  m,
+           const int*           ptr,
+           const int*           col,
+           const T*             val,
+           T                    alpha,
+           const T*             x,
+           T*                   y,
            hipsparseIndexBase_t idx_base,
-           hipsparseDiagType_t diag_type,
-           unsigned int wf_size)
+           hipsparseDiagType_t  diag_type,
+           unsigned int         wf_size)
 {
-    int pivot = std::numeric_limits<int>::max();
+    int            pivot = std::numeric_limits<int>::max();
     std::vector<T> temp(wf_size);
 
     for(int i = m - 1; i >= 0; --i)
@@ -822,7 +822,7 @@ int usolve(int m,
                 }
 
                 int col_j = col[j] - idx_base;
-                T val_j   = val[j];
+                T   val_j = val[j];
 
                 if(col_j < i)
                 {
@@ -924,7 +924,7 @@ double get_time_us_sync(hipStream_t stream);
 
 class Arguments
 {
-    public:
+public:
     int M   = 128;
     int N   = 128;
     int K   = 128;
@@ -936,14 +936,14 @@ class Arguments
     double alpha = 1.0;
     double beta  = 0.0;
 
-    hipsparseOperation_t transA    = HIPSPARSE_OPERATION_NON_TRANSPOSE;
-    hipsparseOperation_t transB    = HIPSPARSE_OPERATION_NON_TRANSPOSE;
-    hipsparseIndexBase_t idx_base  = HIPSPARSE_INDEX_BASE_ZERO;
-    hipsparseIndexBase_t idx_base2 = HIPSPARSE_INDEX_BASE_ZERO;
-    hipsparseAction_t action       = HIPSPARSE_ACTION_NUMERIC;
-    hipsparseHybPartition_t part   = HIPSPARSE_HYB_PARTITION_AUTO;
-    hipsparseDiagType_t diag_type  = HIPSPARSE_DIAG_TYPE_NON_UNIT;
-    hipsparseFillMode_t fill_mode  = HIPSPARSE_FILL_MODE_LOWER;
+    hipsparseOperation_t    transA    = HIPSPARSE_OPERATION_NON_TRANSPOSE;
+    hipsparseOperation_t    transB    = HIPSPARSE_OPERATION_NON_TRANSPOSE;
+    hipsparseIndexBase_t    idx_base  = HIPSPARSE_INDEX_BASE_ZERO;
+    hipsparseIndexBase_t    idx_base2 = HIPSPARSE_INDEX_BASE_ZERO;
+    hipsparseAction_t       action    = HIPSPARSE_ACTION_NUMERIC;
+    hipsparseHybPartition_t part      = HIPSPARSE_HYB_PARTITION_AUTO;
+    hipsparseDiagType_t     diag_type = HIPSPARSE_DIAG_TYPE_NON_UNIT;
+    hipsparseFillMode_t     fill_mode = HIPSPARSE_FILL_MODE_LOWER;
 
     int norm_check = 0;
     int unit_check = 1;

--- a/clients/samples/example_csrmv.cpp
+++ b/clients/samples/example_csrmv.cpp
@@ -23,11 +23,11 @@
 
 #include "utility.hpp"
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <vector>
-#include <hipsparse.h>
 #include <hip/hip_runtime_api.h>
+#include <hipsparse.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
 
 int main(int argc, char* argv[])
 {
@@ -56,19 +56,19 @@ int main(int argc, char* argv[])
     hipsparseCreate(&handle);
 
     hipDeviceProp_t devProp;
-    int device_id = 0;
+    int             device_id = 0;
 
     hipGetDevice(&device_id);
     hipGetDeviceProperties(&devProp, device_id);
     printf("Device: %s\n", devProp.name);
 
     // Generate problem
-    std::vector<int> hAptr;
-    std::vector<int> hAcol;
+    std::vector<int>    hAptr;
+    std::vector<int>    hAcol;
     std::vector<double> hAval;
-    int m   = gen_2d_laplacian(ndim, hAptr, hAcol, hAval, HIPSPARSE_INDEX_BASE_ZERO);
-    int n   = m;
-    int nnz = hAptr[m];
+    int                 m = gen_2d_laplacian(ndim, hAptr, hAcol, hAval, HIPSPARSE_INDEX_BASE_ZERO);
+    int                 n = m;
+    int                 nnz = hAptr[m];
 
     // Sample some random data
     srand(12345ULL);
@@ -84,8 +84,8 @@ int main(int argc, char* argv[])
     hipsparseCreateMatDescr(&descrA);
 
     // Offload data to device
-    int* dAptr    = NULL;
-    int* dAcol    = NULL;
+    int*    dAptr = NULL;
+    int*    dAcol = NULL;
     double* dAval = NULL;
     double* dx    = NULL;
     double* dy    = NULL;
@@ -152,9 +152,9 @@ int main(int argc, char* argv[])
     }
 
     time = (get_time_us() - time) / (trials * batch_size * 1e3);
-    double bandwidth =
-        static_cast<double>(sizeof(double) * (2 * m + nnz) + sizeof(int) * (m + 1 + nnz)) / time /
-        1e6;
+    double bandwidth
+        = static_cast<double>(sizeof(double) * (2 * m + nnz) + sizeof(int) * (m + 1 + nnz)) / time
+          / 1e6;
     double gflops = static_cast<double>(2 * nnz) / time / 1e6;
     printf("m\t\tn\t\tnnz\t\talpha\tbeta\tGFlops\tGB/s\tusec\n");
     printf("%8d\t%8d\t%9d\t%0.2lf\t%0.2lf\t%0.2lf\t%0.2lf\t%0.2lf\n",

--- a/clients/samples/example_handle.cpp
+++ b/clients/samples/example_handle.cpp
@@ -21,8 +21,8 @@
  *
  * ************************************************************************ */
 
-#include <stdio.h>
 #include <hipsparse.h>
+#include <stdio.h>
 
 int main(int argc, char* argv[])
 {

--- a/clients/samples/example_hybmv.cpp
+++ b/clients/samples/example_hybmv.cpp
@@ -23,11 +23,11 @@
 
 #include "utility.hpp"
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <vector>
-#include <hipsparse.h>
 #include <hip/hip_runtime_api.h>
+#include <hipsparse.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
 
 int main(int argc, char* argv[])
 {
@@ -56,19 +56,19 @@ int main(int argc, char* argv[])
     hipsparseCreate(&handle);
 
     hipDeviceProp_t devProp;
-    int device_id = 0;
+    int             device_id = 0;
 
     hipGetDevice(&device_id);
     hipGetDeviceProperties(&devProp, device_id);
     printf("Device: %s\n", devProp.name);
 
     // Generate problem in CSR format
-    std::vector<int> hAptr;
-    std::vector<int> hAcol;
+    std::vector<int>    hAptr;
+    std::vector<int>    hAcol;
     std::vector<double> hAval;
-    int m   = gen_2d_laplacian(ndim, hAptr, hAcol, hAval, HIPSPARSE_INDEX_BASE_ZERO);
-    int n   = m;
-    int nnz = hAptr[m];
+    int                 m = gen_2d_laplacian(ndim, hAptr, hAcol, hAval, HIPSPARSE_INDEX_BASE_ZERO);
+    int                 n = m;
+    int                 nnz = hAptr[m];
 
     // Sample some random data
     srand(12345ULL);
@@ -84,8 +84,8 @@ int main(int argc, char* argv[])
     hipsparseCreateMatDescr(&descrA);
 
     // Offload data to device
-    int* dAptr    = NULL;
-    int* dAcol    = NULL;
+    int*    dAptr = NULL;
+    int*    dAcol = NULL;
     double* dAval = NULL;
     double* dx    = NULL;
     double* dy    = NULL;
@@ -142,8 +142,8 @@ int main(int argc, char* argv[])
     }
 
     time = (get_time_us() - time) / (trials * batch_size * 1e3);
-    double bandwidth =
-        static_cast<double>(sizeof(double) * (2 * m + nnz) + sizeof(int) * (nnz)) / time / 1e6;
+    double bandwidth
+        = static_cast<double>(sizeof(double) * (2 * m + nnz) + sizeof(int) * (nnz)) / time / 1e6;
     double gflops = static_cast<double>(2 * nnz) / time / 1e6;
     printf("m\t\tn\t\tnnz\t\talpha\tbeta\tGFlops\tGB/s\tusec\n");
     printf("%8d\t%8d\t%9d\t%0.2lf\t%0.2lf\t%0.2lf\t%0.2lf\t%0.2lf\n",

--- a/clients/tests/test_axpyi.cpp
+++ b/clients/tests/test_axpyi.cpp
@@ -24,11 +24,11 @@
 #include "testing_axpyi.hpp"
 #include "utility.hpp"
 
-#include <hipsparse.h>
 #include <gtest/gtest.h>
+#include <hipsparse.h>
 #include <vector>
 
-typedef hipsparseIndexBase_t base;
+typedef hipsparseIndexBase_t               base;
 typedef std::tuple<int, int, double, base> axpyi_tuple;
 
 int axpyi_N_range[]   = {12000, 15332, 22031};
@@ -40,7 +40,7 @@ base axpyi_idx_base_range[] = {HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_O
 
 class parameterized_axpyi : public testing::TestWithParam<axpyi_tuple>
 {
-    protected:
+protected:
     parameterized_axpyi() {}
     virtual ~parameterized_axpyi() {}
     virtual void SetUp() {}
@@ -58,7 +58,10 @@ Arguments setup_axpyi_arguments(axpyi_tuple tup)
     return arg;
 }
 
-TEST(axpyi_bad_arg, axpyi_float) { testing_axpyi_bad_arg<float>(); }
+TEST(axpyi_bad_arg, axpyi_float)
+{
+    testing_axpyi_bad_arg<float>();
+}
 
 TEST_P(parameterized_axpyi, axpyi_float)
 {

--- a/clients/tests/test_coo2csr.cpp
+++ b/clients/tests/test_coo2csr.cpp
@@ -24,19 +24,19 @@
 #include "testing_coo2csr.hpp"
 #include "utility.hpp"
 
-#include <hipsparse.h>
 #include <gtest/gtest.h>
-#include <vector>
+#include <hipsparse.h>
 #include <string>
+#include <vector>
 
-typedef std::tuple<int, int, hipsparseIndexBase_t> coo2csr_tuple;
+typedef std::tuple<int, int, hipsparseIndexBase_t>    coo2csr_tuple;
 typedef std::tuple<hipsparseIndexBase_t, std::string> coo2csr_bin_tuple;
 
 int coo2csr_M_range[] = {-1, 0, 10, 500, 872, 1000};
 int coo2csr_N_range[] = {-3, 0, 33, 242, 623, 1000};
 
-hipsparseIndexBase_t coo2csr_idx_base_range[] = {HIPSPARSE_INDEX_BASE_ZERO,
-                                                 HIPSPARSE_INDEX_BASE_ONE};
+hipsparseIndexBase_t coo2csr_idx_base_range[]
+    = {HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE};
 
 std::string coo2csr_bin[] = {"rma10.bin",
                              "mac_econ_fwd500.bin",
@@ -55,7 +55,7 @@ std::string coo2csr_bin[] = {"rma10.bin",
 
 class parameterized_coo2csr : public testing::TestWithParam<coo2csr_tuple>
 {
-    protected:
+protected:
     parameterized_coo2csr() {}
     virtual ~parameterized_coo2csr() {}
     virtual void SetUp() {}
@@ -64,7 +64,7 @@ class parameterized_coo2csr : public testing::TestWithParam<coo2csr_tuple>
 
 class parameterized_coo2csr_bin : public testing::TestWithParam<coo2csr_bin_tuple>
 {
-    protected:
+protected:
     parameterized_coo2csr_bin() {}
     virtual ~parameterized_coo2csr_bin() {}
     virtual void SetUp() {}
@@ -93,7 +93,7 @@ Arguments setup_coo2csr_arguments(coo2csr_bin_tuple tup)
     std::string bin_file = std::get<1>(tup);
 
     // Get current executables absolute path
-    char path_exe[PATH_MAX];
+    char    path_exe[PATH_MAX];
     ssize_t len = readlink("/proc/self/exe", path_exe, sizeof(path_exe) - 1);
     if(len < 14)
     {
@@ -110,7 +110,10 @@ Arguments setup_coo2csr_arguments(coo2csr_bin_tuple tup)
     return arg;
 }
 
-TEST(coo2csr_bad_arg, coo2csr) { testing_coo2csr_bad_arg(); }
+TEST(coo2csr_bad_arg, coo2csr)
+{
+    testing_coo2csr_bad_arg();
+}
 
 TEST_P(parameterized_coo2csr, coo2csr)
 {

--- a/clients/tests/test_coosort.cpp
+++ b/clients/tests/test_coosort.cpp
@@ -24,18 +24,18 @@
 #include "testing_coosort.hpp"
 #include "utility.hpp"
 
-#include <hipsparse.h>
 #include <gtest/gtest.h>
-#include <vector>
+#include <hipsparse.h>
 #include <string>
+#include <vector>
 
-typedef std::tuple<int, int, hipsparseOperation_t, int, hipsparseIndexBase_t> coosort_tuple;
+typedef std::tuple<int, int, hipsparseOperation_t, int, hipsparseIndexBase_t>    coosort_tuple;
 typedef std::tuple<hipsparseOperation_t, int, hipsparseIndexBase_t, std::string> coosort_bin_tuple;
 
-int coosort_M_range[]                = {-1, 0, 10, 500, 3872, 10000};
-int coosort_N_range[]                = {-3, 0, 33, 242, 1623, 10000};
-hipsparseOperation_t coosort_trans[] = {HIPSPARSE_OPERATION_NON_TRANSPOSE,
-                                        HIPSPARSE_OPERATION_TRANSPOSE};
+int                  coosort_M_range[] = {-1, 0, 10, 500, 3872, 10000};
+int                  coosort_N_range[] = {-3, 0, 33, 242, 1623, 10000};
+hipsparseOperation_t coosort_trans[]
+    = {HIPSPARSE_OPERATION_NON_TRANSPOSE, HIPSPARSE_OPERATION_TRANSPOSE};
 
 #if defined(__HIP_PLATFORM_HCC__)
 int coosort_perm[] = {0, 1};
@@ -63,7 +63,7 @@ std::string coosort_bin[] = {"rma10.bin",
 
 class parameterized_coosort : public testing::TestWithParam<coosort_tuple>
 {
-    protected:
+protected:
     parameterized_coosort() {}
     virtual ~parameterized_coosort() {}
     virtual void SetUp() {}
@@ -72,7 +72,7 @@ class parameterized_coosort : public testing::TestWithParam<coosort_tuple>
 
 class parameterized_coosort_bin : public testing::TestWithParam<coosort_bin_tuple>
 {
-    protected:
+protected:
     parameterized_coosort_bin() {}
     virtual ~parameterized_coosort_bin() {}
     virtual void SetUp() {}
@@ -105,7 +105,7 @@ Arguments setup_coosort_arguments(coosort_bin_tuple tup)
     std::string bin_file = std::get<3>(tup);
 
     // Get current executables absolute path
-    char path_exe[PATH_MAX];
+    char    path_exe[PATH_MAX];
     ssize_t len = readlink("/proc/self/exe", path_exe, sizeof(path_exe) - 1);
     if(len < 14)
     {
@@ -122,7 +122,10 @@ Arguments setup_coosort_arguments(coosort_bin_tuple tup)
     return arg;
 }
 
-TEST(coosort_bad_arg, coosort) { testing_coosort_bad_arg(); }
+TEST(coosort_bad_arg, coosort)
+{
+    testing_coosort_bad_arg();
+}
 
 TEST_P(parameterized_coosort, coosort)
 {

--- a/clients/tests/test_csr2coo.cpp
+++ b/clients/tests/test_csr2coo.cpp
@@ -24,19 +24,19 @@
 #include "testing_csr2coo.hpp"
 #include "utility.hpp"
 
-#include <hipsparse.h>
 #include <gtest/gtest.h>
-#include <vector>
+#include <hipsparse.h>
 #include <string>
+#include <vector>
 
-typedef std::tuple<int, int, hipsparseIndexBase_t> csr2coo_tuple;
+typedef std::tuple<int, int, hipsparseIndexBase_t>    csr2coo_tuple;
 typedef std::tuple<hipsparseIndexBase_t, std::string> csr2coo_bin_tuple;
 
 int csr2coo_M_range[] = {-1, 0, 10, 500, 872, 1000};
 int csr2coo_N_range[] = {-3, 0, 33, 242, 623, 1000};
 
-hipsparseIndexBase_t csr2coo_idx_base_range[] = {HIPSPARSE_INDEX_BASE_ZERO,
-                                                 HIPSPARSE_INDEX_BASE_ONE};
+hipsparseIndexBase_t csr2coo_idx_base_range[]
+    = {HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE};
 
 std::string csr2coo_bin[] = {"rma10.bin",
                              "mac_econ_fwd500.bin",
@@ -55,7 +55,7 @@ std::string csr2coo_bin[] = {"rma10.bin",
 
 class parameterized_csr2coo : public testing::TestWithParam<csr2coo_tuple>
 {
-    protected:
+protected:
     parameterized_csr2coo() {}
     virtual ~parameterized_csr2coo() {}
     virtual void SetUp() {}
@@ -64,7 +64,7 @@ class parameterized_csr2coo : public testing::TestWithParam<csr2coo_tuple>
 
 class parameterized_csr2coo_bin : public testing::TestWithParam<csr2coo_bin_tuple>
 {
-    protected:
+protected:
     parameterized_csr2coo_bin() {}
     virtual ~parameterized_csr2coo_bin() {}
     virtual void SetUp() {}
@@ -93,7 +93,7 @@ Arguments setup_csr2coo_arguments(csr2coo_bin_tuple tup)
     std::string bin_file = std::get<1>(tup);
 
     // Get current executables absolute path
-    char path_exe[PATH_MAX];
+    char    path_exe[PATH_MAX];
     ssize_t len = readlink("/proc/self/exe", path_exe, sizeof(path_exe) - 1);
     if(len < 14)
     {
@@ -110,7 +110,10 @@ Arguments setup_csr2coo_arguments(csr2coo_bin_tuple tup)
     return arg;
 }
 
-TEST(csr2coo_bad_arg, csr2coo) { testing_csr2coo_bad_arg(); }
+TEST(csr2coo_bad_arg, csr2coo)
+{
+    testing_csr2coo_bad_arg();
+}
 
 TEST_P(parameterized_csr2coo, csr2coo)
 {

--- a/clients/tests/test_csr2csc.cpp
+++ b/clients/tests/test_csr2csc.cpp
@@ -24,12 +24,12 @@
 #include "testing_csr2csc.hpp"
 #include "utility.hpp"
 
-#include <hipsparse.h>
 #include <gtest/gtest.h>
-#include <vector>
+#include <hipsparse.h>
 #include <string>
+#include <vector>
 
-typedef std::tuple<int, int, hipsparseAction_t, hipsparseIndexBase_t> csr2csc_tuple;
+typedef std::tuple<int, int, hipsparseAction_t, hipsparseIndexBase_t>    csr2csc_tuple;
 typedef std::tuple<hipsparseAction_t, hipsparseIndexBase_t, std::string> csr2csc_bin_tuple;
 
 int csr2csc_M_range[] = {-1, 0, 10, 500, 872, 1000};
@@ -37,8 +37,8 @@ int csr2csc_N_range[] = {-3, 0, 33, 242, 623, 1000};
 
 hipsparseAction_t csr2csc_action_range[] = {HIPSPARSE_ACTION_NUMERIC, HIPSPARSE_ACTION_SYMBOLIC};
 
-hipsparseIndexBase_t csr2csc_csr_base_range[] = {HIPSPARSE_INDEX_BASE_ZERO,
-                                                 HIPSPARSE_INDEX_BASE_ONE};
+hipsparseIndexBase_t csr2csc_csr_base_range[]
+    = {HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE};
 
 std::string csr2csc_bin[] = {"rma10.bin",
                              "mac_econ_fwd500.bin",
@@ -57,7 +57,7 @@ std::string csr2csc_bin[] = {"rma10.bin",
 
 class parameterized_csr2csc : public testing::TestWithParam<csr2csc_tuple>
 {
-    protected:
+protected:
     parameterized_csr2csc() {}
     virtual ~parameterized_csr2csc() {}
     virtual void SetUp() {}
@@ -66,7 +66,7 @@ class parameterized_csr2csc : public testing::TestWithParam<csr2csc_tuple>
 
 class parameterized_csr2csc_bin : public testing::TestWithParam<csr2csc_bin_tuple>
 {
-    protected:
+protected:
     parameterized_csr2csc_bin() {}
     virtual ~parameterized_csr2csc_bin() {}
     virtual void SetUp() {}
@@ -97,7 +97,7 @@ Arguments setup_csr2csc_arguments(csr2csc_bin_tuple tup)
     std::string bin_file = std::get<2>(tup);
 
     // Get current executables absolute path
-    char path_exe[PATH_MAX];
+    char    path_exe[PATH_MAX];
     ssize_t len = readlink("/proc/self/exe", path_exe, sizeof(path_exe) - 1);
     if(len < 14)
     {
@@ -114,7 +114,10 @@ Arguments setup_csr2csc_arguments(csr2csc_bin_tuple tup)
     return arg;
 }
 
-TEST(csr2csc_bad_arg, csr2csc) { testing_csr2csc_bad_arg<float>(); }
+TEST(csr2csc_bad_arg, csr2csc)
+{
+    testing_csr2csc_bad_arg<float>();
+}
 
 TEST_P(parameterized_csr2csc, csr2csc_float)
 {

--- a/clients/tests/test_csr2hyb.cpp
+++ b/clients/tests/test_csr2hyb.cpp
@@ -24,10 +24,10 @@
 #include "testing_csr2hyb.hpp"
 #include "utility.hpp"
 
-#include <hipsparse.h>
 #include <gtest/gtest.h>
-#include <vector>
+#include <hipsparse.h>
 #include <string>
+#include <vector>
 
 typedef std::tuple<int, int, hipsparseIndexBase_t, hipsparseHybPartition_t, int> csr2hyb_tuple;
 typedef std::tuple<hipsparseIndexBase_t, hipsparseHybPartition_t, int, std::string>
@@ -36,11 +36,11 @@ typedef std::tuple<hipsparseIndexBase_t, hipsparseHybPartition_t, int, std::stri
 int csr2hyb_M_range[] = {-1, 0, 10, 500, 872, 1000};
 int csr2hyb_N_range[] = {-3, 0, 33, 242, 623, 1000};
 
-hipsparseIndexBase_t csr2hyb_idx_base_range[] = {HIPSPARSE_INDEX_BASE_ZERO,
-                                                 HIPSPARSE_INDEX_BASE_ONE};
+hipsparseIndexBase_t csr2hyb_idx_base_range[]
+    = {HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE};
 
-hipsparseHybPartition_t csr2hyb_partition[] = {
-    HIPSPARSE_HYB_PARTITION_AUTO, HIPSPARSE_HYB_PARTITION_MAX, HIPSPARSE_HYB_PARTITION_USER};
+hipsparseHybPartition_t csr2hyb_partition[]
+    = {HIPSPARSE_HYB_PARTITION_AUTO, HIPSPARSE_HYB_PARTITION_MAX, HIPSPARSE_HYB_PARTITION_USER};
 
 int csr2hyb_ELL_range[] = {-33, -1, 0, INT32_MAX};
 
@@ -61,7 +61,7 @@ std::string csr2hyb_bin[] = {"rma10.bin",
 
 class parameterized_csr2hyb : public testing::TestWithParam<csr2hyb_tuple>
 {
-    protected:
+protected:
     parameterized_csr2hyb() {}
     virtual ~parameterized_csr2hyb() {}
     virtual void SetUp() {}
@@ -70,7 +70,7 @@ class parameterized_csr2hyb : public testing::TestWithParam<csr2hyb_tuple>
 
 class parameterized_csr2hyb_bin : public testing::TestWithParam<csr2hyb_bin_tuple>
 {
-    protected:
+protected:
     parameterized_csr2hyb_bin() {}
     virtual ~parameterized_csr2hyb_bin() {}
     virtual void SetUp() {}
@@ -103,7 +103,7 @@ Arguments setup_csr2hyb_arguments(csr2hyb_bin_tuple tup)
     std::string bin_file = std::get<3>(tup);
 
     // Get current executables absolute path
-    char path_exe[PATH_MAX];
+    char    path_exe[PATH_MAX];
     ssize_t len = readlink("/proc/self/exe", path_exe, sizeof(path_exe) - 1);
     if(len < 14)
     {
@@ -120,7 +120,10 @@ Arguments setup_csr2hyb_arguments(csr2hyb_bin_tuple tup)
     return arg;
 }
 
-TEST(csr2hyb_bad_arg, csr2hyb) { testing_csr2hyb_bad_arg<float>(); }
+TEST(csr2hyb_bad_arg, csr2hyb)
+{
+    testing_csr2hyb_bad_arg<float>();
+}
 
 TEST_P(parameterized_csr2hyb, csr2hyb_float)
 {

--- a/clients/tests/test_csrilu02.cpp
+++ b/clients/tests/test_csrilu02.cpp
@@ -24,14 +24,14 @@
 #include "testing_csrilu02.hpp"
 #include "utility.hpp"
 
-#include <hipsparse.h>
 #include <gtest/gtest.h>
+#include <hipsparse.h>
+#include <string>
 #include <unistd.h>
 #include <vector>
-#include <string>
 
-typedef hipsparseIndexBase_t base;
-typedef std::tuple<int, base> csrilu02_tuple;
+typedef hipsparseIndexBase_t          base;
+typedef std::tuple<int, base>         csrilu02_tuple;
 typedef std::tuple<base, std::string> csrilu02_bin_tuple;
 
 int csrilu02_M_range[] = {-1, 0, 50, 647};
@@ -58,7 +58,7 @@ std::string csrilu02_bin[] = {"mac_econ_fwd500.bin",
 
 class parameterized_csrilu02 : public testing::TestWithParam<csrilu02_tuple>
 {
-    protected:
+protected:
     parameterized_csrilu02() {}
     virtual ~parameterized_csrilu02() {}
     virtual void SetUp() {}
@@ -67,7 +67,7 @@ class parameterized_csrilu02 : public testing::TestWithParam<csrilu02_tuple>
 
 class parameterized_csrilu02_bin : public testing::TestWithParam<csrilu02_bin_tuple>
 {
-    protected:
+protected:
     parameterized_csrilu02_bin() {}
     virtual ~parameterized_csrilu02_bin() {}
     virtual void SetUp() {}
@@ -94,7 +94,7 @@ Arguments setup_csrilu02_arguments(csrilu02_bin_tuple tup)
     std::string bin_file = std::get<1>(tup);
 
     // Get current executables absolute path
-    char path_exe[PATH_MAX];
+    char    path_exe[PATH_MAX];
     ssize_t len = readlink("/proc/self/exe", path_exe, sizeof(path_exe) - 1);
     if(len < 14)
     {
@@ -111,7 +111,10 @@ Arguments setup_csrilu02_arguments(csrilu02_bin_tuple tup)
     return arg;
 }
 
-TEST(csrilu02_bad_arg, csrilu02_float) { testing_csrilu02_bad_arg<float>(); }
+TEST(csrilu02_bad_arg, csrilu02_float)
+{
+    testing_csrilu02_bad_arg<float>();
+}
 
 TEST_P(parameterized_csrilu02, csrilu02_float)
 {

--- a/clients/tests/test_csrilusv.cpp
+++ b/clients/tests/test_csrilusv.cpp
@@ -24,11 +24,11 @@
 #include "testing_csrilusv.hpp"
 #include "utility.hpp"
 
-#include <hipsparse.h>
 #include <gtest/gtest.h>
+#include <hipsparse.h>
+#include <string>
 #include <unistd.h>
 #include <vector>
-#include <string>
 
 typedef hipsparseIndexBase_t base;
 
@@ -51,7 +51,7 @@ std::string csrilusv_bin[] = {"mac_econ_fwd500.bin",
 
 class parameterized_csrilusv_bin : public testing::TestWithParam<csrilusv_bin_tuple>
 {
-    protected:
+protected:
     parameterized_csrilusv_bin() {}
     virtual ~parameterized_csrilusv_bin() {}
     virtual void SetUp() {}
@@ -69,7 +69,7 @@ Arguments setup_csrilusv_arguments(csrilusv_bin_tuple tup)
     std::string bin_file = std::get<1>(tup);
 
     // Get current executables absolute path
-    char path_exe[PATH_MAX];
+    char    path_exe[PATH_MAX];
     ssize_t len = readlink("/proc/self/exe", path_exe, sizeof(path_exe) - 1);
     if(len < 14)
     {

--- a/clients/tests/test_csrmm.cpp
+++ b/clients/tests/test_csrmm.cpp
@@ -24,13 +24,13 @@
 #include "testing_csrmm.hpp"
 #include "utility.hpp"
 
-#include <hipsparse.h>
 #include <gtest/gtest.h>
+#include <hipsparse.h>
 #include <string>
 
-typedef hipsparseIndexBase_t base;
-typedef hipsparseOperation_t trans;
-typedef std::tuple<int, int, int, double, double, base, trans, trans> csrmm_tuple;
+typedef hipsparseIndexBase_t                                             base;
+typedef hipsparseOperation_t                                             trans;
+typedef std::tuple<int, int, int, double, double, base, trans, trans>    csrmm_tuple;
 typedef std::tuple<int, double, double, base, trans, trans, std::string> csrmm_bin_tuple;
 
 int csrmm_M_range[] = {-1, 0, 42, 511, 3521};
@@ -40,9 +40,9 @@ int csrmm_K_range[] = {-1, 0, 50, 254, 1942};
 double csrmm_alpha_range[] = {-1.0, 0.0, 3.3};
 double csrmm_beta_range[]  = {-0.3, 0.0, 1.0};
 
-base csrmm_idxbase_range[] = {HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE};
-trans csrmm_transA_range[] = {HIPSPARSE_OPERATION_NON_TRANSPOSE};
-trans csrmm_transB_range[] = {HIPSPARSE_OPERATION_NON_TRANSPOSE, HIPSPARSE_OPERATION_TRANSPOSE};
+base  csrmm_idxbase_range[] = {HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE};
+trans csrmm_transA_range[]  = {HIPSPARSE_OPERATION_NON_TRANSPOSE};
+trans csrmm_transB_range[]  = {HIPSPARSE_OPERATION_NON_TRANSPOSE, HIPSPARSE_OPERATION_TRANSPOSE};
 
 std::string csrmm_bin[] = {"rma10.bin",
                            "mac_econ_fwd500.bin",
@@ -61,7 +61,7 @@ std::string csrmm_bin[] = {"rma10.bin",
 
 class parameterized_csrmm : public testing::TestWithParam<csrmm_tuple>
 {
-    protected:
+protected:
     parameterized_csrmm() {}
     virtual ~parameterized_csrmm() {}
     virtual void SetUp() {}
@@ -70,7 +70,7 @@ class parameterized_csrmm : public testing::TestWithParam<csrmm_tuple>
 
 class parameterized_csrmm_bin : public testing::TestWithParam<csrmm_bin_tuple>
 {
-    protected:
+protected:
     parameterized_csrmm_bin() {}
     virtual ~parameterized_csrmm_bin() {}
     virtual void SetUp() {}
@@ -109,7 +109,7 @@ Arguments setup_csrmm_arguments(csrmm_bin_tuple tup)
     std::string bin_file = std::get<6>(tup);
 
     // Get current executables absolute path
-    char path_exe[PATH_MAX];
+    char    path_exe[PATH_MAX];
     ssize_t len = readlink("/proc/self/exe", path_exe, sizeof(path_exe) - 1);
     if(len < 14)
     {
@@ -126,7 +126,10 @@ Arguments setup_csrmm_arguments(csrmm_bin_tuple tup)
     return arg;
 }
 
-TEST(csrmm_bad_arg, csrmm_float) { testing_csrmm_bad_arg<float>(); }
+TEST(csrmm_bad_arg, csrmm_float)
+{
+    testing_csrmm_bad_arg<float>();
+}
 
 TEST_P(parameterized_csrmm, csrmm_float)
 {

--- a/clients/tests/test_csrmv.cpp
+++ b/clients/tests/test_csrmv.cpp
@@ -24,14 +24,14 @@
 #include "testing_csrmv.hpp"
 #include "utility.hpp"
 
-#include <hipsparse.h>
 #include <gtest/gtest.h>
+#include <hipsparse.h>
+#include <string>
 #include <unistd.h>
 #include <vector>
-#include <string>
 
-typedef hipsparseIndexBase_t base;
-typedef std::tuple<int, int, double, double, base> csrmv_tuple;
+typedef hipsparseIndexBase_t                          base;
+typedef std::tuple<int, int, double, double, base>    csrmv_tuple;
 typedef std::tuple<double, double, base, std::string> csrmv_bin_tuple;
 
 int csr_M_range[] = {-1, 0, 500, 7111};
@@ -59,7 +59,7 @@ std::string csr_bin[] = {"rma10.bin",
 
 class parameterized_csrmv : public testing::TestWithParam<csrmv_tuple>
 {
-    protected:
+protected:
     parameterized_csrmv() {}
     virtual ~parameterized_csrmv() {}
     virtual void SetUp() {}
@@ -68,7 +68,7 @@ class parameterized_csrmv : public testing::TestWithParam<csrmv_tuple>
 
 class parameterized_csrmv_bin : public testing::TestWithParam<csrmv_bin_tuple>
 {
-    protected:
+protected:
     parameterized_csrmv_bin() {}
     virtual ~parameterized_csrmv_bin() {}
     virtual void SetUp() {}
@@ -101,7 +101,7 @@ Arguments setup_csrmv_arguments(csrmv_bin_tuple tup)
     std::string bin_file = std::get<3>(tup);
 
     // Get current executables absolute path
-    char path_exe[PATH_MAX];
+    char    path_exe[PATH_MAX];
     ssize_t len = readlink("/proc/self/exe", path_exe, sizeof(path_exe) - 1);
     if(len < 14)
     {
@@ -118,7 +118,10 @@ Arguments setup_csrmv_arguments(csrmv_bin_tuple tup)
     return arg;
 }
 
-TEST(csrmv_bad_arg, csrmv_float) { testing_csrmv_bad_arg<float>(); }
+TEST(csrmv_bad_arg, csrmv_float)
+{
+    testing_csrmv_bad_arg<float>();
+}
 
 TEST_P(parameterized_csrmv, csrmv_float)
 {

--- a/clients/tests/test_csrsort.cpp
+++ b/clients/tests/test_csrsort.cpp
@@ -24,12 +24,12 @@
 #include "testing_csrsort.hpp"
 #include "utility.hpp"
 
-#include <hipsparse.h>
 #include <gtest/gtest.h>
-#include <vector>
+#include <hipsparse.h>
 #include <string>
+#include <vector>
 
-typedef std::tuple<int, int, int, hipsparseIndexBase_t> csrsort_tuple;
+typedef std::tuple<int, int, int, hipsparseIndexBase_t>    csrsort_tuple;
 typedef std::tuple<int, hipsparseIndexBase_t, std::string> csrsort_bin_tuple;
 
 int csrsort_M_range[] = {-1, 0, 10, 500, 872, 1000};
@@ -61,7 +61,7 @@ std::string csrsort_bin[] = {"rma10.bin",
 
 class parameterized_csrsort : public testing::TestWithParam<csrsort_tuple>
 {
-    protected:
+protected:
     parameterized_csrsort() {}
     virtual ~parameterized_csrsort() {}
     virtual void SetUp() {}
@@ -70,7 +70,7 @@ class parameterized_csrsort : public testing::TestWithParam<csrsort_tuple>
 
 class parameterized_csrsort_bin : public testing::TestWithParam<csrsort_bin_tuple>
 {
-    protected:
+protected:
     parameterized_csrsort_bin() {}
     virtual ~parameterized_csrsort_bin() {}
     virtual void SetUp() {}
@@ -101,7 +101,7 @@ Arguments setup_csrsort_arguments(csrsort_bin_tuple tup)
     std::string bin_file = std::get<2>(tup);
 
     // Get current executables absolute path
-    char path_exe[PATH_MAX];
+    char    path_exe[PATH_MAX];
     ssize_t len = readlink("/proc/self/exe", path_exe, sizeof(path_exe) - 1);
     if(len < 14)
     {
@@ -118,7 +118,10 @@ Arguments setup_csrsort_arguments(csrsort_bin_tuple tup)
     return arg;
 }
 
-TEST(csrsort_bad_arg, csrsort) { testing_csrsort_bad_arg(); }
+TEST(csrsort_bad_arg, csrsort)
+{
+    testing_csrsort_bad_arg();
+}
 
 TEST_P(parameterized_csrsort, csrsort)
 {

--- a/clients/tests/test_csrsv2.cpp
+++ b/clients/tests/test_csrsv2.cpp
@@ -24,18 +24,18 @@
 #include "testing_csrsv2.hpp"
 #include "utility.hpp"
 
-#include <hipsparse.h>
 #include <gtest/gtest.h>
+#include <hipsparse.h>
+#include <string>
 #include <unistd.h>
 #include <vector>
-#include <string>
 
 typedef hipsparseIndexBase_t base;
 typedef hipsparseOperation_t op;
-typedef hipsparseDiagType_t diag;
-typedef hipsparseFillMode_t fill;
+typedef hipsparseDiagType_t  diag;
+typedef hipsparseFillMode_t  fill;
 
-typedef std::tuple<int, double, base, op, diag, fill> csrsv2_tuple;
+typedef std::tuple<int, double, base, op, diag, fill>         csrsv2_tuple;
 typedef std::tuple<double, base, op, diag, fill, std::string> csrsv2_bin_tuple;
 
 int csrsv2_M_range[] = {-1, 0, 50, 647};
@@ -43,7 +43,7 @@ int csrsv2_M_range[] = {-1, 0, 50, 647};
 double csrsv2_alpha_range[] = {1.0, 2.3, -3.7};
 
 base csrsv2_idxbase_range[] = {HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE};
-op csrsv2_op_range[]        = {HIPSPARSE_OPERATION_NON_TRANSPOSE};
+op   csrsv2_op_range[]      = {HIPSPARSE_OPERATION_NON_TRANSPOSE};
 diag csrsv2_diag_range[]    = {HIPSPARSE_DIAG_TYPE_NON_UNIT};
 fill csrsv2_fill_range[]    = {HIPSPARSE_FILL_MODE_LOWER, HIPSPARSE_FILL_MODE_UPPER};
 
@@ -62,7 +62,7 @@ std::string csrsv2_bin[] = {"rma10.bin",
 
 class parameterized_csrsv2 : public testing::TestWithParam<csrsv2_tuple>
 {
-    protected:
+protected:
     parameterized_csrsv2() {}
     virtual ~parameterized_csrsv2() {}
     virtual void SetUp() {}
@@ -71,7 +71,7 @@ class parameterized_csrsv2 : public testing::TestWithParam<csrsv2_tuple>
 
 class parameterized_csrsv2_bin : public testing::TestWithParam<csrsv2_bin_tuple>
 {
-    protected:
+protected:
     parameterized_csrsv2_bin() {}
     virtual ~parameterized_csrsv2_bin() {}
     virtual void SetUp() {}
@@ -106,7 +106,7 @@ Arguments setup_csrsv2_arguments(csrsv2_bin_tuple tup)
     std::string bin_file = std::get<5>(tup);
 
     // Get current executables absolute path
-    char path_exe[PATH_MAX];
+    char    path_exe[PATH_MAX];
     ssize_t len = readlink("/proc/self/exe", path_exe, sizeof(path_exe) - 1);
     if(len < 14)
     {
@@ -123,7 +123,10 @@ Arguments setup_csrsv2_arguments(csrsv2_bin_tuple tup)
     return arg;
 }
 
-TEST(csrsv2_bad_arg, csrsv2_float) { testing_csrsv2_bad_arg<float>(); }
+TEST(csrsv2_bad_arg, csrsv2_float)
+{
+    testing_csrsv2_bad_arg<float>();
+}
 
 TEST_P(parameterized_csrsv2, csrsv2_float)
 {

--- a/clients/tests/test_doti.cpp
+++ b/clients/tests/test_doti.cpp
@@ -24,11 +24,11 @@
 #include "testing_doti.hpp"
 #include "utility.hpp"
 
-#include <hipsparse.h>
 #include <gtest/gtest.h>
+#include <hipsparse.h>
 #include <vector>
 
-typedef hipsparseIndexBase_t base;
+typedef hipsparseIndexBase_t       base;
 typedef std::tuple<int, int, base> doti_tuple;
 
 int doti_N_range[]   = {12000, 15332, 22031};
@@ -38,7 +38,7 @@ base doti_idx_base_range[] = {HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ON
 
 class parameterized_doti : public testing::TestWithParam<doti_tuple>
 {
-    protected:
+protected:
     parameterized_doti() {}
     virtual ~parameterized_doti() {}
     virtual void SetUp() {}
@@ -55,7 +55,10 @@ Arguments setup_doti_arguments(doti_tuple tup)
     return arg;
 }
 
-TEST(doti_bad_arg, doti_float) { testing_doti_bad_arg<float>(); }
+TEST(doti_bad_arg, doti_float)
+{
+    testing_doti_bad_arg<float>();
+}
 
 TEST_P(parameterized_doti, doti_float)
 {

--- a/clients/tests/test_gthr.cpp
+++ b/clients/tests/test_gthr.cpp
@@ -24,11 +24,11 @@
 #include "testing_gthr.hpp"
 #include "utility.hpp"
 
-#include <hipsparse.h>
 #include <gtest/gtest.h>
+#include <hipsparse.h>
 #include <vector>
 
-typedef hipsparseIndexBase_t base;
+typedef hipsparseIndexBase_t       base;
 typedef std::tuple<int, int, base> gthr_tuple;
 
 int gthr_N_range[]   = {12000, 15332, 22031};
@@ -38,7 +38,7 @@ base gthr_idx_base_range[] = {HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ON
 
 class parameterized_gthr : public testing::TestWithParam<gthr_tuple>
 {
-    protected:
+protected:
     parameterized_gthr() {}
     virtual ~parameterized_gthr() {}
     virtual void SetUp() {}
@@ -55,7 +55,10 @@ Arguments setup_gthr_arguments(gthr_tuple tup)
     return arg;
 }
 
-TEST(gthr_bad_arg, gthr_float) { testing_gthr_bad_arg<float>(); }
+TEST(gthr_bad_arg, gthr_float)
+{
+    testing_gthr_bad_arg<float>();
+}
 
 TEST_P(parameterized_gthr, gthr_float)
 {

--- a/clients/tests/test_gthrz.cpp
+++ b/clients/tests/test_gthrz.cpp
@@ -24,11 +24,11 @@
 #include "testing_gthrz.hpp"
 #include "utility.hpp"
 
-#include <hipsparse.h>
 #include <gtest/gtest.h>
+#include <hipsparse.h>
 #include <vector>
 
-typedef hipsparseIndexBase_t base;
+typedef hipsparseIndexBase_t       base;
 typedef std::tuple<int, int, base> gthrz_tuple;
 
 int gthrz_N_range[]   = {12000, 15332, 22031};
@@ -38,7 +38,7 @@ base gthrz_idx_base_range[] = {HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_O
 
 class parameterized_gthrz : public testing::TestWithParam<gthrz_tuple>
 {
-    protected:
+protected:
     parameterized_gthrz() {}
     virtual ~parameterized_gthrz() {}
     virtual void SetUp() {}
@@ -55,7 +55,10 @@ Arguments setup_gthrz_arguments(gthrz_tuple tup)
     return arg;
 }
 
-TEST(gthrz_bad_arg, gthrz_float) { testing_gthrz_bad_arg<float>(); }
+TEST(gthrz_bad_arg, gthrz_float)
+{
+    testing_gthrz_bad_arg<float>();
+}
 
 TEST_P(parameterized_gthrz, gthrz_float)
 {

--- a/clients/tests/test_hybmv.cpp
+++ b/clients/tests/test_hybmv.cpp
@@ -24,10 +24,10 @@
 #include "testing_hybmv.hpp"
 #include "utility.hpp"
 
-#include <hipsparse.h>
 #include <gtest/gtest.h>
-#include <vector>
+#include <hipsparse.h>
 #include <string>
+#include <vector>
 
 typedef std::tuple<int, int, double, double, hipsparseIndexBase_t, hipsparseHybPartition_t, int>
     hybmv_tuple;
@@ -42,8 +42,8 @@ std::vector<double> hyb_beta_range  = {0.0, 0.67, 1.0};
 
 hipsparseIndexBase_t hyb_idxbase_range[] = {HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE};
 
-hipsparseHybPartition_t hyb_partition[] = {
-    HIPSPARSE_HYB_PARTITION_AUTO, HIPSPARSE_HYB_PARTITION_MAX, HIPSPARSE_HYB_PARTITION_USER};
+hipsparseHybPartition_t hyb_partition[]
+    = {HIPSPARSE_HYB_PARTITION_AUTO, HIPSPARSE_HYB_PARTITION_MAX, HIPSPARSE_HYB_PARTITION_USER};
 
 int hyb_ELL_range[] = {0, 1, 2};
 
@@ -64,7 +64,7 @@ std::string hyb_bin[] = {"rma10.bin",
 
 class parameterized_hybmv : public testing::TestWithParam<hybmv_tuple>
 {
-    protected:
+protected:
     parameterized_hybmv() {}
     virtual ~parameterized_hybmv() {}
     virtual void SetUp() {}
@@ -73,7 +73,7 @@ class parameterized_hybmv : public testing::TestWithParam<hybmv_tuple>
 
 class parameterized_hybmv_bin : public testing::TestWithParam<hybmv_bin_tuple>
 {
-    protected:
+protected:
     parameterized_hybmv_bin() {}
     virtual ~parameterized_hybmv_bin() {}
     virtual void SetUp() {}
@@ -110,7 +110,7 @@ Arguments setup_hybmv_arguments(hybmv_bin_tuple tup)
     std::string bin_file = std::get<5>(tup);
 
     // Get current executables absolute path
-    char path_exe[PATH_MAX];
+    char    path_exe[PATH_MAX];
     ssize_t len = readlink("/proc/self/exe", path_exe, sizeof(path_exe) - 1);
     if(len < 14)
     {
@@ -127,7 +127,10 @@ Arguments setup_hybmv_arguments(hybmv_bin_tuple tup)
     return arg;
 }
 
-TEST(hybmv_bad_arg, hybmv_float) { testing_hybmv_bad_arg<float>(); }
+TEST(hybmv_bad_arg, hybmv_float)
+{
+    testing_hybmv_bad_arg<float>();
+}
 
 TEST_P(parameterized_hybmv, hybmv_float)
 {

--- a/clients/tests/test_identity.cpp
+++ b/clients/tests/test_identity.cpp
@@ -24,15 +24,15 @@
 #include "testing_identity.hpp"
 #include "utility.hpp"
 
-#include <hipsparse.h>
 #include <gtest/gtest.h>
+#include <hipsparse.h>
 #include <vector>
 
 int identity_N_range[] = {-3, 0, 33, 242, 623, 1000};
 
 class parameterized_identity : public testing::TestWithParam<int>
 {
-    protected:
+protected:
     parameterized_identity() {}
     virtual ~parameterized_identity() {}
     virtual void SetUp() {}
@@ -47,7 +47,10 @@ Arguments setup_identity_arguments(int n)
     return arg;
 }
 
-TEST(identity_bad_arg, identity) { testing_identity_bad_arg(); }
+TEST(identity_bad_arg, identity)
+{
+    testing_identity_bad_arg();
+}
 
 TEST_P(parameterized_identity, identity)
 {

--- a/clients/tests/test_roti.cpp
+++ b/clients/tests/test_roti.cpp
@@ -24,11 +24,11 @@
 #include "testing_roti.hpp"
 #include "utility.hpp"
 
-#include <hipsparse.h>
 #include <gtest/gtest.h>
+#include <hipsparse.h>
 #include <vector>
 
-typedef hipsparseIndexBase_t base;
+typedef hipsparseIndexBase_t                       base;
 typedef std::tuple<int, int, double, double, base> roti_tuple;
 
 int roti_N_range[]   = {12000, 15332, 22031};
@@ -41,7 +41,7 @@ base roti_idx_base_range[] = {HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ON
 
 class parameterized_roti : public testing::TestWithParam<roti_tuple>
 {
-    protected:
+protected:
     parameterized_roti() {}
     virtual ~parameterized_roti() {}
     virtual void SetUp() {}
@@ -60,7 +60,10 @@ Arguments setup_roti_arguments(roti_tuple tup)
     return arg;
 }
 
-TEST(roti_bad_arg, roti_float) { testing_roti_bad_arg<float>(); }
+TEST(roti_bad_arg, roti_float)
+{
+    testing_roti_bad_arg<float>();
+}
 
 TEST_P(parameterized_roti, roti_float)
 {

--- a/clients/tests/test_sctr.cpp
+++ b/clients/tests/test_sctr.cpp
@@ -24,11 +24,11 @@
 #include "testing_sctr.hpp"
 #include "utility.hpp"
 
-#include <hipsparse.h>
 #include <gtest/gtest.h>
+#include <hipsparse.h>
 #include <vector>
 
-typedef hipsparseIndexBase_t base;
+typedef hipsparseIndexBase_t       base;
 typedef std::tuple<int, int, base> sctr_tuple;
 
 int sctr_N_range[]   = {12000, 15332, 22031};
@@ -38,7 +38,7 @@ base sctr_idx_base_range[] = {HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ON
 
 class parameterized_sctr : public testing::TestWithParam<sctr_tuple>
 {
-    protected:
+protected:
     parameterized_sctr() {}
     virtual ~parameterized_sctr() {}
     virtual void SetUp() {}
@@ -55,7 +55,10 @@ Arguments setup_sctr_arguments(sctr_tuple tup)
     return arg;
 }
 
-TEST(sctr_bad_arg, sctr_float) { testing_sctr_bad_arg<float>(); }
+TEST(sctr_bad_arg, sctr_float)
+{
+    testing_sctr_bad_arg<float>();
+}
 
 TEST_P(parameterized_sctr, sctr_float)
 {

--- a/deps/convert.cpp
+++ b/deps/convert.cpp
@@ -21,20 +21,20 @@
  *
  * ************************************************************************ */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <math.h>
-#include <vector>
-#include <sstream>
 #include <algorithm>
+#include <math.h>
+#include <sstream>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <vector>
 
-int read_mtx_matrix(const char* filename,
-                    int& nrow,
-                    int& ncol,
-                    int& nnz,
-                    std::vector<int>& row,
-                    std::vector<int>& col,
+int read_mtx_matrix(const char*          filename,
+                    int&                 nrow,
+                    int&                 ncol,
+                    int&                 nnz,
+                    std::vector<int>&    row,
+                    std::vector<int>&    col,
                     std::vector<double>& val)
 {
     FILE* f = fopen(filename, "r");
@@ -64,13 +64,13 @@ int read_mtx_matrix(const char* filename,
     }
 
     // Convert to lower case
-    for(char *p = array; *p != '\0'; *p = tolower(*p), p++)
+    for(char* p = array; *p != '\0'; *p = tolower(*p), p++)
         ;
-    for(char *p = coord; *p != '\0'; *p = tolower(*p), p++)
+    for(char* p = coord; *p != '\0'; *p = tolower(*p), p++)
         ;
-    for(char *p = data; *p != '\0'; *p = tolower(*p), p++)
+    for(char* p = data; *p != '\0'; *p = tolower(*p), p++)
         ;
-    for(char *p = type; *p != '\0'; *p = tolower(*p), p++)
+    for(char* p = type; *p != '\0'; *p = tolower(*p), p++)
         ;
 
     // Check banner
@@ -121,8 +121,8 @@ int read_mtx_matrix(const char* filename,
     sscanf(line, "%d %d %d", &nrow, &ncol, &snnz);
     nnz = symm ? (snnz - nrow) * 2 + nrow : snnz;
 
-    std::vector<int> unsorted_row(nnz);
-    std::vector<int> unsorted_col(nnz);
+    std::vector<int>    unsorted_row(nnz);
+    std::vector<int>    unsorted_col(nnz);
     std::vector<double> unsorted_val(nnz);
 
     // Read entries
@@ -134,8 +134,8 @@ int read_mtx_matrix(const char* filename,
             return -1;
         }
 
-        int irow;
-        int icol;
+        int    irow;
+        int    icol;
         double ival;
 
         if(!strcmp(data, "pattern"))
@@ -258,9 +258,9 @@ int main(int argc, char* argv[])
     int n;
     int nnz;
 
-    std::vector<int> ptr;
-    std::vector<int> row;
-    std::vector<int> col;
+    std::vector<int>    ptr;
+    std::vector<int>    row;
+    std::vector<int>    col;
     std::vector<double> val;
 
     if(read_mtx_matrix(argv[1], m, n, nnz, row, col, val) != 0)

--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -199,117 +199,117 @@ hipsparseStatus_t hipsparseDestroyCsrilu02Info(csrilu02Info_t info);
 /* Description: Addition of a scalar multiple of a sparse vector x
    and a dense vector y. */
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseSaxpyi(hipsparseHandle_t handle,
-                                  int nnz,
-                                  const float* alpha,
-                                  const float* xVal,
-                                  const int* xInd,
-                                  float* y,
+hipsparseStatus_t hipsparseSaxpyi(hipsparseHandle_t    handle,
+                                  int                  nnz,
+                                  const float*         alpha,
+                                  const float*         xVal,
+                                  const int*           xInd,
+                                  float*               y,
                                   hipsparseIndexBase_t idxBase);
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseDaxpyi(hipsparseHandle_t handle,
-                                  int nnz,
-                                  const double* alpha,
-                                  const double* xVal,
-                                  const int* xInd,
-                                  double* y,
+hipsparseStatus_t hipsparseDaxpyi(hipsparseHandle_t    handle,
+                                  int                  nnz,
+                                  const double*        alpha,
+                                  const double*        xVal,
+                                  const int*           xInd,
+                                  double*              y,
                                   hipsparseIndexBase_t idxBase);
 
 /* Description: Compute the dot product of a sparse vector x
    with a dense vector y. */
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseSdoti(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const float* xVal,
-                                 const int* xInd,
-                                 const float* y,
-                                 float* result,
+hipsparseStatus_t hipsparseSdoti(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 const float*         xVal,
+                                 const int*           xInd,
+                                 const float*         y,
+                                 float*               result,
                                  hipsparseIndexBase_t idxBase);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseDdoti(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const double* xVal,
-                                 const int* xInd,
-                                 const double* y,
-                                 double* result,
+hipsparseStatus_t hipsparseDdoti(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 const double*        xVal,
+                                 const int*           xInd,
+                                 const double*        y,
+                                 double*              result,
                                  hipsparseIndexBase_t idxBase);
 
 /* Description: Gathers the elements that are listed in xInd from
    a dense vector y and stores them in a sparse vector x. */
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseSgthr(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const float* y,
-                                 float* xVal,
-                                 const int* xInd,
+hipsparseStatus_t hipsparseSgthr(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 const float*         y,
+                                 float*               xVal,
+                                 const int*           xInd,
                                  hipsparseIndexBase_t idxBase);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseDgthr(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const double* y,
-                                 double* xVal,
-                                 const int* xInd,
+hipsparseStatus_t hipsparseDgthr(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 const double*        y,
+                                 double*              xVal,
+                                 const int*           xInd,
                                  hipsparseIndexBase_t idxBase);
 
 /* Description: Gathers the elements that are listed in xInd from
    a dense vector y and stores them in a sparse vector x. Gathered
    elements are replaced by zero in y. */
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseSgthrz(hipsparseHandle_t handle,
-                                  int nnz,
-                                  float* y,
-                                  float* xVal,
-                                  const int* xInd,
+hipsparseStatus_t hipsparseSgthrz(hipsparseHandle_t    handle,
+                                  int                  nnz,
+                                  float*               y,
+                                  float*               xVal,
+                                  const int*           xInd,
                                   hipsparseIndexBase_t idxBase);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseDgthrz(hipsparseHandle_t handle,
-                                  int nnz,
-                                  double* y,
-                                  double* xVal,
-                                  const int* xInd,
+hipsparseStatus_t hipsparseDgthrz(hipsparseHandle_t    handle,
+                                  int                  nnz,
+                                  double*              y,
+                                  double*              xVal,
+                                  const int*           xInd,
                                   hipsparseIndexBase_t idxBase);
 
 /* Description: Applies the Givens rotation matrix to a sparse vector
    x and a dense vector y. */
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseSroti(hipsparseHandle_t handle,
-                                 int nnz,
-                                 float* xVal,
-                                 const int* xInd,
-                                 float* y,
-                                 const float* c,
-                                 const float* s,
+hipsparseStatus_t hipsparseSroti(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 float*               xVal,
+                                 const int*           xInd,
+                                 float*               y,
+                                 const float*         c,
+                                 const float*         s,
                                  hipsparseIndexBase_t idxBase);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseDroti(hipsparseHandle_t handle,
-                                 int nnz,
-                                 double* xVal,
-                                 const int* xInd,
-                                 double* y,
-                                 const double* c,
-                                 const double* s,
+hipsparseStatus_t hipsparseDroti(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 double*              xVal,
+                                 const int*           xInd,
+                                 double*              y,
+                                 const double*        c,
+                                 const double*        s,
                                  hipsparseIndexBase_t idxBase);
 
 /* Description: Scatters elements listed in xInd from a sparse vector x
    into a dense vector y. */
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseSsctr(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const float* xVal,
-                                 const int* xInd,
-                                 float* y,
+hipsparseStatus_t hipsparseSsctr(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 const float*         xVal,
+                                 const int*           xInd,
+                                 float*               y,
                                  hipsparseIndexBase_t idxBase);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseDsctr(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const double* xVal,
-                                 const int* xInd,
-                                 double* y,
+hipsparseStatus_t hipsparseDsctr(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 const double*        xVal,
+                                 const int*           xInd,
+                                 double*              y,
                                  hipsparseIndexBase_t idxBase);
 
 /* --- Sparse Level 2 routines --- */
@@ -317,244 +317,244 @@ hipsparseStatus_t hipsparseDsctr(hipsparseHandle_t handle,
 /* Description: Matrix-vector multiplication  y = alpha * op(A) * x  + beta * y,
    where A is a sparse matrix in CSR storage format, x and y are dense vectors. */
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseScsrmv(hipsparseHandle_t handle,
-                                  hipsparseOperation_t transA,
-                                  int m,
-                                  int n,
-                                  int nnz,
-                                  const float* alpha,
+hipsparseStatus_t hipsparseScsrmv(hipsparseHandle_t         handle,
+                                  hipsparseOperation_t      transA,
+                                  int                       m,
+                                  int                       n,
+                                  int                       nnz,
+                                  const float*              alpha,
                                   const hipsparseMatDescr_t descrA,
-                                  const float* csrSortedValA,
-                                  const int* csrSortedRowPtrA,
-                                  const int* csrSortedColIndA,
-                                  const float* x,
-                                  const float* beta,
-                                  float* y);
+                                  const float*              csrSortedValA,
+                                  const int*                csrSortedRowPtrA,
+                                  const int*                csrSortedColIndA,
+                                  const float*              x,
+                                  const float*              beta,
+                                  float*                    y);
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseDcsrmv(hipsparseHandle_t handle,
-                                  hipsparseOperation_t transA,
-                                  int m,
-                                  int n,
-                                  int nnz,
-                                  const double* alpha,
+hipsparseStatus_t hipsparseDcsrmv(hipsparseHandle_t         handle,
+                                  hipsparseOperation_t      transA,
+                                  int                       m,
+                                  int                       n,
+                                  int                       nnz,
+                                  const double*             alpha,
                                   const hipsparseMatDescr_t descrA,
-                                  const double* csrSortedValA,
-                                  const int* csrSortedRowPtrA,
-                                  const int* csrSortedColIndA,
-                                  const double* x,
-                                  const double* beta,
-                                  double* y);
+                                  const double*             csrSortedValA,
+                                  const int*                csrSortedRowPtrA,
+                                  const int*                csrSortedColIndA,
+                                  const double*             x,
+                                  const double*             beta,
+                                  double*                   y);
 
 /* Description: Solution of triangular linear system op(A) * x = alpha * f,
    where A is a sparse matrix in CSR storage format, x and f are dense vectors. */
 HIPSPARSE_EXPORT
 hipsparseStatus_t
-hipsparseXcsrsv2_zeroPivot(hipsparseHandle_t handle, csrsv2Info_t info, int* position);
+    hipsparseXcsrsv2_zeroPivot(hipsparseHandle_t handle, csrsv2Info_t info, int* position);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseScsrsv2_bufferSize(hipsparseHandle_t handle,
-                                              hipsparseOperation_t transA,
-                                              int m,
-                                              int nnz,
+hipsparseStatus_t hipsparseScsrsv2_bufferSize(hipsparseHandle_t         handle,
+                                              hipsparseOperation_t      transA,
+                                              int                       m,
+                                              int                       nnz,
                                               const hipsparseMatDescr_t descrA,
-                                              float* csrSortedValA,
-                                              const int* csrSortedRowPtrA,
-                                              const int* csrSortedColIndA,
-                                              csrsv2Info_t info,
-                                              int* pBufferSizeInBytes);
+                                              float*                    csrSortedValA,
+                                              const int*                csrSortedRowPtrA,
+                                              const int*                csrSortedColIndA,
+                                              csrsv2Info_t              info,
+                                              int*                      pBufferSizeInBytes);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseDcsrsv2_bufferSize(hipsparseHandle_t handle,
-                                              hipsparseOperation_t transA,
-                                              int m,
-                                              int nnz,
+hipsparseStatus_t hipsparseDcsrsv2_bufferSize(hipsparseHandle_t         handle,
+                                              hipsparseOperation_t      transA,
+                                              int                       m,
+                                              int                       nnz,
                                               const hipsparseMatDescr_t descrA,
-                                              double* csrSortedValA,
-                                              const int* csrSortedRowPtrA,
-                                              const int* csrSortedColIndA,
-                                              csrsv2Info_t info,
-                                              int* pBufferSizeInBytes);
+                                              double*                   csrSortedValA,
+                                              const int*                csrSortedRowPtrA,
+                                              const int*                csrSortedColIndA,
+                                              csrsv2Info_t              info,
+                                              int*                      pBufferSizeInBytes);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseScsrsv2_bufferSizeExt(hipsparseHandle_t handle,
-                                                 hipsparseOperation_t transA,
-                                                 int m,
-                                                 int nnz,
+hipsparseStatus_t hipsparseScsrsv2_bufferSizeExt(hipsparseHandle_t         handle,
+                                                 hipsparseOperation_t      transA,
+                                                 int                       m,
+                                                 int                       nnz,
                                                  const hipsparseMatDescr_t descrA,
-                                                 float* csrSortedValA,
-                                                 const int* csrSortedRowPtrA,
-                                                 const int* csrSortedColIndA,
-                                                 csrsv2Info_t info,
-                                                 size_t* pBufferSize);
+                                                 float*                    csrSortedValA,
+                                                 const int*                csrSortedRowPtrA,
+                                                 const int*                csrSortedColIndA,
+                                                 csrsv2Info_t              info,
+                                                 size_t*                   pBufferSize);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseDcsrsv2_bufferSizeExt(hipsparseHandle_t handle,
-                                                 hipsparseOperation_t transA,
-                                                 int m,
-                                                 int nnz,
+hipsparseStatus_t hipsparseDcsrsv2_bufferSizeExt(hipsparseHandle_t         handle,
+                                                 hipsparseOperation_t      transA,
+                                                 int                       m,
+                                                 int                       nnz,
                                                  const hipsparseMatDescr_t descrA,
-                                                 double* csrSortedValA,
-                                                 const int* csrSortedRowPtrA,
-                                                 const int* csrSortedColIndA,
-                                                 csrsv2Info_t info,
-                                                 size_t* pBufferSize);
+                                                 double*                   csrSortedValA,
+                                                 const int*                csrSortedRowPtrA,
+                                                 const int*                csrSortedColIndA,
+                                                 csrsv2Info_t              info,
+                                                 size_t*                   pBufferSize);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseScsrsv2_analysis(hipsparseHandle_t handle,
-                                            hipsparseOperation_t transA,
-                                            int m,
-                                            int nnz,
+hipsparseStatus_t hipsparseScsrsv2_analysis(hipsparseHandle_t         handle,
+                                            hipsparseOperation_t      transA,
+                                            int                       m,
+                                            int                       nnz,
                                             const hipsparseMatDescr_t descrA,
-                                            const float* csrSortedValA,
-                                            const int* csrSortedRowPtrA,
-                                            const int* csrSortedColIndA,
-                                            csrsv2Info_t info,
-                                            hipsparseSolvePolicy_t policy,
-                                            void* pBuffer);
+                                            const float*              csrSortedValA,
+                                            const int*                csrSortedRowPtrA,
+                                            const int*                csrSortedColIndA,
+                                            csrsv2Info_t              info,
+                                            hipsparseSolvePolicy_t    policy,
+                                            void*                     pBuffer);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseDcsrsv2_analysis(hipsparseHandle_t handle,
-                                            hipsparseOperation_t transA,
-                                            int m,
-                                            int nnz,
+hipsparseStatus_t hipsparseDcsrsv2_analysis(hipsparseHandle_t         handle,
+                                            hipsparseOperation_t      transA,
+                                            int                       m,
+                                            int                       nnz,
                                             const hipsparseMatDescr_t descrA,
-                                            const double* csrSortedValA,
-                                            const int* csrSortedRowPtrA,
-                                            const int* csrSortedColIndA,
-                                            csrsv2Info_t info,
-                                            hipsparseSolvePolicy_t policy,
-                                            void* pBuffer);
+                                            const double*             csrSortedValA,
+                                            const int*                csrSortedRowPtrA,
+                                            const int*                csrSortedColIndA,
+                                            csrsv2Info_t              info,
+                                            hipsparseSolvePolicy_t    policy,
+                                            void*                     pBuffer);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseScsrsv2_solve(hipsparseHandle_t handle,
-                                         hipsparseOperation_t transA,
-                                         int m,
-                                         int nnz,
-                                         const float* alpha,
+hipsparseStatus_t hipsparseScsrsv2_solve(hipsparseHandle_t         handle,
+                                         hipsparseOperation_t      transA,
+                                         int                       m,
+                                         int                       nnz,
+                                         const float*              alpha,
                                          const hipsparseMatDescr_t descrA,
-                                         const float* csrSortedValA,
-                                         const int* csrSortedRowPtrA,
-                                         const int* csrSortedColIndA,
-                                         csrsv2Info_t info,
-                                         const float* f,
-                                         float* x,
-                                         hipsparseSolvePolicy_t policy,
-                                         void* pBuffer);
+                                         const float*              csrSortedValA,
+                                         const int*                csrSortedRowPtrA,
+                                         const int*                csrSortedColIndA,
+                                         csrsv2Info_t              info,
+                                         const float*              f,
+                                         float*                    x,
+                                         hipsparseSolvePolicy_t    policy,
+                                         void*                     pBuffer);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseDcsrsv2_solve(hipsparseHandle_t handle,
-                                         hipsparseOperation_t transA,
-                                         int m,
-                                         int nnz,
-                                         const double* alpha,
+hipsparseStatus_t hipsparseDcsrsv2_solve(hipsparseHandle_t         handle,
+                                         hipsparseOperation_t      transA,
+                                         int                       m,
+                                         int                       nnz,
+                                         const double*             alpha,
                                          const hipsparseMatDescr_t descrA,
-                                         const double* csrSortedValA,
-                                         const int* csrSortedRowPtrA,
-                                         const int* csrSortedColIndA,
-                                         csrsv2Info_t info,
-                                         const double* f,
-                                         double* x,
-                                         hipsparseSolvePolicy_t policy,
-                                         void* pBuffer);
+                                         const double*             csrSortedValA,
+                                         const int*                csrSortedRowPtrA,
+                                         const int*                csrSortedColIndA,
+                                         csrsv2Info_t              info,
+                                         const double*             f,
+                                         double*                   x,
+                                         hipsparseSolvePolicy_t    policy,
+                                         void*                     pBuffer);
 
 /* Description: Matrix-vector multiplication  y = alpha * op(A) * x  + beta * y,
    where A is a sparse matrix in HYB storage format, x and y are dense vectors. */
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseShybmv(hipsparseHandle_t handle,
-                                  hipsparseOperation_t transA,
-                                  const float* alpha,
+hipsparseStatus_t hipsparseShybmv(hipsparseHandle_t         handle,
+                                  hipsparseOperation_t      transA,
+                                  const float*              alpha,
                                   const hipsparseMatDescr_t descrA,
-                                  const hipsparseHybMat_t hybA,
-                                  const float* x,
-                                  const float* beta,
-                                  float* y);
+                                  const hipsparseHybMat_t   hybA,
+                                  const float*              x,
+                                  const float*              beta,
+                                  float*                    y);
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseDhybmv(hipsparseHandle_t handle,
-                                  hipsparseOperation_t transA,
-                                  const double* alpha,
+hipsparseStatus_t hipsparseDhybmv(hipsparseHandle_t         handle,
+                                  hipsparseOperation_t      transA,
+                                  const double*             alpha,
                                   const hipsparseMatDescr_t descrA,
-                                  const hipsparseHybMat_t hybA,
-                                  const double* x,
-                                  const double* beta,
-                                  double* y);
+                                  const hipsparseHybMat_t   hybA,
+                                  const double*             x,
+                                  const double*             beta,
+                                  double*                   y);
 
 /* --- Sparse Level 3 routines --- */
 
 /* Description: Matrix-matrix multiplication C = alpha * op(A) * B + beta * C,
    where A is a sparse matrix in CSR storage format, B and C are dense matrices. */
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseScsrmm(hipsparseHandle_t handle,
-                                  hipsparseOperation_t transA,
-                                  int m,
-                                  int n,
-                                  int k,
-                                  int nnz,
-                                  const float* alpha,
+hipsparseStatus_t hipsparseScsrmm(hipsparseHandle_t         handle,
+                                  hipsparseOperation_t      transA,
+                                  int                       m,
+                                  int                       n,
+                                  int                       k,
+                                  int                       nnz,
+                                  const float*              alpha,
                                   const hipsparseMatDescr_t descrA,
-                                  const float* csrSortedValA,
-                                  const int* csrSortedRowPtrA,
-                                  const int* csrSortedColIndA,
-                                  const float* B,
-                                  int ldb,
-                                  const float* beta,
-                                  float* C,
-                                  int ldc);
+                                  const float*              csrSortedValA,
+                                  const int*                csrSortedRowPtrA,
+                                  const int*                csrSortedColIndA,
+                                  const float*              B,
+                                  int                       ldb,
+                                  const float*              beta,
+                                  float*                    C,
+                                  int                       ldc);
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseDcsrmm(hipsparseHandle_t handle,
-                                  hipsparseOperation_t transA,
-                                  int m,
-                                  int n,
-                                  int k,
-                                  int nnz,
-                                  const double* alpha,
+hipsparseStatus_t hipsparseDcsrmm(hipsparseHandle_t         handle,
+                                  hipsparseOperation_t      transA,
+                                  int                       m,
+                                  int                       n,
+                                  int                       k,
+                                  int                       nnz,
+                                  const double*             alpha,
                                   const hipsparseMatDescr_t descrA,
-                                  const double* csrSortedValA,
-                                  const int* csrSortedRowPtrA,
-                                  const int* csrSortedColIndA,
-                                  const double* B,
-                                  int ldb,
-                                  const double* beta,
-                                  double* C,
-                                  int ldc);
+                                  const double*             csrSortedValA,
+                                  const int*                csrSortedRowPtrA,
+                                  const int*                csrSortedColIndA,
+                                  const double*             B,
+                                  int                       ldb,
+                                  const double*             beta,
+                                  double*                   C,
+                                  int                       ldc);
 
 /* Description: Matrix-matrix multiplication C = alpha * op(A) * op(B) + beta * C,
    where A is a sparse matrix in CSR storage format, B and C are dense matrices. */
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseScsrmm2(hipsparseHandle_t handle,
-                                   hipsparseOperation_t transA,
-                                   hipsparseOperation_t transB,
-                                   int m,
-                                   int n,
-                                   int k,
-                                   int nnz,
-                                   const float* alpha,
+hipsparseStatus_t hipsparseScsrmm2(hipsparseHandle_t         handle,
+                                   hipsparseOperation_t      transA,
+                                   hipsparseOperation_t      transB,
+                                   int                       m,
+                                   int                       n,
+                                   int                       k,
+                                   int                       nnz,
+                                   const float*              alpha,
                                    const hipsparseMatDescr_t descrA,
-                                   const float* csrSortedValA,
-                                   const int* csrSortedRowPtrA,
-                                   const int* csrSortedColIndA,
-                                   const float* B,
-                                   int ldb,
-                                   const float* beta,
-                                   float* C,
-                                   int ldc);
+                                   const float*              csrSortedValA,
+                                   const int*                csrSortedRowPtrA,
+                                   const int*                csrSortedColIndA,
+                                   const float*              B,
+                                   int                       ldb,
+                                   const float*              beta,
+                                   float*                    C,
+                                   int                       ldc);
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseDcsrmm2(hipsparseHandle_t handle,
-                                   hipsparseOperation_t transA,
-                                   hipsparseOperation_t transB,
-                                   int m,
-                                   int n,
-                                   int k,
-                                   int nnz,
-                                   const double* alpha,
+hipsparseStatus_t hipsparseDcsrmm2(hipsparseHandle_t         handle,
+                                   hipsparseOperation_t      transA,
+                                   hipsparseOperation_t      transB,
+                                   int                       m,
+                                   int                       n,
+                                   int                       k,
+                                   int                       nnz,
+                                   const double*             alpha,
                                    const hipsparseMatDescr_t descrA,
-                                   const double* csrSortedValA,
-                                   const int* csrSortedRowPtrA,
-                                   const int* csrSortedColIndA,
-                                   const double* B,
-                                   int ldb,
-                                   const double* beta,
-                                   double* C,
-                                   int ldc);
+                                   const double*             csrSortedValA,
+                                   const int*                csrSortedRowPtrA,
+                                   const int*                csrSortedColIndA,
+                                   const double*             B,
+                                   int                       ldb,
+                                   const double*             beta,
+                                   double*                   C,
+                                   int                       ldc);
 
 /* --- Preconditioners --- */
 
@@ -562,179 +562,179 @@ hipsparseStatus_t hipsparseDcsrmm2(hipsparseHandle_t handle,
    of the matrix A stored in CSR format. */
 HIPSPARSE_EXPORT
 hipsparseStatus_t
-hipsparseXcsrilu02_zeroPivot(hipsparseHandle_t handle, csrilu02Info_t info, int* position);
+    hipsparseXcsrilu02_zeroPivot(hipsparseHandle_t handle, csrilu02Info_t info, int* position);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseScsrilu02_bufferSize(hipsparseHandle_t handle,
-                                                int m,
-                                                int nnz,
+hipsparseStatus_t hipsparseScsrilu02_bufferSize(hipsparseHandle_t         handle,
+                                                int                       m,
+                                                int                       nnz,
                                                 const hipsparseMatDescr_t descrA,
-                                                float* csrSortedValA,
-                                                const int* csrSortedRowPtrA,
-                                                const int* csrSortedColIndA,
-                                                csrilu02Info_t info,
-                                                int* pBufferSizeInBytes);
+                                                float*                    csrSortedValA,
+                                                const int*                csrSortedRowPtrA,
+                                                const int*                csrSortedColIndA,
+                                                csrilu02Info_t            info,
+                                                int*                      pBufferSizeInBytes);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseDcsrilu02_bufferSize(hipsparseHandle_t handle,
-                                                int m,
-                                                int nnz,
+hipsparseStatus_t hipsparseDcsrilu02_bufferSize(hipsparseHandle_t         handle,
+                                                int                       m,
+                                                int                       nnz,
                                                 const hipsparseMatDescr_t descrA,
-                                                double* csrSortedValA,
-                                                const int* csrSortedRowPtrA,
-                                                const int* csrSortedColIndA,
-                                                csrilu02Info_t info,
-                                                int* pBufferSizeInBytes);
+                                                double*                   csrSortedValA,
+                                                const int*                csrSortedRowPtrA,
+                                                const int*                csrSortedColIndA,
+                                                csrilu02Info_t            info,
+                                                int*                      pBufferSizeInBytes);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseScsrilu02_bufferSizeExt(hipsparseHandle_t handle,
-                                                   int m,
-                                                   int nnz,
+hipsparseStatus_t hipsparseScsrilu02_bufferSizeExt(hipsparseHandle_t         handle,
+                                                   int                       m,
+                                                   int                       nnz,
                                                    const hipsparseMatDescr_t descrA,
-                                                   float* csrSortedValA,
-                                                   const int* csrSortedRowPtrA,
-                                                   const int* csrSortedColIndA,
-                                                   csrilu02Info_t info,
-                                                   size_t* pBufferSize);
+                                                   float*                    csrSortedValA,
+                                                   const int*                csrSortedRowPtrA,
+                                                   const int*                csrSortedColIndA,
+                                                   csrilu02Info_t            info,
+                                                   size_t*                   pBufferSize);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseDcsrilu02_bufferSizeExt(hipsparseHandle_t handle,
-                                                   int m,
-                                                   int nnz,
+hipsparseStatus_t hipsparseDcsrilu02_bufferSizeExt(hipsparseHandle_t         handle,
+                                                   int                       m,
+                                                   int                       nnz,
                                                    const hipsparseMatDescr_t descrA,
-                                                   double* csrSortedValA,
-                                                   const int* csrSortedRowPtrA,
-                                                   const int* csrSortedColIndA,
-                                                   csrilu02Info_t info,
-                                                   size_t* pBufferSize);
+                                                   double*                   csrSortedValA,
+                                                   const int*                csrSortedRowPtrA,
+                                                   const int*                csrSortedColIndA,
+                                                   csrilu02Info_t            info,
+                                                   size_t*                   pBufferSize);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseScsrilu02_analysis(hipsparseHandle_t handle,
-                                              int m,
-                                              int nnz,
+hipsparseStatus_t hipsparseScsrilu02_analysis(hipsparseHandle_t         handle,
+                                              int                       m,
+                                              int                       nnz,
                                               const hipsparseMatDescr_t descrA,
-                                              const float* csrSortedValA,
-                                              const int* csrSortedRowPtrA,
-                                              const int* csrSortedColIndA,
-                                              csrilu02Info_t info,
-                                              hipsparseSolvePolicy_t policy,
-                                              void* pBuffer);
+                                              const float*              csrSortedValA,
+                                              const int*                csrSortedRowPtrA,
+                                              const int*                csrSortedColIndA,
+                                              csrilu02Info_t            info,
+                                              hipsparseSolvePolicy_t    policy,
+                                              void*                     pBuffer);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseDcsrilu02_analysis(hipsparseHandle_t handle,
-                                              int m,
-                                              int nnz,
+hipsparseStatus_t hipsparseDcsrilu02_analysis(hipsparseHandle_t         handle,
+                                              int                       m,
+                                              int                       nnz,
                                               const hipsparseMatDescr_t descrA,
-                                              const double* csrSortedValA,
-                                              const int* csrSortedRowPtrA,
-                                              const int* csrSortedColIndA,
-                                              csrilu02Info_t info,
-                                              hipsparseSolvePolicy_t policy,
-                                              void* pBuffer);
+                                              const double*             csrSortedValA,
+                                              const int*                csrSortedRowPtrA,
+                                              const int*                csrSortedColIndA,
+                                              csrilu02Info_t            info,
+                                              hipsparseSolvePolicy_t    policy,
+                                              void*                     pBuffer);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseScsrilu02(hipsparseHandle_t handle,
-                                     int m,
-                                     int nnz,
+hipsparseStatus_t hipsparseScsrilu02(hipsparseHandle_t         handle,
+                                     int                       m,
+                                     int                       nnz,
                                      const hipsparseMatDescr_t descrA,
-                                     float* csrSortedValA_valM,
+                                     float*                    csrSortedValA_valM,
                                      /* matrix A values are updated inplace
                                         to be the preconditioner M values */
-                                     const int* csrSortedRowPtrA,
-                                     const int* csrSortedColIndA,
-                                     csrilu02Info_t info,
+                                     const int*             csrSortedRowPtrA,
+                                     const int*             csrSortedColIndA,
+                                     csrilu02Info_t         info,
                                      hipsparseSolvePolicy_t policy,
-                                     void* pBuffer);
+                                     void*                  pBuffer);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseDcsrilu02(hipsparseHandle_t handle,
-                                     int m,
-                                     int nnz,
+hipsparseStatus_t hipsparseDcsrilu02(hipsparseHandle_t         handle,
+                                     int                       m,
+                                     int                       nnz,
                                      const hipsparseMatDescr_t descrA,
-                                     double* csrSortedValA_valM,
+                                     double*                   csrSortedValA_valM,
                                      /* matrix A values are updated inplace
                                         to be the preconditioner M values */
-                                     const int* csrSortedRowPtrA,
-                                     const int* csrSortedColIndA,
-                                     csrilu02Info_t info,
+                                     const int*             csrSortedRowPtrA,
+                                     const int*             csrSortedColIndA,
+                                     csrilu02Info_t         info,
                                      hipsparseSolvePolicy_t policy,
-                                     void* pBuffer);
+                                     void*                  pBuffer);
 
 /* --- Sparse Format Conversion --- */
 
 /* Description: This routine converts a sparse matrix in CSR storage format
    to a sparse matrix in COO storage format. */
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseXcsr2coo(hipsparseHandle_t handle,
-                                    const int* csrRowPtr,
-                                    int nnz,
-                                    int m,
-                                    int* cooRowInd,
+hipsparseStatus_t hipsparseXcsr2coo(hipsparseHandle_t    handle,
+                                    const int*           csrRowPtr,
+                                    int                  nnz,
+                                    int                  m,
+                                    int*                 cooRowInd,
                                     hipsparseIndexBase_t idxBase);
 
 /* Description: This routine converts a sparse matrix in CSR storage format
    to a sparse matrix in CSC storage format. */
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseScsr2csc(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
-                                    int nnz,
-                                    const float* csrSortedVal,
-                                    const int* csrSortedRowPtr,
-                                    const int* csrSortedColInd,
-                                    float* cscSortedVal,
-                                    int* cscSortedRowInd,
-                                    int* cscSortedColPtr,
-                                    hipsparseAction_t copyValues,
+hipsparseStatus_t hipsparseScsr2csc(hipsparseHandle_t    handle,
+                                    int                  m,
+                                    int                  n,
+                                    int                  nnz,
+                                    const float*         csrSortedVal,
+                                    const int*           csrSortedRowPtr,
+                                    const int*           csrSortedColInd,
+                                    float*               cscSortedVal,
+                                    int*                 cscSortedRowInd,
+                                    int*                 cscSortedColPtr,
+                                    hipsparseAction_t    copyValues,
                                     hipsparseIndexBase_t idxBase);
 
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseDcsr2csc(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
-                                    int nnz,
-                                    const double* csrSortedVal,
-                                    const int* csrSortedRowPtr,
-                                    const int* csrSortedColInd,
-                                    double* cscSortedVal,
-                                    int* cscSortedRowInd,
-                                    int* cscSortedColPtr,
-                                    hipsparseAction_t copyValues,
+hipsparseStatus_t hipsparseDcsr2csc(hipsparseHandle_t    handle,
+                                    int                  m,
+                                    int                  n,
+                                    int                  nnz,
+                                    const double*        csrSortedVal,
+                                    const int*           csrSortedRowPtr,
+                                    const int*           csrSortedColInd,
+                                    double*              cscSortedVal,
+                                    int*                 cscSortedRowInd,
+                                    int*                 cscSortedColPtr,
+                                    hipsparseAction_t    copyValues,
                                     hipsparseIndexBase_t idxBase);
 
 /* Description: This routine converts a sparse matrix in CSR storage format
    to a sparse matrix in HYB storage format. */
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseScsr2hyb(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
+hipsparseStatus_t hipsparseScsr2hyb(hipsparseHandle_t         handle,
+                                    int                       m,
+                                    int                       n,
                                     const hipsparseMatDescr_t descrA,
-                                    const float* csrSortedValA,
-                                    const int* csrSortedRowPtrA,
-                                    const int* csrSortedColIndA,
-                                    hipsparseHybMat_t hybA,
-                                    int userEllWidth,
-                                    hipsparseHybPartition_t partitionType);
+                                    const float*              csrSortedValA,
+                                    const int*                csrSortedRowPtrA,
+                                    const int*                csrSortedColIndA,
+                                    hipsparseHybMat_t         hybA,
+                                    int                       userEllWidth,
+                                    hipsparseHybPartition_t   partitionType);
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseDcsr2hyb(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
+hipsparseStatus_t hipsparseDcsr2hyb(hipsparseHandle_t         handle,
+                                    int                       m,
+                                    int                       n,
                                     const hipsparseMatDescr_t descrA,
-                                    const double* csrSortedValA,
-                                    const int* csrSortedRowPtrA,
-                                    const int* csrSortedColIndA,
-                                    hipsparseHybMat_t hybA,
-                                    int userEllWidth,
-                                    hipsparseHybPartition_t partitionType);
+                                    const double*             csrSortedValA,
+                                    const int*                csrSortedRowPtrA,
+                                    const int*                csrSortedColIndA,
+                                    hipsparseHybMat_t         hybA,
+                                    int                       userEllWidth,
+                                    hipsparseHybPartition_t   partitionType);
 
 /* Description: This routine converts a sparse matrix in COO storage format
    to a sparse matrix in CSR storage format. */
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseXcoo2csr(hipsparseHandle_t handle,
-                                    const int* cooRowInd,
-                                    int nnz,
-                                    int m,
-                                    int* csrRowPtr,
+hipsparseStatus_t hipsparseXcoo2csr(hipsparseHandle_t    handle,
+                                    const int*           cooRowInd,
+                                    int                  nnz,
+                                    int                  m,
+                                    int*                 csrRowPtr,
                                     hipsparseIndexBase_t idxBase);
 
 /* Description: This routine creates an identity map. */
@@ -744,56 +744,56 @@ hipsparseStatus_t hipsparseCreateIdentityPermutation(hipsparseHandle_t handle, i
 /* Description: This routine computes the required buffer size for csrsort. */
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseXcsrsort_bufferSizeExt(hipsparseHandle_t handle,
-                                                  int m,
-                                                  int n,
-                                                  int nnz,
-                                                  const int* csrRowPtr,
-                                                  const int* csrColInd,
-                                                  size_t* pBufferSizeInBytes);
+                                                  int               m,
+                                                  int               n,
+                                                  int               nnz,
+                                                  const int*        csrRowPtr,
+                                                  const int*        csrColInd,
+                                                  size_t*           pBufferSizeInBytes);
 
 /* Description: This routine sorts CSR format. */
 HIPSPARSE_EXPORT
-hipsparseStatus_t hipsparseXcsrsort(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
-                                    int nnz,
+hipsparseStatus_t hipsparseXcsrsort(hipsparseHandle_t         handle,
+                                    int                       m,
+                                    int                       n,
+                                    int                       nnz,
                                     const hipsparseMatDescr_t descrA,
-                                    const int* csrRowPtr,
-                                    int* csrColInd,
-                                    int* P,
-                                    void* pBuffer);
+                                    const int*                csrRowPtr,
+                                    int*                      csrColInd,
+                                    int*                      P,
+                                    void*                     pBuffer);
 
 /* Description: This routine computes the required buffer size for coosort. */
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseXcoosort_bufferSizeExt(hipsparseHandle_t handle,
-                                                  int m,
-                                                  int n,
-                                                  int nnz,
-                                                  const int* cooRows,
-                                                  const int* cooCols,
-                                                  size_t* pBufferSizeInBytes);
+                                                  int               m,
+                                                  int               n,
+                                                  int               nnz,
+                                                  const int*        cooRows,
+                                                  const int*        cooCols,
+                                                  size_t*           pBufferSizeInBytes);
 
 /* Description: This routine sorts COO format by rows. */
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseXcoosortByRow(hipsparseHandle_t handle,
-                                         int m,
-                                         int n,
-                                         int nnz,
-                                         int* cooRows,
-                                         int* cooCols,
-                                         int* P,
-                                         void* pBuffer);
+                                         int               m,
+                                         int               n,
+                                         int               nnz,
+                                         int*              cooRows,
+                                         int*              cooCols,
+                                         int*              P,
+                                         void*             pBuffer);
 
 /* Description: This routine sorts COO format by columns. */
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseXcoosortByColumn(hipsparseHandle_t handle,
-                                            int m,
-                                            int n,
-                                            int nnz,
-                                            int* cooRows,
-                                            int* cooCols,
-                                            int* P,
-                                            void* pBuffer);
+                                            int               m,
+                                            int               n,
+                                            int               nnz,
+                                            int*              cooRows,
+                                            int*              cooCols,
+                                            int*              P,
+                                            void*             pBuffer);
 
 #ifdef __cplusplus
 }

--- a/library/src/hcc_detail/hipsparse.cpp
+++ b/library/src/hcc_detail/hipsparse.cpp
@@ -23,9 +23,9 @@
 
 #include "hipsparse.h"
 
+#include <hip/hip_runtime_api.h>
 #include <rocsparse.h>
 #include <stdio.h>
-#include <hip/hip_runtime_api.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -62,16 +62,23 @@ hipsparseStatus_t hipErrorToHIPSPARSEStatus(hipError_t status)
 {
     switch(status)
     {
-    case hipSuccess: return HIPSPARSE_STATUS_SUCCESS;
+    case hipSuccess:
+        return HIPSPARSE_STATUS_SUCCESS;
     case hipErrorMemoryAllocation:
-    case hipErrorLaunchOutOfResources: return HIPSPARSE_STATUS_ALLOC_FAILED;
-    case hipErrorInvalidDevicePointer: return HIPSPARSE_STATUS_INVALID_VALUE;
+    case hipErrorLaunchOutOfResources:
+        return HIPSPARSE_STATUS_ALLOC_FAILED;
+    case hipErrorInvalidDevicePointer:
+        return HIPSPARSE_STATUS_INVALID_VALUE;
     case hipErrorInvalidDevice:
-    case hipErrorInvalidResourceHandle: return HIPSPARSE_STATUS_NOT_INITIALIZED;
-    case hipErrorInvalidValue: return HIPSPARSE_STATUS_INVALID_VALUE;
+    case hipErrorInvalidResourceHandle:
+        return HIPSPARSE_STATUS_NOT_INITIALIZED;
+    case hipErrorInvalidValue:
+        return HIPSPARSE_STATUS_INVALID_VALUE;
     case hipErrorNoDevice:
-    case hipErrorUnknown: return HIPSPARSE_STATUS_INTERNAL_ERROR;
-    default: return HIPSPARSE_STATUS_INTERNAL_ERROR;
+    case hipErrorUnknown:
+        return HIPSPARSE_STATUS_INTERNAL_ERROR;
+    default:
+        return HIPSPARSE_STATUS_INTERNAL_ERROR;
     }
 }
 
@@ -79,17 +86,28 @@ hipsparseStatus_t rocSPARSEStatusToHIPStatus(rocsparse_status_ status)
 {
     switch(status)
     {
-    case rocsparse_status_success: return HIPSPARSE_STATUS_SUCCESS;
-    case rocsparse_status_invalid_handle: return HIPSPARSE_STATUS_NOT_INITIALIZED;
-    case rocsparse_status_not_implemented: return HIPSPARSE_STATUS_INTERNAL_ERROR;
-    case rocsparse_status_invalid_pointer: return HIPSPARSE_STATUS_INVALID_VALUE;
-    case rocsparse_status_invalid_size: return HIPSPARSE_STATUS_INVALID_VALUE;
-    case rocsparse_status_memory_error: return HIPSPARSE_STATUS_ALLOC_FAILED;
-    case rocsparse_status_internal_error: return HIPSPARSE_STATUS_INTERNAL_ERROR;
-    case rocsparse_status_invalid_value: return HIPSPARSE_STATUS_INVALID_VALUE;
-    case rocsparse_status_arch_mismatch: return HIPSPARSE_STATUS_ARCH_MISMATCH;
-    case rocsparse_status_zero_pivot: return HIPSPARSE_STATUS_ZERO_PIVOT;
-    default: throw "Non existent rocsparse_status";
+    case rocsparse_status_success:
+        return HIPSPARSE_STATUS_SUCCESS;
+    case rocsparse_status_invalid_handle:
+        return HIPSPARSE_STATUS_NOT_INITIALIZED;
+    case rocsparse_status_not_implemented:
+        return HIPSPARSE_STATUS_INTERNAL_ERROR;
+    case rocsparse_status_invalid_pointer:
+        return HIPSPARSE_STATUS_INVALID_VALUE;
+    case rocsparse_status_invalid_size:
+        return HIPSPARSE_STATUS_INVALID_VALUE;
+    case rocsparse_status_memory_error:
+        return HIPSPARSE_STATUS_ALLOC_FAILED;
+    case rocsparse_status_internal_error:
+        return HIPSPARSE_STATUS_INTERNAL_ERROR;
+    case rocsparse_status_invalid_value:
+        return HIPSPARSE_STATUS_INVALID_VALUE;
+    case rocsparse_status_arch_mismatch:
+        return HIPSPARSE_STATUS_ARCH_MISMATCH;
+    case rocsparse_status_zero_pivot:
+        return HIPSPARSE_STATUS_ZERO_PIVOT;
+    default:
+        throw "Non existent rocsparse_status";
     }
 }
 
@@ -97,9 +115,12 @@ rocsparse_pointer_mode_ hipPtrModeToHCCPtrMode(hipsparsePointerMode_t mode)
 {
     switch(mode)
     {
-    case HIPSPARSE_POINTER_MODE_HOST: return rocsparse_pointer_mode_host;
-    case HIPSPARSE_POINTER_MODE_DEVICE: return rocsparse_pointer_mode_device;
-    default: throw "Non existent hipsparsePointerMode_t";
+    case HIPSPARSE_POINTER_MODE_HOST:
+        return rocsparse_pointer_mode_host;
+    case HIPSPARSE_POINTER_MODE_DEVICE:
+        return rocsparse_pointer_mode_device;
+    default:
+        throw "Non existent hipsparsePointerMode_t";
     }
 }
 
@@ -107,9 +128,12 @@ hipsparsePointerMode_t HCCPtrModeToHIPPtrMode(rocsparse_pointer_mode_ mode)
 {
     switch(mode)
     {
-    case rocsparse_pointer_mode_host: return HIPSPARSE_POINTER_MODE_HOST;
-    case rocsparse_pointer_mode_device: return HIPSPARSE_POINTER_MODE_DEVICE;
-    default: throw "Non existent rocsparse_pointer_mode";
+    case rocsparse_pointer_mode_host:
+        return HIPSPARSE_POINTER_MODE_HOST;
+    case rocsparse_pointer_mode_device:
+        return HIPSPARSE_POINTER_MODE_DEVICE;
+    default:
+        throw "Non existent rocsparse_pointer_mode";
     }
 }
 
@@ -117,9 +141,12 @@ rocsparse_action_ hipActionToHCCAction(hipsparseAction_t action)
 {
     switch(action)
     {
-    case HIPSPARSE_ACTION_SYMBOLIC: return rocsparse_action_symbolic;
-    case HIPSPARSE_ACTION_NUMERIC: return rocsparse_action_numeric;
-    default: throw "Non existent hipsparseAction_t";
+    case HIPSPARSE_ACTION_SYMBOLIC:
+        return rocsparse_action_symbolic;
+    case HIPSPARSE_ACTION_NUMERIC:
+        return rocsparse_action_numeric;
+    default:
+        throw "Non existent hipsparseAction_t";
     }
 }
 
@@ -127,11 +154,16 @@ rocsparse_matrix_type_ hipMatTypeToHCCMatType(hipsparseMatrixType_t type)
 {
     switch(type)
     {
-    case HIPSPARSE_MATRIX_TYPE_GENERAL: return rocsparse_matrix_type_general;
-    case HIPSPARSE_MATRIX_TYPE_SYMMETRIC: return rocsparse_matrix_type_symmetric;
-    case HIPSPARSE_MATRIX_TYPE_HERMITIAN: return rocsparse_matrix_type_hermitian;
-    case HIPSPARSE_MATRIX_TYPE_TRIANGULAR: return rocsparse_matrix_type_triangular;
-    default: throw "Non existent hipsparseMatrixType_t";
+    case HIPSPARSE_MATRIX_TYPE_GENERAL:
+        return rocsparse_matrix_type_general;
+    case HIPSPARSE_MATRIX_TYPE_SYMMETRIC:
+        return rocsparse_matrix_type_symmetric;
+    case HIPSPARSE_MATRIX_TYPE_HERMITIAN:
+        return rocsparse_matrix_type_hermitian;
+    case HIPSPARSE_MATRIX_TYPE_TRIANGULAR:
+        return rocsparse_matrix_type_triangular;
+    default:
+        throw "Non existent hipsparseMatrixType_t";
     }
 }
 
@@ -139,11 +171,16 @@ hipsparseMatrixType_t HCCMatTypeToHIPMatType(rocsparse_matrix_type_ type)
 {
     switch(type)
     {
-    case rocsparse_matrix_type_general: return HIPSPARSE_MATRIX_TYPE_GENERAL;
-    case rocsparse_matrix_type_symmetric: return HIPSPARSE_MATRIX_TYPE_SYMMETRIC;
-    case rocsparse_matrix_type_hermitian: return HIPSPARSE_MATRIX_TYPE_HERMITIAN;
-    case rocsparse_matrix_type_triangular: return HIPSPARSE_MATRIX_TYPE_TRIANGULAR;
-    default: throw "Non existent rocsparse_matrix_type";
+    case rocsparse_matrix_type_general:
+        return HIPSPARSE_MATRIX_TYPE_GENERAL;
+    case rocsparse_matrix_type_symmetric:
+        return HIPSPARSE_MATRIX_TYPE_SYMMETRIC;
+    case rocsparse_matrix_type_hermitian:
+        return HIPSPARSE_MATRIX_TYPE_HERMITIAN;
+    case rocsparse_matrix_type_triangular:
+        return HIPSPARSE_MATRIX_TYPE_TRIANGULAR;
+    default:
+        throw "Non existent rocsparse_matrix_type";
     }
 }
 
@@ -151,9 +188,12 @@ rocsparse_fill_mode_ hipFillModeToHCCFillMode(hipsparseFillMode_t fillMode)
 {
     switch(fillMode)
     {
-    case HIPSPARSE_FILL_MODE_LOWER: return rocsparse_fill_mode_lower;
-    case HIPSPARSE_FILL_MODE_UPPER: return rocsparse_fill_mode_upper;
-    default: throw "Non existent hipsparseFillMode_t";
+    case HIPSPARSE_FILL_MODE_LOWER:
+        return rocsparse_fill_mode_lower;
+    case HIPSPARSE_FILL_MODE_UPPER:
+        return rocsparse_fill_mode_upper;
+    default:
+        throw "Non existent hipsparseFillMode_t";
     }
 }
 
@@ -161,9 +201,12 @@ hipsparseFillMode_t HCCFillModeToHIPFillMode(rocsparse_fill_mode_ fillMode)
 {
     switch(fillMode)
     {
-    case rocsparse_fill_mode_lower: return HIPSPARSE_FILL_MODE_LOWER;
-    case rocsparse_fill_mode_upper: return HIPSPARSE_FILL_MODE_UPPER;
-    default: throw "Non existent rocsparse_fill_mode";
+    case rocsparse_fill_mode_lower:
+        return HIPSPARSE_FILL_MODE_LOWER;
+    case rocsparse_fill_mode_upper:
+        return HIPSPARSE_FILL_MODE_UPPER;
+    default:
+        throw "Non existent rocsparse_fill_mode";
     }
 }
 
@@ -171,9 +214,12 @@ rocsparse_diag_type_ hipDiagTypeToHCCDiagType(hipsparseDiagType_t diagType)
 {
     switch(diagType)
     {
-    case HIPSPARSE_DIAG_TYPE_UNIT: return rocsparse_diag_type_unit;
-    case HIPSPARSE_DIAG_TYPE_NON_UNIT: return rocsparse_diag_type_non_unit;
-    default: throw "Non existent hipsparseDiagType_t";
+    case HIPSPARSE_DIAG_TYPE_UNIT:
+        return rocsparse_diag_type_unit;
+    case HIPSPARSE_DIAG_TYPE_NON_UNIT:
+        return rocsparse_diag_type_non_unit;
+    default:
+        throw "Non existent hipsparseDiagType_t";
     }
 }
 
@@ -181,9 +227,12 @@ hipsparseDiagType_t HCCDiagTypeToHIPDiagType(rocsparse_diag_type_ diagType)
 {
     switch(diagType)
     {
-    case rocsparse_diag_type_unit: return HIPSPARSE_DIAG_TYPE_UNIT;
-    case rocsparse_diag_type_non_unit: return HIPSPARSE_DIAG_TYPE_NON_UNIT;
-    default: throw "Non existent rocsparse_diag_type";
+    case rocsparse_diag_type_unit:
+        return HIPSPARSE_DIAG_TYPE_UNIT;
+    case rocsparse_diag_type_non_unit:
+        return HIPSPARSE_DIAG_TYPE_NON_UNIT;
+    default:
+        throw "Non existent rocsparse_diag_type";
     }
 }
 
@@ -191,9 +240,12 @@ rocsparse_index_base_ hipBaseToHCCBase(hipsparseIndexBase_t base)
 {
     switch(base)
     {
-    case HIPSPARSE_INDEX_BASE_ZERO: return rocsparse_index_base_zero;
-    case HIPSPARSE_INDEX_BASE_ONE: return rocsparse_index_base_one;
-    default: throw "Non existent hipsparseIndexBase_t";
+    case HIPSPARSE_INDEX_BASE_ZERO:
+        return rocsparse_index_base_zero;
+    case HIPSPARSE_INDEX_BASE_ONE:
+        return rocsparse_index_base_one;
+    default:
+        throw "Non existent hipsparseIndexBase_t";
     }
 }
 
@@ -201,9 +253,12 @@ hipsparseIndexBase_t HCCBaseToHIPBase(rocsparse_index_base_ base)
 {
     switch(base)
     {
-    case rocsparse_index_base_zero: return HIPSPARSE_INDEX_BASE_ZERO;
-    case rocsparse_index_base_one: return HIPSPARSE_INDEX_BASE_ONE;
-    default: throw "Non existent rocsparse_index_base_";
+    case rocsparse_index_base_zero:
+        return HIPSPARSE_INDEX_BASE_ZERO;
+    case rocsparse_index_base_one:
+        return HIPSPARSE_INDEX_BASE_ONE;
+    default:
+        throw "Non existent rocsparse_index_base_";
     }
 }
 
@@ -211,10 +266,14 @@ rocsparse_operation_ hipOperationToHCCOperation(hipsparseOperation_t op)
 {
     switch(op)
     {
-    case HIPSPARSE_OPERATION_NON_TRANSPOSE: return rocsparse_operation_none;
-    case HIPSPARSE_OPERATION_TRANSPOSE: return rocsparse_operation_transpose;
-    case HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE: return rocsparse_operation_conjugate_transpose;
-    default: throw "Non existent hipsparseOperation_t";
+    case HIPSPARSE_OPERATION_NON_TRANSPOSE:
+        return rocsparse_operation_none;
+    case HIPSPARSE_OPERATION_TRANSPOSE:
+        return rocsparse_operation_transpose;
+    case HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE:
+        return rocsparse_operation_conjugate_transpose;
+    default:
+        throw "Non existent hipsparseOperation_t";
     }
 }
 
@@ -222,10 +281,14 @@ hipsparseOperation_t HCCOperationToHIPOperation(rocsparse_operation_ op)
 {
     switch(op)
     {
-    case rocsparse_operation_none: return HIPSPARSE_OPERATION_NON_TRANSPOSE;
-    case rocsparse_operation_transpose: return HIPSPARSE_OPERATION_TRANSPOSE;
-    case rocsparse_operation_conjugate_transpose: return HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE;
-    default: throw "Non existent rocsparse_operation_";
+    case rocsparse_operation_none:
+        return HIPSPARSE_OPERATION_NON_TRANSPOSE;
+    case rocsparse_operation_transpose:
+        return HIPSPARSE_OPERATION_TRANSPOSE;
+    case rocsparse_operation_conjugate_transpose:
+        return HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE;
+    default:
+        throw "Non existent rocsparse_operation_";
     }
 }
 
@@ -233,10 +296,14 @@ rocsparse_hyb_partition_ hipHybPartToHCCHybPart(hipsparseHybPartition_t partitio
 {
     switch(partition)
     {
-    case HIPSPARSE_HYB_PARTITION_AUTO: return rocsparse_hyb_partition_auto;
-    case HIPSPARSE_HYB_PARTITION_USER: return rocsparse_hyb_partition_user;
-    case HIPSPARSE_HYB_PARTITION_MAX: return rocsparse_hyb_partition_max;
-    default: throw "Non existent hipsparseHybPartition_t";
+    case HIPSPARSE_HYB_PARTITION_AUTO:
+        return rocsparse_hyb_partition_auto;
+    case HIPSPARSE_HYB_PARTITION_USER:
+        return rocsparse_hyb_partition_user;
+    case HIPSPARSE_HYB_PARTITION_MAX:
+        return rocsparse_hyb_partition_max;
+    default:
+        throw "Non existent hipsparseHybPartition_t";
     }
 }
 
@@ -244,10 +311,14 @@ hipsparseHybPartition_t HCCHybPartToHIPHybPart(rocsparse_hyb_partition_ partitio
 {
     switch(partition)
     {
-    case rocsparse_hyb_partition_auto: return HIPSPARSE_HYB_PARTITION_AUTO;
-    case rocsparse_hyb_partition_user: return HIPSPARSE_HYB_PARTITION_USER;
-    case rocsparse_hyb_partition_max: return HIPSPARSE_HYB_PARTITION_MAX;
-    default: throw "Non existent rocsparse_hyb_partition_";
+    case rocsparse_hyb_partition_auto:
+        return HIPSPARSE_HYB_PARTITION_AUTO;
+    case rocsparse_hyb_partition_user:
+        return HIPSPARSE_HYB_PARTITION_USER;
+    case rocsparse_hyb_partition_max:
+        return HIPSPARSE_HYB_PARTITION_MAX;
+    default:
+        throw "Non existent rocsparse_hyb_partition_";
     }
 }
 
@@ -261,8 +332,8 @@ hipsparseStatus_t hipsparseCreate(hipsparseHandle_t* handle)
         return HIPSPARSE_STATUS_INVALID_VALUE;
     }
 
-    int deviceId;
-    hipError_t err;
+    int               deviceId;
+    hipError_t        err;
     hipsparseStatus_t retval = HIPSPARSE_STATUS_SUCCESS;
 
     err = hipGetDevice(&deviceId);
@@ -435,36 +506,36 @@ hipsparseStatus_t hipsparseDestroyCsrilu02Info(csrilu02Info_t info)
     return rocSPARSEStatusToHIPStatus(rocsparse_destroy_mat_info((rocsparse_mat_info)info));
 }
 
-hipsparseStatus_t hipsparseSaxpyi(hipsparseHandle_t handle,
-                                  int nnz,
-                                  const float* alpha,
-                                  const float* xVal,
-                                  const int* xInd,
-                                  float* y,
+hipsparseStatus_t hipsparseSaxpyi(hipsparseHandle_t    handle,
+                                  int                  nnz,
+                                  const float*         alpha,
+                                  const float*         xVal,
+                                  const int*           xInd,
+                                  float*               y,
                                   hipsparseIndexBase_t idxBase)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_saxpyi(
         (rocsparse_handle)handle, nnz, alpha, xVal, xInd, y, hipBaseToHCCBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseDaxpyi(hipsparseHandle_t handle,
-                                  int nnz,
-                                  const double* alpha,
-                                  const double* xVal,
-                                  const int* xInd,
-                                  double* y,
+hipsparseStatus_t hipsparseDaxpyi(hipsparseHandle_t    handle,
+                                  int                  nnz,
+                                  const double*        alpha,
+                                  const double*        xVal,
+                                  const int*           xInd,
+                                  double*              y,
                                   hipsparseIndexBase_t idxBase)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_daxpyi(
         (rocsparse_handle)handle, nnz, alpha, xVal, xInd, y, hipBaseToHCCBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseSdoti(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const float* xVal,
-                                 const int* xInd,
-                                 const float* y,
-                                 float* result,
+hipsparseStatus_t hipsparseSdoti(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 const float*         xVal,
+                                 const int*           xInd,
+                                 const float*         y,
+                                 float*               result,
                                  hipsparseIndexBase_t idxBase)
 {
     // Obtain stream, to explicitly sync (cusparse doti is blocking)
@@ -481,12 +552,12 @@ hipsparseStatus_t hipsparseSdoti(hipsparseHandle_t handle,
     return HIPSPARSE_STATUS_SUCCESS;
 }
 
-hipsparseStatus_t hipsparseDdoti(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const double* xVal,
-                                 const int* xInd,
-                                 const double* y,
-                                 double* result,
+hipsparseStatus_t hipsparseDdoti(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 const double*        xVal,
+                                 const int*           xInd,
+                                 const double*        y,
+                                 double*              result,
                                  hipsparseIndexBase_t idxBase)
 {
     // Obtain stream, to explicitly sync (cusparse doti is blocking)
@@ -503,111 +574,111 @@ hipsparseStatus_t hipsparseDdoti(hipsparseHandle_t handle,
     return HIPSPARSE_STATUS_SUCCESS;
 }
 
-hipsparseStatus_t hipsparseSgthr(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const float* y,
-                                 float* xVal,
-                                 const int* xInd,
+hipsparseStatus_t hipsparseSgthr(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 const float*         y,
+                                 float*               xVal,
+                                 const int*           xInd,
                                  hipsparseIndexBase_t idxBase)
 {
     return rocSPARSEStatusToHIPStatus(
         rocsparse_sgthr((rocsparse_handle)handle, nnz, y, xVal, xInd, hipBaseToHCCBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseDgthr(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const double* y,
-                                 double* xVal,
-                                 const int* xInd,
+hipsparseStatus_t hipsparseDgthr(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 const double*        y,
+                                 double*              xVal,
+                                 const int*           xInd,
                                  hipsparseIndexBase_t idxBase)
 {
     return rocSPARSEStatusToHIPStatus(
         rocsparse_dgthr((rocsparse_handle)handle, nnz, y, xVal, xInd, hipBaseToHCCBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseSgthrz(hipsparseHandle_t handle,
-                                  int nnz,
-                                  float* y,
-                                  float* xVal,
-                                  const int* xInd,
+hipsparseStatus_t hipsparseSgthrz(hipsparseHandle_t    handle,
+                                  int                  nnz,
+                                  float*               y,
+                                  float*               xVal,
+                                  const int*           xInd,
                                   hipsparseIndexBase_t idxBase)
 {
     return rocSPARSEStatusToHIPStatus(
         rocsparse_sgthrz((rocsparse_handle)handle, nnz, y, xVal, xInd, hipBaseToHCCBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseDgthrz(hipsparseHandle_t handle,
-                                  int nnz,
-                                  double* y,
-                                  double* xVal,
-                                  const int* xInd,
+hipsparseStatus_t hipsparseDgthrz(hipsparseHandle_t    handle,
+                                  int                  nnz,
+                                  double*              y,
+                                  double*              xVal,
+                                  const int*           xInd,
                                   hipsparseIndexBase_t idxBase)
 {
     return rocSPARSEStatusToHIPStatus(
         rocsparse_dgthrz((rocsparse_handle)handle, nnz, y, xVal, xInd, hipBaseToHCCBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseSroti(hipsparseHandle_t handle,
-                                 int nnz,
-                                 float* xVal,
-                                 const int* xInd,
-                                 float* y,
-                                 const float* c,
-                                 const float* s,
+hipsparseStatus_t hipsparseSroti(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 float*               xVal,
+                                 const int*           xInd,
+                                 float*               y,
+                                 const float*         c,
+                                 const float*         s,
                                  hipsparseIndexBase_t idxBase)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_sroti(
         (rocsparse_handle)handle, nnz, xVal, xInd, y, c, s, hipBaseToHCCBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseDroti(hipsparseHandle_t handle,
-                                 int nnz,
-                                 double* xVal,
-                                 const int* xInd,
-                                 double* y,
-                                 const double* c,
-                                 const double* s,
+hipsparseStatus_t hipsparseDroti(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 double*              xVal,
+                                 const int*           xInd,
+                                 double*              y,
+                                 const double*        c,
+                                 const double*        s,
                                  hipsparseIndexBase_t idxBase)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_droti(
         (rocsparse_handle)handle, nnz, xVal, xInd, y, c, s, hipBaseToHCCBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseSsctr(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const float* xVal,
-                                 const int* xInd,
-                                 float* y,
+hipsparseStatus_t hipsparseSsctr(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 const float*         xVal,
+                                 const int*           xInd,
+                                 float*               y,
                                  hipsparseIndexBase_t idxBase)
 {
     return rocSPARSEStatusToHIPStatus(
         rocsparse_ssctr((rocsparse_handle)handle, nnz, xVal, xInd, y, hipBaseToHCCBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseDsctr(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const double* xVal,
-                                 const int* xInd,
-                                 double* y,
+hipsparseStatus_t hipsparseDsctr(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 const double*        xVal,
+                                 const int*           xInd,
+                                 double*              y,
                                  hipsparseIndexBase_t idxBase)
 {
     return rocSPARSEStatusToHIPStatus(
         rocsparse_dsctr((rocsparse_handle)handle, nnz, xVal, xInd, y, hipBaseToHCCBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseScsrmv(hipsparseHandle_t handle,
-                                  hipsparseOperation_t transA,
-                                  int m,
-                                  int n,
-                                  int nnz,
-                                  const float* alpha,
+hipsparseStatus_t hipsparseScsrmv(hipsparseHandle_t         handle,
+                                  hipsparseOperation_t      transA,
+                                  int                       m,
+                                  int                       n,
+                                  int                       nnz,
+                                  const float*              alpha,
                                   const hipsparseMatDescr_t descrA,
-                                  const float* csrSortedValA,
-                                  const int* csrSortedRowPtrA,
-                                  const int* csrSortedColIndA,
-                                  const float* x,
-                                  const float* beta,
-                                  float* y)
+                                  const float*              csrSortedValA,
+                                  const int*                csrSortedRowPtrA,
+                                  const int*                csrSortedColIndA,
+                                  const float*              x,
+                                  const float*              beta,
+                                  float*                    y)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_scsrmv((rocsparse_handle)handle,
                                                        hipOperationToHCCOperation(transA),
@@ -625,19 +696,19 @@ hipsparseStatus_t hipsparseScsrmv(hipsparseHandle_t handle,
                                                        y));
 }
 
-hipsparseStatus_t hipsparseDcsrmv(hipsparseHandle_t handle,
-                                  hipsparseOperation_t transA,
-                                  int m,
-                                  int n,
-                                  int nnz,
-                                  const double* alpha,
+hipsparseStatus_t hipsparseDcsrmv(hipsparseHandle_t         handle,
+                                  hipsparseOperation_t      transA,
+                                  int                       m,
+                                  int                       n,
+                                  int                       nnz,
+                                  const double*             alpha,
                                   const hipsparseMatDescr_t descrA,
-                                  const double* csrSortedValA,
-                                  const int* csrSortedRowPtrA,
-                                  const int* csrSortedColIndA,
-                                  const double* x,
-                                  const double* beta,
-                                  double* y)
+                                  const double*             csrSortedValA,
+                                  const int*                csrSortedRowPtrA,
+                                  const int*                csrSortedColIndA,
+                                  const double*             x,
+                                  const double*             beta,
+                                  double*                   y)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_dcsrmv((rocsparse_handle)handle,
                                                        hipOperationToHCCOperation(transA),
@@ -656,7 +727,7 @@ hipsparseStatus_t hipsparseDcsrmv(hipsparseHandle_t handle,
 }
 
 hipsparseStatus_t
-hipsparseXcsrsv2_zeroPivot(hipsparseHandle_t handle, csrsv2Info_t info, int* position)
+    hipsparseXcsrsv2_zeroPivot(hipsparseHandle_t handle, csrsv2Info_t info, int* position)
 {
     // Obtain stream, to explicitly sync (cusparse csrsv2_zeropivot is blocking)
     hipStream_t stream;
@@ -672,23 +743,23 @@ hipsparseXcsrsv2_zeroPivot(hipsparseHandle_t handle, csrsv2Info_t info, int* pos
     return HIPSPARSE_STATUS_SUCCESS;
 }
 
-hipsparseStatus_t hipsparseScsrsv2_bufferSize(hipsparseHandle_t handle,
-                                              hipsparseOperation_t transA,
-                                              int m,
-                                              int nnz,
+hipsparseStatus_t hipsparseScsrsv2_bufferSize(hipsparseHandle_t         handle,
+                                              hipsparseOperation_t      transA,
+                                              int                       m,
+                                              int                       nnz,
                                               const hipsparseMatDescr_t descrA,
-                                              float* csrSortedValA,
-                                              const int* csrSortedRowPtrA,
-                                              const int* csrSortedColIndA,
-                                              csrsv2Info_t info,
-                                              int* pBufferSizeInBytes)
+                                              float*                    csrSortedValA,
+                                              const int*                csrSortedRowPtrA,
+                                              const int*                csrSortedColIndA,
+                                              csrsv2Info_t              info,
+                                              int*                      pBufferSizeInBytes)
 {
     if(pBufferSizeInBytes == nullptr)
     {
         return HIPSPARSE_STATUS_INVALID_VALUE;
     }
 
-    size_t buffer_size;
+    size_t           buffer_size;
     rocsparse_status status;
 
     status = rocsparse_scsrsv_buffer_size((rocsparse_handle)handle,
@@ -707,23 +778,23 @@ hipsparseStatus_t hipsparseScsrsv2_bufferSize(hipsparseHandle_t handle,
     return rocSPARSEStatusToHIPStatus(status);
 }
 
-hipsparseStatus_t hipsparseDcsrsv2_bufferSize(hipsparseHandle_t handle,
-                                              hipsparseOperation_t transA,
-                                              int m,
-                                              int nnz,
+hipsparseStatus_t hipsparseDcsrsv2_bufferSize(hipsparseHandle_t         handle,
+                                              hipsparseOperation_t      transA,
+                                              int                       m,
+                                              int                       nnz,
                                               const hipsparseMatDescr_t descrA,
-                                              double* csrSortedValA,
-                                              const int* csrSortedRowPtrA,
-                                              const int* csrSortedColIndA,
-                                              csrsv2Info_t info,
-                                              int* pBufferSizeInBytes)
+                                              double*                   csrSortedValA,
+                                              const int*                csrSortedRowPtrA,
+                                              const int*                csrSortedColIndA,
+                                              csrsv2Info_t              info,
+                                              int*                      pBufferSizeInBytes)
 {
     if(pBufferSizeInBytes == nullptr)
     {
         return HIPSPARSE_STATUS_INVALID_VALUE;
     }
 
-    size_t buffer_size;
+    size_t           buffer_size;
     rocsparse_status status;
 
     status = rocsparse_dcsrsv_buffer_size((rocsparse_handle)handle,
@@ -742,16 +813,16 @@ hipsparseStatus_t hipsparseDcsrsv2_bufferSize(hipsparseHandle_t handle,
     return rocSPARSEStatusToHIPStatus(status);
 }
 
-hipsparseStatus_t hipsparseScsrsv2_bufferSizeExt(hipsparseHandle_t handle,
-                                                 hipsparseOperation_t transA,
-                                                 int m,
-                                                 int nnz,
+hipsparseStatus_t hipsparseScsrsv2_bufferSizeExt(hipsparseHandle_t         handle,
+                                                 hipsparseOperation_t      transA,
+                                                 int                       m,
+                                                 int                       nnz,
                                                  const hipsparseMatDescr_t descrA,
-                                                 float* csrSortedValA,
-                                                 const int* csrSortedRowPtrA,
-                                                 const int* csrSortedColIndA,
-                                                 csrsv2Info_t info,
-                                                 size_t* pBufferSize)
+                                                 float*                    csrSortedValA,
+                                                 const int*                csrSortedRowPtrA,
+                                                 const int*                csrSortedColIndA,
+                                                 csrsv2Info_t              info,
+                                                 size_t*                   pBufferSize)
 {
     return rocSPARSEStatusToHIPStatus(
         rocsparse_scsrsv_buffer_size((rocsparse_handle)handle,
@@ -766,16 +837,16 @@ hipsparseStatus_t hipsparseScsrsv2_bufferSizeExt(hipsparseHandle_t handle,
                                      pBufferSize));
 }
 
-hipsparseStatus_t hipsparseDcsrsv2_bufferSizeExt(hipsparseHandle_t handle,
-                                                 hipsparseOperation_t transA,
-                                                 int m,
-                                                 int nnz,
+hipsparseStatus_t hipsparseDcsrsv2_bufferSizeExt(hipsparseHandle_t         handle,
+                                                 hipsparseOperation_t      transA,
+                                                 int                       m,
+                                                 int                       nnz,
                                                  const hipsparseMatDescr_t descrA,
-                                                 double* csrSortedValA,
-                                                 const int* csrSortedRowPtrA,
-                                                 const int* csrSortedColIndA,
-                                                 csrsv2Info_t info,
-                                                 size_t* pBufferSize)
+                                                 double*                   csrSortedValA,
+                                                 const int*                csrSortedRowPtrA,
+                                                 const int*                csrSortedColIndA,
+                                                 csrsv2Info_t              info,
+                                                 size_t*                   pBufferSize)
 {
     return rocSPARSEStatusToHIPStatus(
         rocsparse_dcsrsv_buffer_size((rocsparse_handle)handle,
@@ -790,17 +861,17 @@ hipsparseStatus_t hipsparseDcsrsv2_bufferSizeExt(hipsparseHandle_t handle,
                                      pBufferSize));
 }
 
-hipsparseStatus_t hipsparseScsrsv2_analysis(hipsparseHandle_t handle,
-                                            hipsparseOperation_t transA,
-                                            int m,
-                                            int nnz,
+hipsparseStatus_t hipsparseScsrsv2_analysis(hipsparseHandle_t         handle,
+                                            hipsparseOperation_t      transA,
+                                            int                       m,
+                                            int                       nnz,
                                             const hipsparseMatDescr_t descrA,
-                                            const float* csrSortedValA,
-                                            const int* csrSortedRowPtrA,
-                                            const int* csrSortedColIndA,
-                                            csrsv2Info_t info,
-                                            hipsparseSolvePolicy_t policy,
-                                            void* pBuffer)
+                                            const float*              csrSortedValA,
+                                            const int*                csrSortedRowPtrA,
+                                            const int*                csrSortedColIndA,
+                                            csrsv2Info_t              info,
+                                            hipsparseSolvePolicy_t    policy,
+                                            void*                     pBuffer)
 {
     // Obtain stream, to explicitly sync (cusparse csrsv2_analysis is blocking)
     hipStream_t stream;
@@ -826,17 +897,17 @@ hipsparseStatus_t hipsparseScsrsv2_analysis(hipsparseHandle_t handle,
     return HIPSPARSE_STATUS_SUCCESS;
 }
 
-hipsparseStatus_t hipsparseDcsrsv2_analysis(hipsparseHandle_t handle,
-                                            hipsparseOperation_t transA,
-                                            int m,
-                                            int nnz,
+hipsparseStatus_t hipsparseDcsrsv2_analysis(hipsparseHandle_t         handle,
+                                            hipsparseOperation_t      transA,
+                                            int                       m,
+                                            int                       nnz,
                                             const hipsparseMatDescr_t descrA,
-                                            const double* csrSortedValA,
-                                            const int* csrSortedRowPtrA,
-                                            const int* csrSortedColIndA,
-                                            csrsv2Info_t info,
-                                            hipsparseSolvePolicy_t policy,
-                                            void* pBuffer)
+                                            const double*             csrSortedValA,
+                                            const int*                csrSortedRowPtrA,
+                                            const int*                csrSortedColIndA,
+                                            csrsv2Info_t              info,
+                                            hipsparseSolvePolicy_t    policy,
+                                            void*                     pBuffer)
 {
     // Obtain stream, to explicitly sync (cusparse csrsv2_analysis is blocking)
     hipStream_t stream;
@@ -862,20 +933,20 @@ hipsparseStatus_t hipsparseDcsrsv2_analysis(hipsparseHandle_t handle,
     return HIPSPARSE_STATUS_SUCCESS;
 }
 
-hipsparseStatus_t hipsparseScsrsv2_solve(hipsparseHandle_t handle,
-                                         hipsparseOperation_t transA,
-                                         int m,
-                                         int nnz,
-                                         const float* alpha,
+hipsparseStatus_t hipsparseScsrsv2_solve(hipsparseHandle_t         handle,
+                                         hipsparseOperation_t      transA,
+                                         int                       m,
+                                         int                       nnz,
+                                         const float*              alpha,
                                          const hipsparseMatDescr_t descrA,
-                                         const float* csrSortedValA,
-                                         const int* csrSortedRowPtrA,
-                                         const int* csrSortedColIndA,
-                                         csrsv2Info_t info,
-                                         const float* f,
-                                         float* x,
-                                         hipsparseSolvePolicy_t policy,
-                                         void* pBuffer)
+                                         const float*              csrSortedValA,
+                                         const int*                csrSortedRowPtrA,
+                                         const int*                csrSortedColIndA,
+                                         csrsv2Info_t              info,
+                                         const float*              f,
+                                         float*                    x,
+                                         hipsparseSolvePolicy_t    policy,
+                                         void*                     pBuffer)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_scsrsv_solve((rocsparse_handle)handle,
                                                              hipOperationToHCCOperation(transA),
@@ -893,20 +964,20 @@ hipsparseStatus_t hipsparseScsrsv2_solve(hipsparseHandle_t handle,
                                                              pBuffer));
 }
 
-hipsparseStatus_t hipsparseDcsrsv2_solve(hipsparseHandle_t handle,
-                                         hipsparseOperation_t transA,
-                                         int m,
-                                         int nnz,
-                                         const double* alpha,
+hipsparseStatus_t hipsparseDcsrsv2_solve(hipsparseHandle_t         handle,
+                                         hipsparseOperation_t      transA,
+                                         int                       m,
+                                         int                       nnz,
+                                         const double*             alpha,
                                          const hipsparseMatDescr_t descrA,
-                                         const double* csrSortedValA,
-                                         const int* csrSortedRowPtrA,
-                                         const int* csrSortedColIndA,
-                                         csrsv2Info_t info,
-                                         const double* f,
-                                         double* x,
-                                         hipsparseSolvePolicy_t policy,
-                                         void* pBuffer)
+                                         const double*             csrSortedValA,
+                                         const int*                csrSortedRowPtrA,
+                                         const int*                csrSortedColIndA,
+                                         csrsv2Info_t              info,
+                                         const double*             f,
+                                         double*                   x,
+                                         hipsparseSolvePolicy_t    policy,
+                                         void*                     pBuffer)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_dcsrsv_solve((rocsparse_handle)handle,
                                                              hipOperationToHCCOperation(transA),
@@ -924,14 +995,14 @@ hipsparseStatus_t hipsparseDcsrsv2_solve(hipsparseHandle_t handle,
                                                              pBuffer));
 }
 
-hipsparseStatus_t hipsparseShybmv(hipsparseHandle_t handle,
-                                  hipsparseOperation_t transA,
-                                  const float* alpha,
+hipsparseStatus_t hipsparseShybmv(hipsparseHandle_t         handle,
+                                  hipsparseOperation_t      transA,
+                                  const float*              alpha,
                                   const hipsparseMatDescr_t descrA,
-                                  const hipsparseHybMat_t hybA,
-                                  const float* x,
-                                  const float* beta,
-                                  float* y)
+                                  const hipsparseHybMat_t   hybA,
+                                  const float*              x,
+                                  const float*              beta,
+                                  float*                    y)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_shybmv((rocsparse_handle)handle,
                                                        hipOperationToHCCOperation(transA),
@@ -943,14 +1014,14 @@ hipsparseStatus_t hipsparseShybmv(hipsparseHandle_t handle,
                                                        y));
 }
 
-hipsparseStatus_t hipsparseDhybmv(hipsparseHandle_t handle,
-                                  hipsparseOperation_t transA,
-                                  const double* alpha,
+hipsparseStatus_t hipsparseDhybmv(hipsparseHandle_t         handle,
+                                  hipsparseOperation_t      transA,
+                                  const double*             alpha,
                                   const hipsparseMatDescr_t descrA,
-                                  const hipsparseHybMat_t hybA,
-                                  const double* x,
-                                  const double* beta,
-                                  double* y)
+                                  const hipsparseHybMat_t   hybA,
+                                  const double*             x,
+                                  const double*             beta,
+                                  double*                   y)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_dhybmv((rocsparse_handle)handle,
                                                        hipOperationToHCCOperation(transA),
@@ -962,22 +1033,22 @@ hipsparseStatus_t hipsparseDhybmv(hipsparseHandle_t handle,
                                                        y));
 }
 
-hipsparseStatus_t hipsparseScsrmm(hipsparseHandle_t handle,
-                                  hipsparseOperation_t transA,
-                                  int m,
-                                  int n,
-                                  int k,
-                                  int nnz,
-                                  const float* alpha,
+hipsparseStatus_t hipsparseScsrmm(hipsparseHandle_t         handle,
+                                  hipsparseOperation_t      transA,
+                                  int                       m,
+                                  int                       n,
+                                  int                       k,
+                                  int                       nnz,
+                                  const float*              alpha,
                                   const hipsparseMatDescr_t descrA,
-                                  const float* csrSortedValA,
-                                  const int* csrSortedRowPtrA,
-                                  const int* csrSortedColIndA,
-                                  const float* B,
-                                  int ldb,
-                                  const float* beta,
-                                  float* C,
-                                  int ldc)
+                                  const float*              csrSortedValA,
+                                  const int*                csrSortedRowPtrA,
+                                  const int*                csrSortedColIndA,
+                                  const float*              B,
+                                  int                       ldb,
+                                  const float*              beta,
+                                  float*                    C,
+                                  int                       ldc)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_scsrmm((rocsparse_handle)handle,
                                                        hipOperationToHCCOperation(transA),
@@ -998,22 +1069,22 @@ hipsparseStatus_t hipsparseScsrmm(hipsparseHandle_t handle,
                                                        ldc));
 }
 
-hipsparseStatus_t hipsparseDcsrmm(hipsparseHandle_t handle,
-                                  hipsparseOperation_t transA,
-                                  int m,
-                                  int n,
-                                  int k,
-                                  int nnz,
-                                  const double* alpha,
+hipsparseStatus_t hipsparseDcsrmm(hipsparseHandle_t         handle,
+                                  hipsparseOperation_t      transA,
+                                  int                       m,
+                                  int                       n,
+                                  int                       k,
+                                  int                       nnz,
+                                  const double*             alpha,
                                   const hipsparseMatDescr_t descrA,
-                                  const double* csrSortedValA,
-                                  const int* csrSortedRowPtrA,
-                                  const int* csrSortedColIndA,
-                                  const double* B,
-                                  int ldb,
-                                  const double* beta,
-                                  double* C,
-                                  int ldc)
+                                  const double*             csrSortedValA,
+                                  const int*                csrSortedRowPtrA,
+                                  const int*                csrSortedColIndA,
+                                  const double*             B,
+                                  int                       ldb,
+                                  const double*             beta,
+                                  double*                   C,
+                                  int                       ldc)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_dcsrmm((rocsparse_handle)handle,
                                                        hipOperationToHCCOperation(transA),
@@ -1034,23 +1105,23 @@ hipsparseStatus_t hipsparseDcsrmm(hipsparseHandle_t handle,
                                                        ldc));
 }
 
-hipsparseStatus_t hipsparseScsrmm2(hipsparseHandle_t handle,
-                                   hipsparseOperation_t transA,
-                                   hipsparseOperation_t transB,
-                                   int m,
-                                   int n,
-                                   int k,
-                                   int nnz,
-                                   const float* alpha,
+hipsparseStatus_t hipsparseScsrmm2(hipsparseHandle_t         handle,
+                                   hipsparseOperation_t      transA,
+                                   hipsparseOperation_t      transB,
+                                   int                       m,
+                                   int                       n,
+                                   int                       k,
+                                   int                       nnz,
+                                   const float*              alpha,
                                    const hipsparseMatDescr_t descrA,
-                                   const float* csrSortedValA,
-                                   const int* csrSortedRowPtrA,
-                                   const int* csrSortedColIndA,
-                                   const float* B,
-                                   int ldb,
-                                   const float* beta,
-                                   float* C,
-                                   int ldc)
+                                   const float*              csrSortedValA,
+                                   const int*                csrSortedRowPtrA,
+                                   const int*                csrSortedColIndA,
+                                   const float*              B,
+                                   int                       ldb,
+                                   const float*              beta,
+                                   float*                    C,
+                                   int                       ldc)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_scsrmm((rocsparse_handle)handle,
                                                        hipOperationToHCCOperation(transA),
@@ -1071,23 +1142,23 @@ hipsparseStatus_t hipsparseScsrmm2(hipsparseHandle_t handle,
                                                        ldc));
 }
 
-hipsparseStatus_t hipsparseDcsrmm2(hipsparseHandle_t handle,
-                                   hipsparseOperation_t transA,
-                                   hipsparseOperation_t transB,
-                                   int m,
-                                   int n,
-                                   int k,
-                                   int nnz,
-                                   const double* alpha,
+hipsparseStatus_t hipsparseDcsrmm2(hipsparseHandle_t         handle,
+                                   hipsparseOperation_t      transA,
+                                   hipsparseOperation_t      transB,
+                                   int                       m,
+                                   int                       n,
+                                   int                       k,
+                                   int                       nnz,
+                                   const double*             alpha,
                                    const hipsparseMatDescr_t descrA,
-                                   const double* csrSortedValA,
-                                   const int* csrSortedRowPtrA,
-                                   const int* csrSortedColIndA,
-                                   const double* B,
-                                   int ldb,
-                                   const double* beta,
-                                   double* C,
-                                   int ldc)
+                                   const double*             csrSortedValA,
+                                   const int*                csrSortedRowPtrA,
+                                   const int*                csrSortedColIndA,
+                                   const double*             B,
+                                   int                       ldb,
+                                   const double*             beta,
+                                   double*                   C,
+                                   int                       ldc)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_dcsrmm((rocsparse_handle)handle,
                                                        hipOperationToHCCOperation(transA),
@@ -1109,7 +1180,7 @@ hipsparseStatus_t hipsparseDcsrmm2(hipsparseHandle_t handle,
 }
 
 hipsparseStatus_t
-hipsparseXcsrilu02_zeroPivot(hipsparseHandle_t handle, csrilu02Info_t info, int* position)
+    hipsparseXcsrilu02_zeroPivot(hipsparseHandle_t handle, csrilu02Info_t info, int* position)
 {
     // Obtain stream, to explicitly sync (cusparse csrilu02_zeropivot is blocking)
     hipStream_t stream;
@@ -1125,22 +1196,22 @@ hipsparseXcsrilu02_zeroPivot(hipsparseHandle_t handle, csrilu02Info_t info, int*
     return HIPSPARSE_STATUS_SUCCESS;
 }
 
-hipsparseStatus_t hipsparseScsrilu02_bufferSize(hipsparseHandle_t handle,
-                                                int m,
-                                                int nnz,
+hipsparseStatus_t hipsparseScsrilu02_bufferSize(hipsparseHandle_t         handle,
+                                                int                       m,
+                                                int                       nnz,
                                                 const hipsparseMatDescr_t descrA,
-                                                float* csrSortedValA,
-                                                const int* csrSortedRowPtrA,
-                                                const int* csrSortedColIndA,
-                                                csrilu02Info_t info,
-                                                int* pBufferSizeInBytes)
+                                                float*                    csrSortedValA,
+                                                const int*                csrSortedRowPtrA,
+                                                const int*                csrSortedColIndA,
+                                                csrilu02Info_t            info,
+                                                int*                      pBufferSizeInBytes)
 {
     if(pBufferSizeInBytes == nullptr)
     {
         return HIPSPARSE_STATUS_INVALID_VALUE;
     }
 
-    size_t buffer_size;
+    size_t           buffer_size;
     rocsparse_status status;
 
     status = rocsparse_scsrilu0_buffer_size((rocsparse_handle)handle,
@@ -1158,22 +1229,22 @@ hipsparseStatus_t hipsparseScsrilu02_bufferSize(hipsparseHandle_t handle,
     return rocSPARSEStatusToHIPStatus(status);
 }
 
-hipsparseStatus_t hipsparseDcsrilu02_bufferSize(hipsparseHandle_t handle,
-                                                int m,
-                                                int nnz,
+hipsparseStatus_t hipsparseDcsrilu02_bufferSize(hipsparseHandle_t         handle,
+                                                int                       m,
+                                                int                       nnz,
                                                 const hipsparseMatDescr_t descrA,
-                                                double* csrSortedValA,
-                                                const int* csrSortedRowPtrA,
-                                                const int* csrSortedColIndA,
-                                                csrilu02Info_t info,
-                                                int* pBufferSizeInBytes)
+                                                double*                   csrSortedValA,
+                                                const int*                csrSortedRowPtrA,
+                                                const int*                csrSortedColIndA,
+                                                csrilu02Info_t            info,
+                                                int*                      pBufferSizeInBytes)
 {
     if(pBufferSizeInBytes == nullptr)
     {
         return HIPSPARSE_STATUS_INVALID_VALUE;
     }
 
-    size_t buffer_size;
+    size_t           buffer_size;
     rocsparse_status status;
 
     status = rocsparse_dcsrilu0_buffer_size((rocsparse_handle)handle,
@@ -1191,15 +1262,15 @@ hipsparseStatus_t hipsparseDcsrilu02_bufferSize(hipsparseHandle_t handle,
     return rocSPARSEStatusToHIPStatus(status);
 }
 
-hipsparseStatus_t hipsparseScsrilu02_bufferSizeExt(hipsparseHandle_t handle,
-                                                   int m,
-                                                   int nnz,
+hipsparseStatus_t hipsparseScsrilu02_bufferSizeExt(hipsparseHandle_t         handle,
+                                                   int                       m,
+                                                   int                       nnz,
                                                    const hipsparseMatDescr_t descrA,
-                                                   float* csrSortedValA,
-                                                   const int* csrSortedRowPtrA,
-                                                   const int* csrSortedColIndA,
-                                                   csrilu02Info_t info,
-                                                   size_t* pBufferSize)
+                                                   float*                    csrSortedValA,
+                                                   const int*                csrSortedRowPtrA,
+                                                   const int*                csrSortedColIndA,
+                                                   csrilu02Info_t            info,
+                                                   size_t*                   pBufferSize)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_scsrilu0_buffer_size((rocsparse_handle)handle,
                                                                      m,
@@ -1212,15 +1283,15 @@ hipsparseStatus_t hipsparseScsrilu02_bufferSizeExt(hipsparseHandle_t handle,
                                                                      pBufferSize));
 }
 
-hipsparseStatus_t hipsparseDcsrilu02_bufferSizeExt(hipsparseHandle_t handle,
-                                                   int m,
-                                                   int nnz,
+hipsparseStatus_t hipsparseDcsrilu02_bufferSizeExt(hipsparseHandle_t         handle,
+                                                   int                       m,
+                                                   int                       nnz,
                                                    const hipsparseMatDescr_t descrA,
-                                                   double* csrSortedValA,
-                                                   const int* csrSortedRowPtrA,
-                                                   const int* csrSortedColIndA,
-                                                   csrilu02Info_t info,
-                                                   size_t* pBufferSize)
+                                                   double*                   csrSortedValA,
+                                                   const int*                csrSortedRowPtrA,
+                                                   const int*                csrSortedColIndA,
+                                                   csrilu02Info_t            info,
+                                                   size_t*                   pBufferSize)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_dcsrilu0_buffer_size((rocsparse_handle)handle,
                                                                      m,
@@ -1233,16 +1304,16 @@ hipsparseStatus_t hipsparseDcsrilu02_bufferSizeExt(hipsparseHandle_t handle,
                                                                      pBufferSize));
 }
 
-hipsparseStatus_t hipsparseScsrilu02_analysis(hipsparseHandle_t handle,
-                                              int m,
-                                              int nnz,
+hipsparseStatus_t hipsparseScsrilu02_analysis(hipsparseHandle_t         handle,
+                                              int                       m,
+                                              int                       nnz,
                                               const hipsparseMatDescr_t descrA,
-                                              const float* csrSortedValA,
-                                              const int* csrSortedRowPtrA,
-                                              const int* csrSortedColIndA,
-                                              csrilu02Info_t info,
-                                              hipsparseSolvePolicy_t policy,
-                                              void* pBuffer)
+                                              const float*              csrSortedValA,
+                                              const int*                csrSortedRowPtrA,
+                                              const int*                csrSortedColIndA,
+                                              csrilu02Info_t            info,
+                                              hipsparseSolvePolicy_t    policy,
+                                              void*                     pBuffer)
 {
     // Obtain stream, to explicitly sync (cusparse csrilu02_analysis is blocking)
     hipStream_t stream;
@@ -1267,16 +1338,16 @@ hipsparseStatus_t hipsparseScsrilu02_analysis(hipsparseHandle_t handle,
     return HIPSPARSE_STATUS_SUCCESS;
 }
 
-hipsparseStatus_t hipsparseDcsrilu02_analysis(hipsparseHandle_t handle,
-                                              int m,
-                                              int nnz,
+hipsparseStatus_t hipsparseDcsrilu02_analysis(hipsparseHandle_t         handle,
+                                              int                       m,
+                                              int                       nnz,
                                               const hipsparseMatDescr_t descrA,
-                                              const double* csrSortedValA,
-                                              const int* csrSortedRowPtrA,
-                                              const int* csrSortedColIndA,
-                                              csrilu02Info_t info,
-                                              hipsparseSolvePolicy_t policy,
-                                              void* pBuffer)
+                                              const double*             csrSortedValA,
+                                              const int*                csrSortedRowPtrA,
+                                              const int*                csrSortedColIndA,
+                                              csrilu02Info_t            info,
+                                              hipsparseSolvePolicy_t    policy,
+                                              void*                     pBuffer)
 {
     // Obtain stream, to explicitly sync (cusparse csrilu02_analysis is blocking)
     hipStream_t stream;
@@ -1301,18 +1372,18 @@ hipsparseStatus_t hipsparseDcsrilu02_analysis(hipsparseHandle_t handle,
     return HIPSPARSE_STATUS_SUCCESS;
 }
 
-hipsparseStatus_t hipsparseScsrilu02(hipsparseHandle_t handle,
-                                     int m,
-                                     int nnz,
+hipsparseStatus_t hipsparseScsrilu02(hipsparseHandle_t         handle,
+                                     int                       m,
+                                     int                       nnz,
                                      const hipsparseMatDescr_t descrA,
-                                     float* csrSortedValA_valM,
+                                     float*                    csrSortedValA_valM,
                                      /* matrix A values are updated inplace
                                         to be the preconditioner M values */
-                                     const int* csrSortedRowPtrA,
-                                     const int* csrSortedColIndA,
-                                     csrilu02Info_t info,
+                                     const int*             csrSortedRowPtrA,
+                                     const int*             csrSortedColIndA,
+                                     csrilu02Info_t         info,
                                      hipsparseSolvePolicy_t policy,
-                                     void* pBuffer)
+                                     void*                  pBuffer)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_scsrilu0((rocsparse_handle)handle,
                                                          m,
@@ -1326,18 +1397,18 @@ hipsparseStatus_t hipsparseScsrilu02(hipsparseHandle_t handle,
                                                          pBuffer));
 }
 
-hipsparseStatus_t hipsparseDcsrilu02(hipsparseHandle_t handle,
-                                     int m,
-                                     int nnz,
+hipsparseStatus_t hipsparseDcsrilu02(hipsparseHandle_t         handle,
+                                     int                       m,
+                                     int                       nnz,
                                      const hipsparseMatDescr_t descrA,
-                                     double* csrSortedValA_valM,
+                                     double*                   csrSortedValA_valM,
                                      /* matrix A values are updated inplace
                                         to be the preconditioner M values */
-                                     const int* csrSortedRowPtrA,
-                                     const int* csrSortedColIndA,
-                                     csrilu02Info_t info,
+                                     const int*             csrSortedRowPtrA,
+                                     const int*             csrSortedColIndA,
+                                     csrilu02Info_t         info,
                                      hipsparseSolvePolicy_t policy,
-                                     void* pBuffer)
+                                     void*                  pBuffer)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_dcsrilu0((rocsparse_handle)handle,
                                                          m,
@@ -1351,28 +1422,28 @@ hipsparseStatus_t hipsparseDcsrilu02(hipsparseHandle_t handle,
                                                          pBuffer));
 }
 
-hipsparseStatus_t hipsparseXcsr2coo(hipsparseHandle_t handle,
-                                    const int* csrRowPtr,
-                                    int nnz,
-                                    int m,
-                                    int* cooRowInd,
+hipsparseStatus_t hipsparseXcsr2coo(hipsparseHandle_t    handle,
+                                    const int*           csrRowPtr,
+                                    int                  nnz,
+                                    int                  m,
+                                    int*                 cooRowInd,
                                     hipsparseIndexBase_t idxBase)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_csr2coo(
         (rocsparse_handle)handle, csrRowPtr, nnz, m, cooRowInd, hipBaseToHCCBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseScsr2csc(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
-                                    int nnz,
-                                    const float* csrSortedVal,
-                                    const int* csrSortedRowPtr,
-                                    const int* csrSortedColInd,
-                                    float* cscSortedVal,
-                                    int* cscSortedRowInd,
-                                    int* cscSortedColPtr,
-                                    hipsparseAction_t copyValues,
+hipsparseStatus_t hipsparseScsr2csc(hipsparseHandle_t    handle,
+                                    int                  m,
+                                    int                  n,
+                                    int                  nnz,
+                                    const float*         csrSortedVal,
+                                    const int*           csrSortedRowPtr,
+                                    const int*           csrSortedColInd,
+                                    float*               cscSortedVal,
+                                    int*                 cscSortedRowInd,
+                                    int*                 cscSortedColPtr,
+                                    hipsparseAction_t    copyValues,
                                     hipsparseIndexBase_t idxBase)
 {
     // Determine buffer size
@@ -1418,17 +1489,17 @@ hipsparseStatus_t hipsparseScsr2csc(hipsparseHandle_t handle,
     return HIPSPARSE_STATUS_SUCCESS;
 }
 
-hipsparseStatus_t hipsparseDcsr2csc(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
-                                    int nnz,
-                                    const double* csrSortedVal,
-                                    const int* csrSortedRowPtr,
-                                    const int* csrSortedColInd,
-                                    double* cscSortedVal,
-                                    int* cscSortedRowInd,
-                                    int* cscSortedColPtr,
-                                    hipsparseAction_t copyValues,
+hipsparseStatus_t hipsparseDcsr2csc(hipsparseHandle_t    handle,
+                                    int                  m,
+                                    int                  n,
+                                    int                  nnz,
+                                    const double*        csrSortedVal,
+                                    const int*           csrSortedRowPtr,
+                                    const int*           csrSortedColInd,
+                                    double*              cscSortedVal,
+                                    int*                 cscSortedRowInd,
+                                    int*                 cscSortedColPtr,
+                                    hipsparseAction_t    copyValues,
                                     hipsparseIndexBase_t idxBase)
 {
     // Determine buffer size
@@ -1474,16 +1545,16 @@ hipsparseStatus_t hipsparseDcsr2csc(hipsparseHandle_t handle,
     return HIPSPARSE_STATUS_SUCCESS;
 }
 
-hipsparseStatus_t hipsparseScsr2hyb(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
+hipsparseStatus_t hipsparseScsr2hyb(hipsparseHandle_t         handle,
+                                    int                       m,
+                                    int                       n,
                                     const hipsparseMatDescr_t descrA,
-                                    const float* csrSortedValA,
-                                    const int* csrSortedRowPtrA,
-                                    const int* csrSortedColIndA,
-                                    hipsparseHybMat_t hybA,
-                                    int userEllWidth,
-                                    hipsparseHybPartition_t partitionType)
+                                    const float*              csrSortedValA,
+                                    const int*                csrSortedRowPtrA,
+                                    const int*                csrSortedColIndA,
+                                    hipsparseHybMat_t         hybA,
+                                    int                       userEllWidth,
+                                    hipsparseHybPartition_t   partitionType)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_scsr2hyb((rocsparse_handle)handle,
                                                          m,
@@ -1497,16 +1568,16 @@ hipsparseStatus_t hipsparseScsr2hyb(hipsparseHandle_t handle,
                                                          hipHybPartToHCCHybPart(partitionType)));
 }
 
-hipsparseStatus_t hipsparseDcsr2hyb(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
+hipsparseStatus_t hipsparseDcsr2hyb(hipsparseHandle_t         handle,
+                                    int                       m,
+                                    int                       n,
                                     const hipsparseMatDescr_t descrA,
-                                    const double* csrSortedValA,
-                                    const int* csrSortedRowPtrA,
-                                    const int* csrSortedColIndA,
-                                    hipsparseHybMat_t hybA,
-                                    int userEllWidth,
-                                    hipsparseHybPartition_t partitionType)
+                                    const double*             csrSortedValA,
+                                    const int*                csrSortedRowPtrA,
+                                    const int*                csrSortedColIndA,
+                                    hipsparseHybMat_t         hybA,
+                                    int                       userEllWidth,
+                                    hipsparseHybPartition_t   partitionType)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_dcsr2hyb((rocsparse_handle)handle,
                                                          m,
@@ -1520,11 +1591,11 @@ hipsparseStatus_t hipsparseDcsr2hyb(hipsparseHandle_t handle,
                                                          hipHybPartToHCCHybPart(partitionType)));
 }
 
-hipsparseStatus_t hipsparseXcoo2csr(hipsparseHandle_t handle,
-                                    const int* cooRowInd,
-                                    int nnz,
-                                    int m,
-                                    int* csrRowPtr,
+hipsparseStatus_t hipsparseXcoo2csr(hipsparseHandle_t    handle,
+                                    const int*           cooRowInd,
+                                    int                  nnz,
+                                    int                  m,
+                                    int*                 csrRowPtr,
                                     hipsparseIndexBase_t idxBase)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_coo2csr(
@@ -1538,26 +1609,26 @@ hipsparseStatus_t hipsparseCreateIdentityPermutation(hipsparseHandle_t handle, i
 }
 
 hipsparseStatus_t hipsparseXcsrsort_bufferSizeExt(hipsparseHandle_t handle,
-                                                  int m,
-                                                  int n,
-                                                  int nnz,
-                                                  const int* csrRowPtr,
-                                                  const int* csrColInd,
-                                                  size_t* pBufferSizeInBytes)
+                                                  int               m,
+                                                  int               n,
+                                                  int               nnz,
+                                                  const int*        csrRowPtr,
+                                                  const int*        csrColInd,
+                                                  size_t*           pBufferSizeInBytes)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_csrsort_buffer_size(
         (rocsparse_handle)handle, m, n, nnz, csrRowPtr, csrColInd, pBufferSizeInBytes));
 }
 
-hipsparseStatus_t hipsparseXcsrsort(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
-                                    int nnz,
+hipsparseStatus_t hipsparseXcsrsort(hipsparseHandle_t         handle,
+                                    int                       m,
+                                    int                       n,
+                                    int                       nnz,
                                     const hipsparseMatDescr_t descrA,
-                                    const int* csrRowPtr,
-                                    int* csrColInd,
-                                    int* P,
-                                    void* pBuffer)
+                                    const int*                csrRowPtr,
+                                    int*                      csrColInd,
+                                    int*                      P,
+                                    void*                     pBuffer)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_csrsort((rocsparse_handle)handle,
                                                         m,
@@ -1571,38 +1642,38 @@ hipsparseStatus_t hipsparseXcsrsort(hipsparseHandle_t handle,
 }
 
 hipsparseStatus_t hipsparseXcoosort_bufferSizeExt(hipsparseHandle_t handle,
-                                                  int m,
-                                                  int n,
-                                                  int nnz,
-                                                  const int* cooRows,
-                                                  const int* cooCols,
-                                                  size_t* pBufferSizeInBytes)
+                                                  int               m,
+                                                  int               n,
+                                                  int               nnz,
+                                                  const int*        cooRows,
+                                                  const int*        cooCols,
+                                                  size_t*           pBufferSizeInBytes)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_coosort_buffer_size(
         (rocsparse_handle)handle, m, n, nnz, cooRows, cooCols, pBufferSizeInBytes));
 }
 
 hipsparseStatus_t hipsparseXcoosortByRow(hipsparseHandle_t handle,
-                                         int m,
-                                         int n,
-                                         int nnz,
-                                         int* cooRows,
-                                         int* cooCols,
-                                         int* P,
-                                         void* pBuffer)
+                                         int               m,
+                                         int               n,
+                                         int               nnz,
+                                         int*              cooRows,
+                                         int*              cooCols,
+                                         int*              P,
+                                         void*             pBuffer)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_coosort_by_row(
         (rocsparse_handle)handle, m, n, nnz, cooRows, cooCols, P, pBuffer));
 }
 
 hipsparseStatus_t hipsparseXcoosortByColumn(hipsparseHandle_t handle,
-                                            int m,
-                                            int n,
-                                            int nnz,
-                                            int* cooRows,
-                                            int* cooCols,
-                                            int* P,
-                                            void* pBuffer)
+                                            int               m,
+                                            int               n,
+                                            int               nnz,
+                                            int*              cooRows,
+                                            int*              cooCols,
+                                            int*              P,
+                                            void*             pBuffer)
 {
     return rocSPARSEStatusToHIPStatus(rocsparse_coosort_by_column(
         (rocsparse_handle)handle, m, n, nnz, cooRows, cooCols, P, pBuffer));

--- a/library/src/nvcc_detail/hipsparse.cpp
+++ b/library/src/nvcc_detail/hipsparse.cpp
@@ -23,10 +23,10 @@
 
 #include "hipsparse.h"
 
-#include <stdio.h>
-#include <hip/hip_runtime_api.h>
 #include <cuda_runtime_api.h>
 #include <cusparse_v2.h>
+#include <hip/hip_runtime_api.h>
+#include <stdio.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,18 +45,28 @@ hipsparseStatus_t hipCUSPARSEStatusToHIPStatus(cusparseStatus_t cuStatus)
 {
     switch(cuStatus)
     {
-    case CUSPARSE_STATUS_SUCCESS: return HIPSPARSE_STATUS_SUCCESS;
-    case CUSPARSE_STATUS_NOT_INITIALIZED: return HIPSPARSE_STATUS_NOT_INITIALIZED;
-    case CUSPARSE_STATUS_ALLOC_FAILED: return HIPSPARSE_STATUS_ALLOC_FAILED;
-    case CUSPARSE_STATUS_INVALID_VALUE: return HIPSPARSE_STATUS_INVALID_VALUE;
-    case CUSPARSE_STATUS_ARCH_MISMATCH: return HIPSPARSE_STATUS_ARCH_MISMATCH;
-    case CUSPARSE_STATUS_MAPPING_ERROR: return HIPSPARSE_STATUS_MAPPING_ERROR;
-    case CUSPARSE_STATUS_EXECUTION_FAILED: return HIPSPARSE_STATUS_EXECUTION_FAILED;
-    case CUSPARSE_STATUS_INTERNAL_ERROR: return HIPSPARSE_STATUS_INTERNAL_ERROR;
+    case CUSPARSE_STATUS_SUCCESS:
+        return HIPSPARSE_STATUS_SUCCESS;
+    case CUSPARSE_STATUS_NOT_INITIALIZED:
+        return HIPSPARSE_STATUS_NOT_INITIALIZED;
+    case CUSPARSE_STATUS_ALLOC_FAILED:
+        return HIPSPARSE_STATUS_ALLOC_FAILED;
+    case CUSPARSE_STATUS_INVALID_VALUE:
+        return HIPSPARSE_STATUS_INVALID_VALUE;
+    case CUSPARSE_STATUS_ARCH_MISMATCH:
+        return HIPSPARSE_STATUS_ARCH_MISMATCH;
+    case CUSPARSE_STATUS_MAPPING_ERROR:
+        return HIPSPARSE_STATUS_MAPPING_ERROR;
+    case CUSPARSE_STATUS_EXECUTION_FAILED:
+        return HIPSPARSE_STATUS_EXECUTION_FAILED;
+    case CUSPARSE_STATUS_INTERNAL_ERROR:
+        return HIPSPARSE_STATUS_INTERNAL_ERROR;
     case CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED:
         return HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED;
-    case CUSPARSE_STATUS_ZERO_PIVOT: return HIPSPARSE_STATUS_ZERO_PIVOT;
-    default: throw "Non existent cusparseStatus_t";
+    case CUSPARSE_STATUS_ZERO_PIVOT:
+        return HIPSPARSE_STATUS_ZERO_PIVOT;
+    default:
+        throw "Non existent cusparseStatus_t";
     }
 }
 
@@ -64,9 +74,12 @@ cusparsePointerMode_t hipPointerModeToCudaPointerMode(hipsparsePointerMode_t mod
 {
     switch(mode)
     {
-    case HIPSPARSE_POINTER_MODE_HOST: return CUSPARSE_POINTER_MODE_HOST;
-    case HIPSPARSE_POINTER_MODE_DEVICE: return CUSPARSE_POINTER_MODE_DEVICE;
-    default: throw "Non existent hipsparsePointerMode_t";
+    case HIPSPARSE_POINTER_MODE_HOST:
+        return CUSPARSE_POINTER_MODE_HOST;
+    case HIPSPARSE_POINTER_MODE_DEVICE:
+        return CUSPARSE_POINTER_MODE_DEVICE;
+    default:
+        throw "Non existent hipsparsePointerMode_t";
     }
 }
 
@@ -74,9 +87,12 @@ hipsparsePointerMode_t CudaPointerModeToHIPPointerMode(cusparsePointerMode_t mod
 {
     switch(mode)
     {
-    case CUSPARSE_POINTER_MODE_HOST: return HIPSPARSE_POINTER_MODE_HOST;
-    case CUSPARSE_POINTER_MODE_DEVICE: return HIPSPARSE_POINTER_MODE_DEVICE;
-    default: throw "Non existent cusparsePointerMode_t";
+    case CUSPARSE_POINTER_MODE_HOST:
+        return HIPSPARSE_POINTER_MODE_HOST;
+    case CUSPARSE_POINTER_MODE_DEVICE:
+        return HIPSPARSE_POINTER_MODE_DEVICE;
+    default:
+        throw "Non existent cusparsePointerMode_t";
     }
 }
 
@@ -84,9 +100,12 @@ cusparseAction_t hipActionToCudaAction(hipsparseAction_t action)
 {
     switch(action)
     {
-    case HIPSPARSE_ACTION_SYMBOLIC: return CUSPARSE_ACTION_SYMBOLIC;
-    case HIPSPARSE_ACTION_NUMERIC: return CUSPARSE_ACTION_NUMERIC;
-    default: throw "Non existent hipsparseAction_t";
+    case HIPSPARSE_ACTION_SYMBOLIC:
+        return CUSPARSE_ACTION_SYMBOLIC;
+    case HIPSPARSE_ACTION_NUMERIC:
+        return CUSPARSE_ACTION_NUMERIC;
+    default:
+        throw "Non existent hipsparseAction_t";
     }
 }
 
@@ -94,9 +113,12 @@ hipsparseAction_t CudaActionToHIPAction(cusparseAction_t action)
 {
     switch(action)
     {
-    case CUSPARSE_ACTION_SYMBOLIC: return HIPSPARSE_ACTION_SYMBOLIC;
-    case CUSPARSE_ACTION_NUMERIC: return HIPSPARSE_ACTION_NUMERIC;
-    default: throw "Non existent cusparseAction_t";
+    case CUSPARSE_ACTION_SYMBOLIC:
+        return HIPSPARSE_ACTION_SYMBOLIC;
+    case CUSPARSE_ACTION_NUMERIC:
+        return HIPSPARSE_ACTION_NUMERIC;
+    default:
+        throw "Non existent cusparseAction_t";
     }
 }
 
@@ -104,11 +126,16 @@ cusparseMatrixType_t hipMatrixTypeToCudaMatrixType(hipsparseMatrixType_t type)
 {
     switch(type)
     {
-    case HIPSPARSE_MATRIX_TYPE_GENERAL: return CUSPARSE_MATRIX_TYPE_GENERAL;
-    case HIPSPARSE_MATRIX_TYPE_SYMMETRIC: return CUSPARSE_MATRIX_TYPE_SYMMETRIC;
-    case HIPSPARSE_MATRIX_TYPE_HERMITIAN: return CUSPARSE_MATRIX_TYPE_HERMITIAN;
-    case HIPSPARSE_MATRIX_TYPE_TRIANGULAR: return CUSPARSE_MATRIX_TYPE_TRIANGULAR;
-    default: throw "Non existent hipsparseMatrixType_t";
+    case HIPSPARSE_MATRIX_TYPE_GENERAL:
+        return CUSPARSE_MATRIX_TYPE_GENERAL;
+    case HIPSPARSE_MATRIX_TYPE_SYMMETRIC:
+        return CUSPARSE_MATRIX_TYPE_SYMMETRIC;
+    case HIPSPARSE_MATRIX_TYPE_HERMITIAN:
+        return CUSPARSE_MATRIX_TYPE_HERMITIAN;
+    case HIPSPARSE_MATRIX_TYPE_TRIANGULAR:
+        return CUSPARSE_MATRIX_TYPE_TRIANGULAR;
+    default:
+        throw "Non existent hipsparseMatrixType_t";
     }
 }
 
@@ -116,11 +143,16 @@ hipsparseMatrixType_t CudaMatrixTypeToHIPMatrixType(cusparseMatrixType_t type)
 {
     switch(type)
     {
-    case CUSPARSE_MATRIX_TYPE_GENERAL: return HIPSPARSE_MATRIX_TYPE_GENERAL;
-    case CUSPARSE_MATRIX_TYPE_SYMMETRIC: return HIPSPARSE_MATRIX_TYPE_SYMMETRIC;
-    case CUSPARSE_MATRIX_TYPE_HERMITIAN: return HIPSPARSE_MATRIX_TYPE_HERMITIAN;
-    case CUSPARSE_MATRIX_TYPE_TRIANGULAR: return HIPSPARSE_MATRIX_TYPE_TRIANGULAR;
-    default: throw "Non existent cusparseMatrixType_t";
+    case CUSPARSE_MATRIX_TYPE_GENERAL:
+        return HIPSPARSE_MATRIX_TYPE_GENERAL;
+    case CUSPARSE_MATRIX_TYPE_SYMMETRIC:
+        return HIPSPARSE_MATRIX_TYPE_SYMMETRIC;
+    case CUSPARSE_MATRIX_TYPE_HERMITIAN:
+        return HIPSPARSE_MATRIX_TYPE_HERMITIAN;
+    case CUSPARSE_MATRIX_TYPE_TRIANGULAR:
+        return HIPSPARSE_MATRIX_TYPE_TRIANGULAR;
+    default:
+        throw "Non existent cusparseMatrixType_t";
     }
 }
 
@@ -128,9 +160,12 @@ cusparseFillMode_t hipFillToCudaFill(hipsparseFillMode_t fill)
 {
     switch(fill)
     {
-    case HIPSPARSE_FILL_MODE_LOWER: return CUSPARSE_FILL_MODE_LOWER;
-    case HIPSPARSE_FILL_MODE_UPPER: return CUSPARSE_FILL_MODE_UPPER;
-    default: throw "Non existent hipsparseFillMode_t";
+    case HIPSPARSE_FILL_MODE_LOWER:
+        return CUSPARSE_FILL_MODE_LOWER;
+    case HIPSPARSE_FILL_MODE_UPPER:
+        return CUSPARSE_FILL_MODE_UPPER;
+    default:
+        throw "Non existent hipsparseFillMode_t";
     }
 }
 
@@ -138,9 +173,12 @@ hipsparseFillMode_t CudaFillToHIPFill(cusparseFillMode_t fill)
 {
     switch(fill)
     {
-    case CUSPARSE_FILL_MODE_LOWER: return HIPSPARSE_FILL_MODE_LOWER;
-    case CUSPARSE_FILL_MODE_UPPER: return HIPSPARSE_FILL_MODE_UPPER;
-    default: throw "Non existent cusparseFillMode_t";
+    case CUSPARSE_FILL_MODE_LOWER:
+        return HIPSPARSE_FILL_MODE_LOWER;
+    case CUSPARSE_FILL_MODE_UPPER:
+        return HIPSPARSE_FILL_MODE_UPPER;
+    default:
+        throw "Non existent cusparseFillMode_t";
     }
 }
 
@@ -148,9 +186,12 @@ cusparseDiagType_t hipDiagonalToCudaDiagonal(hipsparseDiagType_t diagonal)
 {
     switch(diagonal)
     {
-    case HIPSPARSE_DIAG_TYPE_NON_UNIT: return CUSPARSE_DIAG_TYPE_NON_UNIT;
-    case HIPSPARSE_DIAG_TYPE_UNIT: return CUSPARSE_DIAG_TYPE_UNIT;
-    default: throw "Non existent hipsparseDiagType_t";
+    case HIPSPARSE_DIAG_TYPE_NON_UNIT:
+        return CUSPARSE_DIAG_TYPE_NON_UNIT;
+    case HIPSPARSE_DIAG_TYPE_UNIT:
+        return CUSPARSE_DIAG_TYPE_UNIT;
+    default:
+        throw "Non existent hipsparseDiagType_t";
     }
 }
 
@@ -158,9 +199,12 @@ hipsparseDiagType_t CudaDiagonalToHIPDiagonal(cusparseDiagType_t diagonal)
 {
     switch(diagonal)
     {
-    case CUSPARSE_DIAG_TYPE_NON_UNIT: return HIPSPARSE_DIAG_TYPE_NON_UNIT;
-    case CUSPARSE_DIAG_TYPE_UNIT: return HIPSPARSE_DIAG_TYPE_UNIT;
-    default: throw "Non existent cusparseDiagType_t";
+    case CUSPARSE_DIAG_TYPE_NON_UNIT:
+        return HIPSPARSE_DIAG_TYPE_NON_UNIT;
+    case CUSPARSE_DIAG_TYPE_UNIT:
+        return HIPSPARSE_DIAG_TYPE_UNIT;
+    default:
+        throw "Non existent cusparseDiagType_t";
     }
 }
 
@@ -168,9 +212,12 @@ cusparseIndexBase_t hipIndexBaseToCudaIndexBase(hipsparseIndexBase_t base)
 {
     switch(base)
     {
-    case HIPSPARSE_INDEX_BASE_ZERO: return CUSPARSE_INDEX_BASE_ZERO;
-    case HIPSPARSE_INDEX_BASE_ONE: return CUSPARSE_INDEX_BASE_ONE;
-    default: throw "Non existent hipsparseIndexBase_t";
+    case HIPSPARSE_INDEX_BASE_ZERO:
+        return CUSPARSE_INDEX_BASE_ZERO;
+    case HIPSPARSE_INDEX_BASE_ONE:
+        return CUSPARSE_INDEX_BASE_ONE;
+    default:
+        throw "Non existent hipsparseIndexBase_t";
     }
 }
 
@@ -178,9 +225,12 @@ hipsparseIndexBase_t CudaIndexBaseToHIPIndexBase(cusparseIndexBase_t base)
 {
     switch(base)
     {
-    case CUSPARSE_INDEX_BASE_ZERO: return HIPSPARSE_INDEX_BASE_ZERO;
-    case CUSPARSE_INDEX_BASE_ONE: return HIPSPARSE_INDEX_BASE_ONE;
-    default: throw "Non existent cusparseIndexBase_t";
+    case CUSPARSE_INDEX_BASE_ZERO:
+        return HIPSPARSE_INDEX_BASE_ZERO;
+    case CUSPARSE_INDEX_BASE_ONE:
+        return HIPSPARSE_INDEX_BASE_ONE;
+    default:
+        throw "Non existent cusparseIndexBase_t";
     }
 }
 
@@ -188,10 +238,14 @@ cusparseOperation_t hipOperationToCudaOperation(hipsparseOperation_t op)
 {
     switch(op)
     {
-    case HIPSPARSE_OPERATION_NON_TRANSPOSE: return CUSPARSE_OPERATION_NON_TRANSPOSE;
-    case HIPSPARSE_OPERATION_TRANSPOSE: return CUSPARSE_OPERATION_TRANSPOSE;
-    case HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE: return CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE;
-    default: throw "Non existent hipsparseOperation_t";
+    case HIPSPARSE_OPERATION_NON_TRANSPOSE:
+        return CUSPARSE_OPERATION_NON_TRANSPOSE;
+    case HIPSPARSE_OPERATION_TRANSPOSE:
+        return CUSPARSE_OPERATION_TRANSPOSE;
+    case HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE:
+        return CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE;
+    default:
+        throw "Non existent hipsparseOperation_t";
     }
 }
 
@@ -199,10 +253,14 @@ hipsparseOperation_t CudaOperationToHIPOperation(cusparseOperation_t op)
 {
     switch(op)
     {
-    case CUSPARSE_OPERATION_NON_TRANSPOSE: return HIPSPARSE_OPERATION_NON_TRANSPOSE;
-    case CUSPARSE_OPERATION_TRANSPOSE: return HIPSPARSE_OPERATION_TRANSPOSE;
-    case CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE: return HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE;
-    default: throw "Non existent cusparseOperation_t";
+    case CUSPARSE_OPERATION_NON_TRANSPOSE:
+        return HIPSPARSE_OPERATION_NON_TRANSPOSE;
+    case CUSPARSE_OPERATION_TRANSPOSE:
+        return HIPSPARSE_OPERATION_TRANSPOSE;
+    case CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE:
+        return HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE;
+    default:
+        throw "Non existent cusparseOperation_t";
     }
 }
 
@@ -210,10 +268,14 @@ cusparseHybPartition_t hipHybPartitionToCudaHybPartition(hipsparseHybPartition_t
 {
     switch(part)
     {
-    case HIPSPARSE_HYB_PARTITION_AUTO: return CUSPARSE_HYB_PARTITION_AUTO;
-    case HIPSPARSE_HYB_PARTITION_USER: return CUSPARSE_HYB_PARTITION_USER;
-    case HIPSPARSE_HYB_PARTITION_MAX: return CUSPARSE_HYB_PARTITION_MAX;
-    default: throw "Non existent hipsparseHybPartition_t";
+    case HIPSPARSE_HYB_PARTITION_AUTO:
+        return CUSPARSE_HYB_PARTITION_AUTO;
+    case HIPSPARSE_HYB_PARTITION_USER:
+        return CUSPARSE_HYB_PARTITION_USER;
+    case HIPSPARSE_HYB_PARTITION_MAX:
+        return CUSPARSE_HYB_PARTITION_MAX;
+    default:
+        throw "Non existent hipsparseHybPartition_t";
     }
 }
 
@@ -221,9 +283,12 @@ cusparseSolvePolicy_t hipPolicyToCudaPolicy(hipsparseSolvePolicy_t policy)
 {
     switch(policy)
     {
-    case HIPSPARSE_SOLVE_POLICY_NO_LEVEL: return CUSPARSE_SOLVE_POLICY_NO_LEVEL;
-    case HIPSPARSE_SOLVE_POLICY_USE_LEVEL: return CUSPARSE_SOLVE_POLICY_USE_LEVEL;
-    default: throw "Non existent hipsparseSolvePolicy_t";
+    case HIPSPARSE_SOLVE_POLICY_NO_LEVEL:
+        return CUSPARSE_SOLVE_POLICY_NO_LEVEL;
+    case HIPSPARSE_SOLVE_POLICY_USE_LEVEL:
+        return CUSPARSE_SOLVE_POLICY_USE_LEVEL;
+    default:
+        throw "Non existent hipsparseSolvePolicy_t";
     }
 }
 
@@ -231,9 +296,12 @@ cusparseSideMode_t hipSideToCudaSide(hipsparseSideMode_t side)
 {
     switch(side)
     {
-    case HIPSPARSE_SIDE_LEFT: return CUSPARSE_SIDE_LEFT;
-    case HIPSPARSE_SIDE_RIGHT: return CUSPARSE_SIDE_RIGHT;
-    default: throw "Non existent hipsparseSideMode_t";
+    case HIPSPARSE_SIDE_LEFT:
+        return CUSPARSE_SIDE_LEFT;
+    case HIPSPARSE_SIDE_RIGHT:
+        return CUSPARSE_SIDE_RIGHT;
+    default:
+        throw "Non existent hipsparseSideMode_t";
     }
 }
 
@@ -241,9 +309,12 @@ hipsparseSideMode_t CudaSideToHIPSide(cusparseSideMode_t side)
 {
     switch(side)
     {
-    case CUSPARSE_SIDE_LEFT: return HIPSPARSE_SIDE_LEFT;
-    case CUSPARSE_SIDE_RIGHT: return HIPSPARSE_SIDE_RIGHT;
-    default: throw "Non existent cusparseSideMode_t";
+    case CUSPARSE_SIDE_LEFT:
+        return HIPSPARSE_SIDE_LEFT;
+    case CUSPARSE_SIDE_RIGHT:
+        return HIPSPARSE_SIDE_RIGHT;
+    default:
+        throw "Non existent cusparseSideMode_t";
     }
 }
 
@@ -314,8 +385,8 @@ hipsparseStatus_t hipsparseSetPointerMode(hipsparseHandle_t handle, hipsparsePoi
 hipsparseStatus_t hipsparseGetPointerMode(hipsparseHandle_t handle, hipsparsePointerMode_t* mode)
 {
     cusparsePointerMode_t cusparseMode;
-    cusparseStatus_t status = cusparseGetPointerMode((cusparseHandle_t)handle, &cusparseMode);
-    *mode                   = CudaPointerModeToHIPPointerMode(cusparseMode);
+    cusparseStatus_t      status = cusparseGetPointerMode((cusparseHandle_t)handle, &cusparseMode);
+    *mode                        = CudaPointerModeToHIPPointerMode(cusparseMode);
     return hipCUSPARSEStatusToHIPStatus(status);
 }
 
@@ -409,36 +480,36 @@ hipsparseStatus_t hipsparseDestroyCsrilu02Info(csrilu02Info_t info)
     return hipCUSPARSEStatusToHIPStatus(cusparseDestroyCsrilu02Info((csrilu02Info_t)info));
 }
 
-hipsparseStatus_t hipsparseSaxpyi(hipsparseHandle_t handle,
-                                  int nnz,
-                                  const float* alpha,
-                                  const float* xVal,
-                                  const int* xInd,
-                                  float* y,
+hipsparseStatus_t hipsparseSaxpyi(hipsparseHandle_t    handle,
+                                  int                  nnz,
+                                  const float*         alpha,
+                                  const float*         xVal,
+                                  const int*           xInd,
+                                  float*               y,
                                   hipsparseIndexBase_t idxBase)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseSaxpyi(
         (cusparseHandle_t)handle, nnz, alpha, xVal, xInd, y, hipIndexBaseToCudaIndexBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseDaxpyi(hipsparseHandle_t handle,
-                                  int nnz,
-                                  const double* alpha,
-                                  const double* xVal,
-                                  const int* xInd,
-                                  double* y,
+hipsparseStatus_t hipsparseDaxpyi(hipsparseHandle_t    handle,
+                                  int                  nnz,
+                                  const double*        alpha,
+                                  const double*        xVal,
+                                  const int*           xInd,
+                                  double*              y,
                                   hipsparseIndexBase_t idxBase)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseDaxpyi(
         (cusparseHandle_t)handle, nnz, alpha, xVal, xInd, y, hipIndexBaseToCudaIndexBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseSdoti(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const float* xVal,
-                                 const int* xInd,
-                                 const float* y,
-                                 float* result,
+hipsparseStatus_t hipsparseSdoti(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 const float*         xVal,
+                                 const int*           xInd,
+                                 const float*         y,
+                                 float*               result,
                                  hipsparseIndexBase_t idxBase)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseSdoti((cusparseHandle_t)handle,
@@ -450,12 +521,12 @@ hipsparseStatus_t hipsparseSdoti(hipsparseHandle_t handle,
                                                       hipIndexBaseToCudaIndexBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseDdoti(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const double* xVal,
-                                 const int* xInd,
-                                 const double* y,
-                                 double* result,
+hipsparseStatus_t hipsparseDdoti(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 const double*        xVal,
+                                 const int*           xInd,
+                                 const double*        y,
+                                 double*              result,
                                  hipsparseIndexBase_t idxBase)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseDdoti((cusparseHandle_t)handle,
@@ -467,111 +538,111 @@ hipsparseStatus_t hipsparseDdoti(hipsparseHandle_t handle,
                                                       hipIndexBaseToCudaIndexBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseSgthr(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const float* y,
-                                 float* xVal,
-                                 const int* xInd,
+hipsparseStatus_t hipsparseSgthr(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 const float*         y,
+                                 float*               xVal,
+                                 const int*           xInd,
                                  hipsparseIndexBase_t idxBase)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseSgthr(
         (cusparseHandle_t)handle, nnz, y, xVal, xInd, hipIndexBaseToCudaIndexBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseDgthr(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const double* y,
-                                 double* xVal,
-                                 const int* xInd,
+hipsparseStatus_t hipsparseDgthr(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 const double*        y,
+                                 double*              xVal,
+                                 const int*           xInd,
                                  hipsparseIndexBase_t idxBase)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseDgthr(
         (cusparseHandle_t)handle, nnz, y, xVal, xInd, hipIndexBaseToCudaIndexBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseSgthrz(hipsparseHandle_t handle,
-                                  int nnz,
-                                  float* y,
-                                  float* xVal,
-                                  const int* xInd,
+hipsparseStatus_t hipsparseSgthrz(hipsparseHandle_t    handle,
+                                  int                  nnz,
+                                  float*               y,
+                                  float*               xVal,
+                                  const int*           xInd,
                                   hipsparseIndexBase_t idxBase)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseSgthrz(
         (cusparseHandle_t)handle, nnz, y, xVal, xInd, hipIndexBaseToCudaIndexBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseDgthrz(hipsparseHandle_t handle,
-                                  int nnz,
-                                  double* y,
-                                  double* xVal,
-                                  const int* xInd,
+hipsparseStatus_t hipsparseDgthrz(hipsparseHandle_t    handle,
+                                  int                  nnz,
+                                  double*              y,
+                                  double*              xVal,
+                                  const int*           xInd,
                                   hipsparseIndexBase_t idxBase)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseDgthrz(
         (cusparseHandle_t)handle, nnz, y, xVal, xInd, hipIndexBaseToCudaIndexBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseSroti(hipsparseHandle_t handle,
-                                 int nnz,
-                                 float* xVal,
-                                 const int* xInd,
-                                 float* y,
-                                 const float* c,
-                                 const float* s,
+hipsparseStatus_t hipsparseSroti(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 float*               xVal,
+                                 const int*           xInd,
+                                 float*               y,
+                                 const float*         c,
+                                 const float*         s,
                                  hipsparseIndexBase_t idxBase)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseSroti(
         (cusparseHandle_t)handle, nnz, xVal, xInd, y, c, s, hipIndexBaseToCudaIndexBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseDroti(hipsparseHandle_t handle,
-                                 int nnz,
-                                 double* xVal,
-                                 const int* xInd,
-                                 double* y,
-                                 const double* c,
-                                 const double* s,
+hipsparseStatus_t hipsparseDroti(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 double*              xVal,
+                                 const int*           xInd,
+                                 double*              y,
+                                 const double*        c,
+                                 const double*        s,
                                  hipsparseIndexBase_t idxBase)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseDroti(
         (cusparseHandle_t)handle, nnz, xVal, xInd, y, c, s, hipIndexBaseToCudaIndexBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseSsctr(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const float* xVal,
-                                 const int* xInd,
-                                 float* y,
+hipsparseStatus_t hipsparseSsctr(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 const float*         xVal,
+                                 const int*           xInd,
+                                 float*               y,
                                  hipsparseIndexBase_t idxBase)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseSsctr(
         (cusparseHandle_t)handle, nnz, xVal, xInd, y, hipIndexBaseToCudaIndexBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseDsctr(hipsparseHandle_t handle,
-                                 int nnz,
-                                 const double* xVal,
-                                 const int* xInd,
-                                 double* y,
+hipsparseStatus_t hipsparseDsctr(hipsparseHandle_t    handle,
+                                 int                  nnz,
+                                 const double*        xVal,
+                                 const int*           xInd,
+                                 double*              y,
                                  hipsparseIndexBase_t idxBase)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseDsctr(
         (cusparseHandle_t)handle, nnz, xVal, xInd, y, hipIndexBaseToCudaIndexBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseScsrmv(hipsparseHandle_t handle,
-                                  hipsparseOperation_t transA,
-                                  int m,
-                                  int n,
-                                  int nnz,
-                                  const float* alpha,
+hipsparseStatus_t hipsparseScsrmv(hipsparseHandle_t         handle,
+                                  hipsparseOperation_t      transA,
+                                  int                       m,
+                                  int                       n,
+                                  int                       nnz,
+                                  const float*              alpha,
                                   const hipsparseMatDescr_t descrA,
-                                  const float* csrSortedValA,
-                                  const int* csrSortedRowPtrA,
-                                  const int* csrSortedColIndA,
-                                  const float* x,
-                                  const float* beta,
-                                  float* y)
+                                  const float*              csrSortedValA,
+                                  const int*                csrSortedRowPtrA,
+                                  const int*                csrSortedColIndA,
+                                  const float*              x,
+                                  const float*              beta,
+                                  float*                    y)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseScsrmv((cusparseHandle_t)handle,
                                                        hipOperationToCudaOperation(transA),
@@ -588,19 +659,19 @@ hipsparseStatus_t hipsparseScsrmv(hipsparseHandle_t handle,
                                                        y));
 }
 
-hipsparseStatus_t hipsparseDcsrmv(hipsparseHandle_t handle,
-                                  hipsparseOperation_t transA,
-                                  int m,
-                                  int n,
-                                  int nnz,
-                                  const double* alpha,
+hipsparseStatus_t hipsparseDcsrmv(hipsparseHandle_t         handle,
+                                  hipsparseOperation_t      transA,
+                                  int                       m,
+                                  int                       n,
+                                  int                       nnz,
+                                  const double*             alpha,
                                   const hipsparseMatDescr_t descrA,
-                                  const double* csrSortedValA,
-                                  const int* csrSortedRowPtrA,
-                                  const int* csrSortedColIndA,
-                                  const double* x,
-                                  const double* beta,
-                                  double* y)
+                                  const double*             csrSortedValA,
+                                  const int*                csrSortedRowPtrA,
+                                  const int*                csrSortedColIndA,
+                                  const double*             x,
+                                  const double*             beta,
+                                  double*                   y)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseDcsrmv((cusparseHandle_t)handle,
                                                        hipOperationToCudaOperation(transA),
@@ -618,22 +689,22 @@ hipsparseStatus_t hipsparseDcsrmv(hipsparseHandle_t handle,
 }
 
 hipsparseStatus_t
-hipsparseXcsrsv2_zeroPivot(hipsparseHandle_t handle, csrsv2Info_t info, int* position)
+    hipsparseXcsrsv2_zeroPivot(hipsparseHandle_t handle, csrsv2Info_t info, int* position)
 {
     return hipCUSPARSEStatusToHIPStatus(
         cusparseXcsrsv2_zeroPivot((cusparseHandle_t)handle, (csrsv2Info_t)info, position));
 }
 
-hipsparseStatus_t hipsparseScsrsv2_bufferSize(hipsparseHandle_t handle,
-                                              hipsparseOperation_t transA,
-                                              int m,
-                                              int nnz,
+hipsparseStatus_t hipsparseScsrsv2_bufferSize(hipsparseHandle_t         handle,
+                                              hipsparseOperation_t      transA,
+                                              int                       m,
+                                              int                       nnz,
                                               const hipsparseMatDescr_t descrA,
-                                              float* csrSortedValA,
-                                              const int* csrSortedRowPtrA,
-                                              const int* csrSortedColIndA,
-                                              csrsv2Info_t info,
-                                              int* pBufferSizeInBytes)
+                                              float*                    csrSortedValA,
+                                              const int*                csrSortedRowPtrA,
+                                              const int*                csrSortedColIndA,
+                                              csrsv2Info_t              info,
+                                              int*                      pBufferSizeInBytes)
 {
     return hipCUSPARSEStatusToHIPStatus(
         cusparseScsrsv2_bufferSize((cusparseHandle_t)handle,
@@ -648,16 +719,16 @@ hipsparseStatus_t hipsparseScsrsv2_bufferSize(hipsparseHandle_t handle,
                                    pBufferSizeInBytes));
 }
 
-hipsparseStatus_t hipsparseDcsrsv2_bufferSize(hipsparseHandle_t handle,
-                                              hipsparseOperation_t transA,
-                                              int m,
-                                              int nnz,
+hipsparseStatus_t hipsparseDcsrsv2_bufferSize(hipsparseHandle_t         handle,
+                                              hipsparseOperation_t      transA,
+                                              int                       m,
+                                              int                       nnz,
                                               const hipsparseMatDescr_t descrA,
-                                              double* csrSortedValA,
-                                              const int* csrSortedRowPtrA,
-                                              const int* csrSortedColIndA,
-                                              csrsv2Info_t info,
-                                              int* pBufferSizeInBytes)
+                                              double*                   csrSortedValA,
+                                              const int*                csrSortedRowPtrA,
+                                              const int*                csrSortedColIndA,
+                                              csrsv2Info_t              info,
+                                              int*                      pBufferSizeInBytes)
 {
     return hipCUSPARSEStatusToHIPStatus(
         cusparseDcsrsv2_bufferSize((cusparseHandle_t)handle,
@@ -672,16 +743,16 @@ hipsparseStatus_t hipsparseDcsrsv2_bufferSize(hipsparseHandle_t handle,
                                    pBufferSizeInBytes));
 }
 
-hipsparseStatus_t hipsparseScsrsv2_bufferSizeExt(hipsparseHandle_t handle,
-                                                 hipsparseOperation_t transA,
-                                                 int m,
-                                                 int nnz,
+hipsparseStatus_t hipsparseScsrsv2_bufferSizeExt(hipsparseHandle_t         handle,
+                                                 hipsparseOperation_t      transA,
+                                                 int                       m,
+                                                 int                       nnz,
                                                  const hipsparseMatDescr_t descrA,
-                                                 float* csrSortedValA,
-                                                 const int* csrSortedRowPtrA,
-                                                 const int* csrSortedColIndA,
-                                                 csrsv2Info_t info,
-                                                 size_t* pBufferSize)
+                                                 float*                    csrSortedValA,
+                                                 const int*                csrSortedRowPtrA,
+                                                 const int*                csrSortedColIndA,
+                                                 csrsv2Info_t              info,
+                                                 size_t*                   pBufferSize)
 {
     return hipCUSPARSEStatusToHIPStatus(
         cusparseScsrsv2_bufferSizeExt((cusparseHandle_t)handle,
@@ -696,16 +767,16 @@ hipsparseStatus_t hipsparseScsrsv2_bufferSizeExt(hipsparseHandle_t handle,
                                       pBufferSize));
 }
 
-hipsparseStatus_t hipsparseDcsrsv2_bufferSizeExt(hipsparseHandle_t handle,
-                                                 hipsparseOperation_t transA,
-                                                 int m,
-                                                 int nnz,
+hipsparseStatus_t hipsparseDcsrsv2_bufferSizeExt(hipsparseHandle_t         handle,
+                                                 hipsparseOperation_t      transA,
+                                                 int                       m,
+                                                 int                       nnz,
                                                  const hipsparseMatDescr_t descrA,
-                                                 double* csrSortedValA,
-                                                 const int* csrSortedRowPtrA,
-                                                 const int* csrSortedColIndA,
-                                                 csrsv2Info_t info,
-                                                 size_t* pBufferSize)
+                                                 double*                   csrSortedValA,
+                                                 const int*                csrSortedRowPtrA,
+                                                 const int*                csrSortedColIndA,
+                                                 csrsv2Info_t              info,
+                                                 size_t*                   pBufferSize)
 {
     return hipCUSPARSEStatusToHIPStatus(
         cusparseDcsrsv2_bufferSizeExt((cusparseHandle_t)handle,
@@ -720,17 +791,17 @@ hipsparseStatus_t hipsparseDcsrsv2_bufferSizeExt(hipsparseHandle_t handle,
                                       pBufferSize));
 }
 
-hipsparseStatus_t hipsparseScsrsv2_analysis(hipsparseHandle_t handle,
-                                            hipsparseOperation_t transA,
-                                            int m,
-                                            int nnz,
+hipsparseStatus_t hipsparseScsrsv2_analysis(hipsparseHandle_t         handle,
+                                            hipsparseOperation_t      transA,
+                                            int                       m,
+                                            int                       nnz,
                                             const hipsparseMatDescr_t descrA,
-                                            const float* csrSortedValA,
-                                            const int* csrSortedRowPtrA,
-                                            const int* csrSortedColIndA,
-                                            csrsv2Info_t info,
-                                            hipsparseSolvePolicy_t policy,
-                                            void* pBuffer)
+                                            const float*              csrSortedValA,
+                                            const int*                csrSortedRowPtrA,
+                                            const int*                csrSortedColIndA,
+                                            csrsv2Info_t              info,
+                                            hipsparseSolvePolicy_t    policy,
+                                            void*                     pBuffer)
 {
     return hipCUSPARSEStatusToHIPStatus(
         cusparseScsrsv2_analysis((cusparseHandle_t)handle,
@@ -746,17 +817,17 @@ hipsparseStatus_t hipsparseScsrsv2_analysis(hipsparseHandle_t handle,
                                  pBuffer));
 }
 
-hipsparseStatus_t hipsparseDcsrsv2_analysis(hipsparseHandle_t handle,
-                                            hipsparseOperation_t transA,
-                                            int m,
-                                            int nnz,
+hipsparseStatus_t hipsparseDcsrsv2_analysis(hipsparseHandle_t         handle,
+                                            hipsparseOperation_t      transA,
+                                            int                       m,
+                                            int                       nnz,
                                             const hipsparseMatDescr_t descrA,
-                                            const double* csrSortedValA,
-                                            const int* csrSortedRowPtrA,
-                                            const int* csrSortedColIndA,
-                                            csrsv2Info_t info,
-                                            hipsparseSolvePolicy_t policy,
-                                            void* pBuffer)
+                                            const double*             csrSortedValA,
+                                            const int*                csrSortedRowPtrA,
+                                            const int*                csrSortedColIndA,
+                                            csrsv2Info_t              info,
+                                            hipsparseSolvePolicy_t    policy,
+                                            void*                     pBuffer)
 {
     return hipCUSPARSEStatusToHIPStatus(
         cusparseDcsrsv2_analysis((cusparseHandle_t)handle,
@@ -772,20 +843,20 @@ hipsparseStatus_t hipsparseDcsrsv2_analysis(hipsparseHandle_t handle,
                                  pBuffer));
 }
 
-hipsparseStatus_t hipsparseScsrsv2_solve(hipsparseHandle_t handle,
-                                         hipsparseOperation_t transA,
-                                         int m,
-                                         int nnz,
-                                         const float* alpha,
+hipsparseStatus_t hipsparseScsrsv2_solve(hipsparseHandle_t         handle,
+                                         hipsparseOperation_t      transA,
+                                         int                       m,
+                                         int                       nnz,
+                                         const float*              alpha,
                                          const hipsparseMatDescr_t descrA,
-                                         const float* csrSortedValA,
-                                         const int* csrSortedRowPtrA,
-                                         const int* csrSortedColIndA,
-                                         csrsv2Info_t info,
-                                         const float* f,
-                                         float* x,
-                                         hipsparseSolvePolicy_t policy,
-                                         void* pBuffer)
+                                         const float*              csrSortedValA,
+                                         const int*                csrSortedRowPtrA,
+                                         const int*                csrSortedColIndA,
+                                         csrsv2Info_t              info,
+                                         const float*              f,
+                                         float*                    x,
+                                         hipsparseSolvePolicy_t    policy,
+                                         void*                     pBuffer)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseScsrsv2_solve((cusparseHandle_t)handle,
                                                               hipOperationToCudaOperation(transA),
@@ -803,20 +874,20 @@ hipsparseStatus_t hipsparseScsrsv2_solve(hipsparseHandle_t handle,
                                                               pBuffer));
 }
 
-hipsparseStatus_t hipsparseDcsrsv2_solve(hipsparseHandle_t handle,
-                                         hipsparseOperation_t transA,
-                                         int m,
-                                         int nnz,
-                                         const double* alpha,
+hipsparseStatus_t hipsparseDcsrsv2_solve(hipsparseHandle_t         handle,
+                                         hipsparseOperation_t      transA,
+                                         int                       m,
+                                         int                       nnz,
+                                         const double*             alpha,
                                          const hipsparseMatDescr_t descrA,
-                                         const double* csrSortedValA,
-                                         const int* csrSortedRowPtrA,
-                                         const int* csrSortedColIndA,
-                                         csrsv2Info_t info,
-                                         const double* f,
-                                         double* x,
-                                         hipsparseSolvePolicy_t policy,
-                                         void* pBuffer)
+                                         const double*             csrSortedValA,
+                                         const int*                csrSortedRowPtrA,
+                                         const int*                csrSortedColIndA,
+                                         csrsv2Info_t              info,
+                                         const double*             f,
+                                         double*                   x,
+                                         hipsparseSolvePolicy_t    policy,
+                                         void*                     pBuffer)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseDcsrsv2_solve((cusparseHandle_t)handle,
                                                               hipOperationToCudaOperation(transA),
@@ -834,14 +905,14 @@ hipsparseStatus_t hipsparseDcsrsv2_solve(hipsparseHandle_t handle,
                                                               pBuffer));
 }
 
-hipsparseStatus_t hipsparseShybmv(hipsparseHandle_t handle,
-                                  hipsparseOperation_t transA,
-                                  const float* alpha,
+hipsparseStatus_t hipsparseShybmv(hipsparseHandle_t         handle,
+                                  hipsparseOperation_t      transA,
+                                  const float*              alpha,
                                   const hipsparseMatDescr_t descrA,
-                                  const hipsparseHybMat_t hybA,
-                                  const float* x,
-                                  const float* beta,
-                                  float* y)
+                                  const hipsparseHybMat_t   hybA,
+                                  const float*              x,
+                                  const float*              beta,
+                                  float*                    y)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseShybmv((cusparseHandle_t)handle,
                                                        hipOperationToCudaOperation(transA),
@@ -853,14 +924,14 @@ hipsparseStatus_t hipsparseShybmv(hipsparseHandle_t handle,
                                                        y));
 }
 
-hipsparseStatus_t hipsparseDhybmv(hipsparseHandle_t handle,
-                                  hipsparseOperation_t transA,
-                                  const double* alpha,
+hipsparseStatus_t hipsparseDhybmv(hipsparseHandle_t         handle,
+                                  hipsparseOperation_t      transA,
+                                  const double*             alpha,
                                   const hipsparseMatDescr_t descrA,
-                                  const hipsparseHybMat_t hybA,
-                                  const double* x,
-                                  const double* beta,
-                                  double* y)
+                                  const hipsparseHybMat_t   hybA,
+                                  const double*             x,
+                                  const double*             beta,
+                                  double*                   y)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseDhybmv((cusparseHandle_t)handle,
                                                        hipOperationToCudaOperation(transA),
@@ -872,22 +943,22 @@ hipsparseStatus_t hipsparseDhybmv(hipsparseHandle_t handle,
                                                        y));
 }
 
-hipsparseStatus_t hipsparseScsrmm(hipsparseHandle_t handle,
-                                  hipsparseOperation_t transA,
-                                  int m,
-                                  int n,
-                                  int k,
-                                  int nnz,
-                                  const float* alpha,
+hipsparseStatus_t hipsparseScsrmm(hipsparseHandle_t         handle,
+                                  hipsparseOperation_t      transA,
+                                  int                       m,
+                                  int                       n,
+                                  int                       k,
+                                  int                       nnz,
+                                  const float*              alpha,
                                   const hipsparseMatDescr_t descrA,
-                                  const float* csrSortedValA,
-                                  const int* csrSortedRowPtrA,
-                                  const int* csrSortedColIndA,
-                                  const float* B,
-                                  int ldb,
-                                  const float* beta,
-                                  float* C,
-                                  int ldc)
+                                  const float*              csrSortedValA,
+                                  const int*                csrSortedRowPtrA,
+                                  const int*                csrSortedColIndA,
+                                  const float*              B,
+                                  int                       ldb,
+                                  const float*              beta,
+                                  float*                    C,
+                                  int                       ldc)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseScsrmm((cusparseHandle_t)handle,
                                                        hipOperationToCudaOperation(transA),
@@ -907,22 +978,22 @@ hipsparseStatus_t hipsparseScsrmm(hipsparseHandle_t handle,
                                                        ldc));
 }
 
-hipsparseStatus_t hipsparseDcsrmm(hipsparseHandle_t handle,
-                                  hipsparseOperation_t transA,
-                                  int m,
-                                  int n,
-                                  int k,
-                                  int nnz,
-                                  const double* alpha,
+hipsparseStatus_t hipsparseDcsrmm(hipsparseHandle_t         handle,
+                                  hipsparseOperation_t      transA,
+                                  int                       m,
+                                  int                       n,
+                                  int                       k,
+                                  int                       nnz,
+                                  const double*             alpha,
                                   const hipsparseMatDescr_t descrA,
-                                  const double* csrSortedValA,
-                                  const int* csrSortedRowPtrA,
-                                  const int* csrSortedColIndA,
-                                  const double* B,
-                                  int ldb,
-                                  const double* beta,
-                                  double* C,
-                                  int ldc)
+                                  const double*             csrSortedValA,
+                                  const int*                csrSortedRowPtrA,
+                                  const int*                csrSortedColIndA,
+                                  const double*             B,
+                                  int                       ldb,
+                                  const double*             beta,
+                                  double*                   C,
+                                  int                       ldc)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseDcsrmm((cusparseHandle_t)handle,
                                                        hipOperationToCudaOperation(transA),
@@ -942,23 +1013,23 @@ hipsparseStatus_t hipsparseDcsrmm(hipsparseHandle_t handle,
                                                        ldc));
 }
 
-hipsparseStatus_t hipsparseScsrmm2(hipsparseHandle_t handle,
-                                   hipsparseOperation_t transA,
-                                   hipsparseOperation_t transB,
-                                   int m,
-                                   int n,
-                                   int k,
-                                   int nnz,
-                                   const float* alpha,
+hipsparseStatus_t hipsparseScsrmm2(hipsparseHandle_t         handle,
+                                   hipsparseOperation_t      transA,
+                                   hipsparseOperation_t      transB,
+                                   int                       m,
+                                   int                       n,
+                                   int                       k,
+                                   int                       nnz,
+                                   const float*              alpha,
                                    const hipsparseMatDescr_t descrA,
-                                   const float* csrSortedValA,
-                                   const int* csrSortedRowPtrA,
-                                   const int* csrSortedColIndA,
-                                   const float* B,
-                                   int ldb,
-                                   const float* beta,
-                                   float* C,
-                                   int ldc)
+                                   const float*              csrSortedValA,
+                                   const int*                csrSortedRowPtrA,
+                                   const int*                csrSortedColIndA,
+                                   const float*              B,
+                                   int                       ldb,
+                                   const float*              beta,
+                                   float*                    C,
+                                   int                       ldc)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseScsrmm2((cusparseHandle_t)handle,
                                                         hipOperationToCudaOperation(transA),
@@ -979,23 +1050,23 @@ hipsparseStatus_t hipsparseScsrmm2(hipsparseHandle_t handle,
                                                         ldc));
 }
 
-hipsparseStatus_t hipsparseDcsrmm2(hipsparseHandle_t handle,
-                                   hipsparseOperation_t transA,
-                                   hipsparseOperation_t transB,
-                                   int m,
-                                   int n,
-                                   int k,
-                                   int nnz,
-                                   const double* alpha,
+hipsparseStatus_t hipsparseDcsrmm2(hipsparseHandle_t         handle,
+                                   hipsparseOperation_t      transA,
+                                   hipsparseOperation_t      transB,
+                                   int                       m,
+                                   int                       n,
+                                   int                       k,
+                                   int                       nnz,
+                                   const double*             alpha,
                                    const hipsparseMatDescr_t descrA,
-                                   const double* csrSortedValA,
-                                   const int* csrSortedRowPtrA,
-                                   const int* csrSortedColIndA,
-                                   const double* B,
-                                   int ldb,
-                                   const double* beta,
-                                   double* C,
-                                   int ldc)
+                                   const double*             csrSortedValA,
+                                   const int*                csrSortedRowPtrA,
+                                   const int*                csrSortedColIndA,
+                                   const double*             B,
+                                   int                       ldb,
+                                   const double*             beta,
+                                   double*                   C,
+                                   int                       ldc)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseDcsrmm2((cusparseHandle_t)handle,
                                                         hipOperationToCudaOperation(transA),
@@ -1017,21 +1088,21 @@ hipsparseStatus_t hipsparseDcsrmm2(hipsparseHandle_t handle,
 }
 
 hipsparseStatus_t
-hipsparseXcsrilu02_zeroPivot(hipsparseHandle_t handle, csrilu02Info_t info, int* position)
+    hipsparseXcsrilu02_zeroPivot(hipsparseHandle_t handle, csrilu02Info_t info, int* position)
 {
     return hipCUSPARSEStatusToHIPStatus(
         cusparseXcsrilu02_zeroPivot((cusparseHandle_t)handle, (csrilu02Info_t)info, position));
 }
 
-hipsparseStatus_t hipsparseScsrilu02_bufferSize(hipsparseHandle_t handle,
-                                                int m,
-                                                int nnz,
+hipsparseStatus_t hipsparseScsrilu02_bufferSize(hipsparseHandle_t         handle,
+                                                int                       m,
+                                                int                       nnz,
                                                 const hipsparseMatDescr_t descrA,
-                                                float* csrSortedValA,
-                                                const int* csrSortedRowPtrA,
-                                                const int* csrSortedColIndA,
-                                                csrilu02Info_t info,
-                                                int* pBufferSizeInBytes)
+                                                float*                    csrSortedValA,
+                                                const int*                csrSortedRowPtrA,
+                                                const int*                csrSortedColIndA,
+                                                csrilu02Info_t            info,
+                                                int*                      pBufferSizeInBytes)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseScsrilu02_bufferSize((cusparseHandle_t)handle,
                                                                      m,
@@ -1044,15 +1115,15 @@ hipsparseStatus_t hipsparseScsrilu02_bufferSize(hipsparseHandle_t handle,
                                                                      pBufferSizeInBytes));
 }
 
-hipsparseStatus_t hipsparseDcsrilu02_bufferSize(hipsparseHandle_t handle,
-                                                int m,
-                                                int nnz,
+hipsparseStatus_t hipsparseDcsrilu02_bufferSize(hipsparseHandle_t         handle,
+                                                int                       m,
+                                                int                       nnz,
                                                 const hipsparseMatDescr_t descrA,
-                                                double* csrSortedValA,
-                                                const int* csrSortedRowPtrA,
-                                                const int* csrSortedColIndA,
-                                                csrilu02Info_t info,
-                                                int* pBufferSizeInBytes)
+                                                double*                   csrSortedValA,
+                                                const int*                csrSortedRowPtrA,
+                                                const int*                csrSortedColIndA,
+                                                csrilu02Info_t            info,
+                                                int*                      pBufferSizeInBytes)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseDcsrilu02_bufferSize((cusparseHandle_t)handle,
                                                                      m,
@@ -1065,15 +1136,15 @@ hipsparseStatus_t hipsparseDcsrilu02_bufferSize(hipsparseHandle_t handle,
                                                                      pBufferSizeInBytes));
 }
 
-hipsparseStatus_t hipsparseScsrilu02_bufferSizeExt(hipsparseHandle_t handle,
-                                                   int m,
-                                                   int nnz,
+hipsparseStatus_t hipsparseScsrilu02_bufferSizeExt(hipsparseHandle_t         handle,
+                                                   int                       m,
+                                                   int                       nnz,
                                                    const hipsparseMatDescr_t descrA,
-                                                   float* csrSortedValA,
-                                                   const int* csrSortedRowPtrA,
-                                                   const int* csrSortedColIndA,
-                                                   csrilu02Info_t info,
-                                                   size_t* pBufferSize)
+                                                   float*                    csrSortedValA,
+                                                   const int*                csrSortedRowPtrA,
+                                                   const int*                csrSortedColIndA,
+                                                   csrilu02Info_t            info,
+                                                   size_t*                   pBufferSize)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseScsrilu02_bufferSizeExt((cusparseHandle_t)handle,
                                                                         m,
@@ -1086,15 +1157,15 @@ hipsparseStatus_t hipsparseScsrilu02_bufferSizeExt(hipsparseHandle_t handle,
                                                                         pBufferSize));
 }
 
-hipsparseStatus_t hipsparseDcsrilu02_bufferSizeExt(hipsparseHandle_t handle,
-                                                   int m,
-                                                   int nnz,
+hipsparseStatus_t hipsparseDcsrilu02_bufferSizeExt(hipsparseHandle_t         handle,
+                                                   int                       m,
+                                                   int                       nnz,
                                                    const hipsparseMatDescr_t descrA,
-                                                   double* csrSortedValA,
-                                                   const int* csrSortedRowPtrA,
-                                                   const int* csrSortedColIndA,
-                                                   csrilu02Info_t info,
-                                                   size_t* pBufferSize)
+                                                   double*                   csrSortedValA,
+                                                   const int*                csrSortedRowPtrA,
+                                                   const int*                csrSortedColIndA,
+                                                   csrilu02Info_t            info,
+                                                   size_t*                   pBufferSize)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseDcsrilu02_bufferSizeExt((cusparseHandle_t)handle,
                                                                         m,
@@ -1107,16 +1178,16 @@ hipsparseStatus_t hipsparseDcsrilu02_bufferSizeExt(hipsparseHandle_t handle,
                                                                         pBufferSize));
 }
 
-hipsparseStatus_t hipsparseScsrilu02_analysis(hipsparseHandle_t handle,
-                                              int m,
-                                              int nnz,
+hipsparseStatus_t hipsparseScsrilu02_analysis(hipsparseHandle_t         handle,
+                                              int                       m,
+                                              int                       nnz,
                                               const hipsparseMatDescr_t descrA,
-                                              const float* csrSortedValA,
-                                              const int* csrSortedRowPtrA,
-                                              const int* csrSortedColIndA,
-                                              csrilu02Info_t info,
-                                              hipsparseSolvePolicy_t policy,
-                                              void* pBuffer)
+                                              const float*              csrSortedValA,
+                                              const int*                csrSortedRowPtrA,
+                                              const int*                csrSortedColIndA,
+                                              csrilu02Info_t            info,
+                                              hipsparseSolvePolicy_t    policy,
+                                              void*                     pBuffer)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseScsrilu02_analysis((cusparseHandle_t)handle,
                                                                    m,
@@ -1130,16 +1201,16 @@ hipsparseStatus_t hipsparseScsrilu02_analysis(hipsparseHandle_t handle,
                                                                    pBuffer));
 }
 
-hipsparseStatus_t hipsparseDcsrilu02_analysis(hipsparseHandle_t handle,
-                                              int m,
-                                              int nnz,
+hipsparseStatus_t hipsparseDcsrilu02_analysis(hipsparseHandle_t         handle,
+                                              int                       m,
+                                              int                       nnz,
                                               const hipsparseMatDescr_t descrA,
-                                              const double* csrSortedValA,
-                                              const int* csrSortedRowPtrA,
-                                              const int* csrSortedColIndA,
-                                              csrilu02Info_t info,
-                                              hipsparseSolvePolicy_t policy,
-                                              void* pBuffer)
+                                              const double*             csrSortedValA,
+                                              const int*                csrSortedRowPtrA,
+                                              const int*                csrSortedColIndA,
+                                              csrilu02Info_t            info,
+                                              hipsparseSolvePolicy_t    policy,
+                                              void*                     pBuffer)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseDcsrilu02_analysis((cusparseHandle_t)handle,
                                                                    m,
@@ -1153,18 +1224,18 @@ hipsparseStatus_t hipsparseDcsrilu02_analysis(hipsparseHandle_t handle,
                                                                    pBuffer));
 }
 
-hipsparseStatus_t hipsparseScsrilu02(hipsparseHandle_t handle,
-                                     int m,
-                                     int nnz,
+hipsparseStatus_t hipsparseScsrilu02(hipsparseHandle_t         handle,
+                                     int                       m,
+                                     int                       nnz,
                                      const hipsparseMatDescr_t descrA,
-                                     float* csrSortedValA_valM,
+                                     float*                    csrSortedValA_valM,
                                      /* matrix A values are updated inplace
                                         to be the preconditioner M values */
-                                     const int* csrSortedRowPtrA,
-                                     const int* csrSortedColIndA,
-                                     csrilu02Info_t info,
+                                     const int*             csrSortedRowPtrA,
+                                     const int*             csrSortedColIndA,
+                                     csrilu02Info_t         info,
                                      hipsparseSolvePolicy_t policy,
-                                     void* pBuffer)
+                                     void*                  pBuffer)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseScsrilu02((cusparseHandle_t)handle,
                                                           m,
@@ -1178,18 +1249,18 @@ hipsparseStatus_t hipsparseScsrilu02(hipsparseHandle_t handle,
                                                           pBuffer));
 }
 
-hipsparseStatus_t hipsparseDcsrilu02(hipsparseHandle_t handle,
-                                     int m,
-                                     int nnz,
+hipsparseStatus_t hipsparseDcsrilu02(hipsparseHandle_t         handle,
+                                     int                       m,
+                                     int                       nnz,
                                      const hipsparseMatDescr_t descrA,
-                                     double* csrSortedValA_valM,
+                                     double*                   csrSortedValA_valM,
                                      /* matrix A values are updated inplace
                                         to be the preconditioner M values */
-                                     const int* csrSortedRowPtrA,
-                                     const int* csrSortedColIndA,
-                                     csrilu02Info_t info,
+                                     const int*             csrSortedRowPtrA,
+                                     const int*             csrSortedColIndA,
+                                     csrilu02Info_t         info,
                                      hipsparseSolvePolicy_t policy,
-                                     void* pBuffer)
+                                     void*                  pBuffer)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseDcsrilu02((cusparseHandle_t)handle,
                                                           m,
@@ -1203,11 +1274,11 @@ hipsparseStatus_t hipsparseDcsrilu02(hipsparseHandle_t handle,
                                                           pBuffer));
 }
 
-hipsparseStatus_t hipsparseXcsr2coo(hipsparseHandle_t handle,
-                                    const int* csrRowPtr,
-                                    int nnz,
-                                    int m,
-                                    int* cooRowInd,
+hipsparseStatus_t hipsparseXcsr2coo(hipsparseHandle_t    handle,
+                                    const int*           csrRowPtr,
+                                    int                  nnz,
+                                    int                  m,
+                                    int*                 cooRowInd,
                                     hipsparseIndexBase_t idxBase)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseXcsr2coo((cusparseHandle_t)handle,
@@ -1218,17 +1289,17 @@ hipsparseStatus_t hipsparseXcsr2coo(hipsparseHandle_t handle,
                                                          hipIndexBaseToCudaIndexBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseScsr2csc(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
-                                    int nnz,
-                                    const float* csrSortedVal,
-                                    const int* csrSortedRowPtr,
-                                    const int* csrSortedColInd,
-                                    float* cscSortedVal,
-                                    int* cscSortedRowInd,
-                                    int* cscSortedColPtr,
-                                    hipsparseAction_t copyValues,
+hipsparseStatus_t hipsparseScsr2csc(hipsparseHandle_t    handle,
+                                    int                  m,
+                                    int                  n,
+                                    int                  nnz,
+                                    const float*         csrSortedVal,
+                                    const int*           csrSortedRowPtr,
+                                    const int*           csrSortedColInd,
+                                    float*               cscSortedVal,
+                                    int*                 cscSortedRowInd,
+                                    int*                 cscSortedColPtr,
+                                    hipsparseAction_t    copyValues,
                                     hipsparseIndexBase_t idxBase)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseScsr2csc((cusparseHandle_t)handle,
@@ -1245,17 +1316,17 @@ hipsparseStatus_t hipsparseScsr2csc(hipsparseHandle_t handle,
                                                          hipIndexBaseToCudaIndexBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseDcsr2csc(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
-                                    int nnz,
-                                    const double* csrSortedVal,
-                                    const int* csrSortedRowPtr,
-                                    const int* csrSortedColInd,
-                                    double* cscSortedVal,
-                                    int* cscSortedRowInd,
-                                    int* cscSortedColPtr,
-                                    hipsparseAction_t copyValues,
+hipsparseStatus_t hipsparseDcsr2csc(hipsparseHandle_t    handle,
+                                    int                  m,
+                                    int                  n,
+                                    int                  nnz,
+                                    const double*        csrSortedVal,
+                                    const int*           csrSortedRowPtr,
+                                    const int*           csrSortedColInd,
+                                    double*              cscSortedVal,
+                                    int*                 cscSortedRowInd,
+                                    int*                 cscSortedColPtr,
+                                    hipsparseAction_t    copyValues,
                                     hipsparseIndexBase_t idxBase)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseDcsr2csc((cusparseHandle_t)handle,
@@ -1272,16 +1343,16 @@ hipsparseStatus_t hipsparseDcsr2csc(hipsparseHandle_t handle,
                                                          hipIndexBaseToCudaIndexBase(idxBase)));
 }
 
-hipsparseStatus_t hipsparseScsr2hyb(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
+hipsparseStatus_t hipsparseScsr2hyb(hipsparseHandle_t         handle,
+                                    int                       m,
+                                    int                       n,
                                     const hipsparseMatDescr_t descrA,
-                                    const float* csrSortedValA,
-                                    const int* csrSortedRowPtrA,
-                                    const int* csrSortedColIndA,
-                                    hipsparseHybMat_t hybA,
-                                    int userEllWidth,
-                                    hipsparseHybPartition_t partitionType)
+                                    const float*              csrSortedValA,
+                                    const int*                csrSortedRowPtrA,
+                                    const int*                csrSortedColIndA,
+                                    hipsparseHybMat_t         hybA,
+                                    int                       userEllWidth,
+                                    hipsparseHybPartition_t   partitionType)
 {
     return hipCUSPARSEStatusToHIPStatus(
         cusparseScsr2hyb((cusparseHandle_t)handle,
@@ -1296,16 +1367,16 @@ hipsparseStatus_t hipsparseScsr2hyb(hipsparseHandle_t handle,
                          hipHybPartitionToCudaHybPartition(partitionType)));
 }
 
-hipsparseStatus_t hipsparseDcsr2hyb(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
+hipsparseStatus_t hipsparseDcsr2hyb(hipsparseHandle_t         handle,
+                                    int                       m,
+                                    int                       n,
                                     const hipsparseMatDescr_t descrA,
-                                    const double* csrSortedValA,
-                                    const int* csrSortedRowPtrA,
-                                    const int* csrSortedColIndA,
-                                    hipsparseHybMat_t hybA,
-                                    int userEllWidth,
-                                    hipsparseHybPartition_t partitionType)
+                                    const double*             csrSortedValA,
+                                    const int*                csrSortedRowPtrA,
+                                    const int*                csrSortedColIndA,
+                                    hipsparseHybMat_t         hybA,
+                                    int                       userEllWidth,
+                                    hipsparseHybPartition_t   partitionType)
 {
     return hipCUSPARSEStatusToHIPStatus(
         cusparseDcsr2hyb((cusparseHandle_t)handle,
@@ -1320,11 +1391,11 @@ hipsparseStatus_t hipsparseDcsr2hyb(hipsparseHandle_t handle,
                          hipHybPartitionToCudaHybPartition(partitionType)));
 }
 
-hipsparseStatus_t hipsparseXcoo2csr(hipsparseHandle_t handle,
-                                    const int* cooRowInd,
-                                    int nnz,
-                                    int m,
-                                    int* csrRowPtr,
+hipsparseStatus_t hipsparseXcoo2csr(hipsparseHandle_t    handle,
+                                    const int*           cooRowInd,
+                                    int                  nnz,
+                                    int                  m,
+                                    int*                 csrRowPtr,
                                     hipsparseIndexBase_t idxBase)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseXcoo2csr((cusparseHandle_t)handle,
@@ -1342,26 +1413,26 @@ hipsparseStatus_t hipsparseCreateIdentityPermutation(hipsparseHandle_t handle, i
 }
 
 hipsparseStatus_t hipsparseXcsrsort_bufferSizeExt(hipsparseHandle_t handle,
-                                                  int m,
-                                                  int n,
-                                                  int nnz,
-                                                  const int* csrRowPtr,
-                                                  const int* csrColInd,
-                                                  size_t* pBufferSizeInBytes)
+                                                  int               m,
+                                                  int               n,
+                                                  int               nnz,
+                                                  const int*        csrRowPtr,
+                                                  const int*        csrColInd,
+                                                  size_t*           pBufferSizeInBytes)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseXcsrsort_bufferSizeExt(
         (cusparseHandle_t)handle, m, n, nnz, csrRowPtr, csrColInd, pBufferSizeInBytes));
 }
 
-hipsparseStatus_t hipsparseXcsrsort(hipsparseHandle_t handle,
-                                    int m,
-                                    int n,
-                                    int nnz,
+hipsparseStatus_t hipsparseXcsrsort(hipsparseHandle_t         handle,
+                                    int                       m,
+                                    int                       n,
+                                    int                       nnz,
                                     const hipsparseMatDescr_t descrA,
-                                    const int* csrRowPtr,
-                                    int* csrColInd,
-                                    int* P,
-                                    void* pBuffer)
+                                    const int*                csrRowPtr,
+                                    int*                      csrColInd,
+                                    int*                      P,
+                                    void*                     pBuffer)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseXcsrsort((cusparseHandle_t)handle,
                                                          m,
@@ -1375,38 +1446,38 @@ hipsparseStatus_t hipsparseXcsrsort(hipsparseHandle_t handle,
 }
 
 hipsparseStatus_t hipsparseXcoosort_bufferSizeExt(hipsparseHandle_t handle,
-                                                  int m,
-                                                  int n,
-                                                  int nnz,
-                                                  const int* cooRows,
-                                                  const int* cooCols,
-                                                  size_t* pBufferSizeInBytes)
+                                                  int               m,
+                                                  int               n,
+                                                  int               nnz,
+                                                  const int*        cooRows,
+                                                  const int*        cooCols,
+                                                  size_t*           pBufferSizeInBytes)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseXcoosort_bufferSizeExt(
         (cusparseHandle_t)handle, m, n, nnz, cooRows, cooCols, pBufferSizeInBytes));
 }
 
 hipsparseStatus_t hipsparseXcoosortByRow(hipsparseHandle_t handle,
-                                         int m,
-                                         int n,
-                                         int nnz,
-                                         int* cooRows,
-                                         int* cooCols,
-                                         int* P,
-                                         void* pBuffer)
+                                         int               m,
+                                         int               n,
+                                         int               nnz,
+                                         int*              cooRows,
+                                         int*              cooCols,
+                                         int*              P,
+                                         void*             pBuffer)
 {
     return hipCUSPARSEStatusToHIPStatus(
         cusparseXcoosortByRow((cusparseHandle_t)handle, m, n, nnz, cooRows, cooCols, P, pBuffer));
 }
 
 hipsparseStatus_t hipsparseXcoosortByColumn(hipsparseHandle_t handle,
-                                            int m,
-                                            int n,
-                                            int nnz,
-                                            int* cooRows,
-                                            int* cooCols,
-                                            int* P,
-                                            void* pBuffer)
+                                            int               m,
+                                            int               n,
+                                            int               nnz,
+                                            int*              cooRows,
+                                            int*              cooCols,
+                                            int*              P,
+                                            void*             pBuffer)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseXcoosortByColumn(
         (cusparseHandle_t)handle, m, n, nnz, cooRows, cooCols, P, pBuffer));


### PR DESCRIPTION
- Changed formatter to /opt/rocm/hcc/bin/clang-format, which is clang-format-9
- Passed CI