### PR TITLE
New clang-format file for rocm2.5

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,12 +23,14 @@ DisableFormat:   false
 Standard: Cpp11
 
 AccessModifierOffset: -4
-AlignAfterOpenBracket: true
+AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: true
 AlignConsecutiveDeclarations: true
-AlignEscapedNewlinesLeft: true
+AlignEscapedNewlines: Left
 AlignOperands:   true
 AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
@@ -46,6 +48,7 @@ BinPackParameters: false
 BreakBeforeBraces: Custom
 # Control of individual brace wrapping cases
 BraceWrapping: {
+    AfterCaseLabel: 'true'
     AfterClass: 'true'
     AfterControlStatement: 'true'
     AfterEnum : 'true'
@@ -72,11 +75,12 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-#SpaceBeforeCpp11BracedList: false
+SpaceBeforeCpp11BracedList: false
 DerivePointerAlignment: false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
 IndentCaseLabels: false
+IndentPPDirectives: None
 #FixNamespaceComments: true
 IndentWrappedFunctionNames: true
 KeepEmptyLinesAtTheStartOfBlocks: true
@@ -116,5 +120,4 @@ SortIncludes: true
 ReflowComments: false
 
 #IncludeBlocks: Preserve
-#IndentPPDirectives: AfterHash
 ---

--- a/clients/include/testing_axpyi.hpp
+++ b/clients/include/testing_axpyi.hpp
@@ -52,9 +52,9 @@ void testing_axpyi_bad_arg(void)
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
     hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
-    auto dxVal_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dxInd_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-    auto dy_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dxVal_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dxInd_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto dy_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     T*   dxVal = (T*)dxVal_managed.get();
     int* dxInd = (int*)dxInd_managed.get();
@@ -124,10 +124,10 @@ hipsparseStatus_t testing_axpyi(Arguments argus)
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
         auto dxInd_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto dxVal_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         int* dxInd = (int*)dxInd_managed.get();
         T*   dxVal = (T*)dxVal_managed.get();
@@ -173,11 +173,11 @@ hipsparseStatus_t testing_axpyi(Arguments argus)
     hy_gold = hy_1;
 
     // allocate memory on device
-    auto dxInd_managed   = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
-    auto dxVal_managed   = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dy_1_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
-    auto dy_2_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
-    auto d_alpha_managed = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+    auto dxInd_managed   = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
+    auto dxVal_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dy_1_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
+    auto dy_2_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
+    auto d_alpha_managed = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
 
     int* dxInd   = (int*)dxInd_managed.get();
     T*   dxVal   = (T*)dxVal_managed.get();

--- a/clients/include/testing_coo2csr.hpp
+++ b/clients/include/testing_coo2csr.hpp
@@ -52,9 +52,9 @@ void testing_coo2csr_bad_arg(void)
     hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
     auto coo_row_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
     auto csr_row_ptr_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
 
     int* coo_row_ind = (int*)coo_row_ind_managed.get();
     int* csr_row_ptr = (int*)csr_row_ptr_managed.get();
@@ -132,9 +132,9 @@ hipsparseStatus_t testing_coo2csr(Arguments argus)
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
         auto coo_row_ind_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto csr_row_ptr_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
 
         int* coo_row_ind = (int*)coo_row_ind_managed.get();
         int* csr_row_ptr = (int*)csr_row_ptr_managed.get();
@@ -225,10 +225,9 @@ hipsparseStatus_t testing_coo2csr(Arguments argus)
     std::vector<int> hcsr_row_ptr_gold(m + 1, 0);
 
     // Allocate memory on the device
-    auto dcoo_row_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+    auto dcoo_row_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
     auto dcsr_row_ptr_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * (m + 1)), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};
 
     int* dcoo_row_ind = (int*)dcoo_row_ind_managed.get();
     int* dcsr_row_ptr = (int*)dcsr_row_ptr_managed.get();

--- a/clients/include/testing_coosort.hpp
+++ b/clients/include/testing_coosort.hpp
@@ -55,12 +55,12 @@ void testing_coosort_bad_arg(void)
     size_t buffer_size = 0;
 
     auto coo_row_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
     auto coo_col_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-    auto perm_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto perm_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
     auto buffer_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
 
     int*  coo_row_ind = (int*)coo_row_ind_managed.get();
     int*  coo_col_ind = (int*)coo_col_ind_managed.get();
@@ -233,13 +233,13 @@ hipsparseStatus_t testing_coosort(Arguments argus)
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
         auto coo_row_ind_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto coo_col_ind_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto perm_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto buffer_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
 
         int*  coo_row_ind = (int*)coo_row_ind_managed.get();
         int*  coo_col_ind = (int*)coo_col_ind_managed.get();
@@ -415,14 +415,12 @@ hipsparseStatus_t testing_coosort(Arguments argus)
     }
 
     // Allocate memory on the device
-    auto dcoo_row_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
-    auto dcoo_col_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
-    auto dcoo_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(float) * nnz), device_free};
+    auto dcoo_row_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
+    auto dcoo_col_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
+    auto dcoo_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(float) * nnz), device_free};
     auto dcoo_val_sorted_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(float) * nnz), device_free};
-    auto dperm_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(float) * nnz), device_free};
+    auto dperm_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
 
     int*   dcoo_row_ind    = (int*)dcoo_row_ind_managed.get();
     int*   dcoo_col_ind    = (int*)dcoo_col_ind_managed.get();
@@ -456,7 +454,7 @@ hipsparseStatus_t testing_coosort(Arguments argus)
 
         // Allocate buffer on the device
         auto dbuffer_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(char) * buffer_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(char) * buffer_size), device_free};
 
         void* dbuffer = (void*)dbuffer_managed.get();
 
@@ -525,7 +523,7 @@ hipsparseStatus_t testing_coosort(Arguments argus)
             handle, m, n, nnz, dcoo_row_ind, dcoo_col_ind, &buffer_size);
 
         auto dbuffer_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(char) * buffer_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(char) * buffer_size), device_free};
         void* dbuffer = (void*)dbuffer_managed.get();
 
         for(int iter = 0; iter < number_cold_calls; ++iter)

--- a/clients/include/testing_csr2coo.hpp
+++ b/clients/include/testing_csr2coo.hpp
@@ -52,9 +52,9 @@ void testing_csr2coo_bad_arg(void)
     hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
     auto csr_row_ptr_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
     auto coo_row_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
 
     int* csr_row_ptr = (int*)csr_row_ptr_managed.get();
     int* coo_row_ind = (int*)coo_row_ind_managed.get();
@@ -132,9 +132,9 @@ hipsparseStatus_t testing_csr2coo(Arguments argus)
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
         auto csr_row_ptr_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto coo_row_ind_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
 
         int* csr_row_ptr = (int*)csr_row_ptr_managed.get();
         int* coo_row_ind = (int*)coo_row_ind_managed.get();
@@ -213,9 +213,8 @@ hipsparseStatus_t testing_csr2coo(Arguments argus)
 
     // Allocate memory on the device
     auto dcsr_row_ptr_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * (m + 1)), device_free};
-    auto dcoo_row_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};
+    auto dcoo_row_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
 
     int* dcsr_row_ptr = (int*)dcsr_row_ptr_managed.get();
     int* dcoo_row_ind = (int*)dcoo_row_ind_managed.get();

--- a/clients/include/testing_csr2csc.hpp
+++ b/clients/include/testing_csr2csc.hpp
@@ -54,15 +54,15 @@ void testing_csr2csc_bad_arg(void)
     hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
     auto csr_row_ptr_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
     auto csr_col_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-    auto csr_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto csr_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
     auto csc_row_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
     auto csc_col_ptr_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-    auto csc_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto csc_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     int* csr_row_ptr = (int*)csr_row_ptr_managed.get();
     int* csr_col_ind = (int*)csr_col_ind_managed.get();
@@ -256,17 +256,17 @@ hipsparseStatus_t testing_csr2csc(Arguments argus)
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
         auto csr_row_ptr_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto csr_col_ind_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto csr_val_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
         auto csc_row_ind_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto csc_col_ptr_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto csc_val_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         int* csr_row_ptr = (int*)csr_row_ptr_managed.get();
         int* csr_col_ind = (int*)csr_col_ind_managed.get();
@@ -365,15 +365,13 @@ hipsparseStatus_t testing_csr2csc(Arguments argus)
 
     // Allocate memory on the device
     auto dcsr_row_ptr_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * (m + 1)), device_free};
-    auto dcsr_col_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
-    auto dcsr_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dcsc_row_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};
+    auto dcsr_col_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
+    auto dcsr_val_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dcsc_row_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
     auto dcsc_col_ptr_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * (n + 1)), device_free};
-    auto dcsc_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * (n + 1)), device_free};
+    auto dcsc_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
 
     int* dcsr_row_ptr = (int*)dcsr_row_ptr_managed.get();
     int* dcsr_col_ind = (int*)dcsr_col_ind_managed.get();

--- a/clients/include/testing_csr2hyb.hpp
+++ b/clients/include/testing_csr2hyb.hpp
@@ -74,10 +74,10 @@ void testing_csr2hyb_bad_arg(void)
     hipsparseHybMat_t           hyb = unique_ptr_hyb->hyb;
 
     auto csr_row_ptr_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
     auto csr_col_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-    auto csr_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto csr_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     int* csr_row_ptr = (int*)csr_row_ptr_managed.get();
     int* csr_col_ind = (int*)csr_col_ind_managed.get();
@@ -204,11 +204,11 @@ hipsparseStatus_t testing_csr2hyb(Arguments argus)
     if(m <= 0 || n <= 0 || nnz <= 0)
     {
         auto csr_row_ptr_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto csr_col_ind_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto csr_val_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         int* csr_row_ptr = (int*)csr_row_ptr_managed.get();
         int* csr_col_ind = (int*)csr_col_ind_managed.get();
@@ -294,10 +294,9 @@ hipsparseStatus_t testing_csr2hyb(Arguments argus)
 
     // Allocate memory on the device
     auto dcsr_row_ptr_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * (m + 1)), device_free};
-    auto dcsr_col_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
-    auto dcsr_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};
+    auto dcsr_col_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
+    auto dcsr_val_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
 
     int* dcsr_row_ptr = (int*)dcsr_row_ptr_managed.get();
     int* dcsr_col_ind = (int*)dcsr_col_ind_managed.get();

--- a/clients/include/testing_csrilu02.hpp
+++ b/clients/include/testing_csrilu02.hpp
@@ -59,11 +59,11 @@ void testing_csrilu02_bad_arg(void)
     std::unique_ptr<csrilu02_struct> unique_ptr_csrilu02(new csrilu02_struct);
     csrilu02Info_t                   info = unique_ptr_csrilu02->info;
 
-    auto dptr_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-    auto dcol_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-    auto dval_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dptr_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto dcol_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
     auto dbuffer_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
 
     int*  dptr    = (int*)dptr_managed.get();
     int*  dcol    = (int*)dcol_managed.get();
@@ -333,13 +333,12 @@ hipsparseStatus_t testing_csrilu02(Arguments argus)
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
         auto dptr_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto dcol_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-        auto dval_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+        auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
         auto buffer_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
 
         int*  dptr   = (int*)dptr_managed.get();
         int*  dcol   = (int*)dcol_managed.get();
@@ -458,10 +457,10 @@ hipsparseStatus_t testing_csrilu02(Arguments argus)
     }
 
     // Allocate memory on device
-    auto dptr_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * (m + 1)), device_free};
-    auto dcol_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
-    auto dval_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto d_position_managed = hipsparse_unique_ptr {device_malloc(sizeof(int)), device_free};
+    auto dptr_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};
+    auto dcol_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
+    auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto d_position_managed = hipsparse_unique_ptr{device_malloc(sizeof(int)), device_free};
 
     int* dptr       = (int*)dptr_managed.get();
     int* dcol       = (int*)dcol_managed.get();
@@ -486,7 +485,7 @@ hipsparseStatus_t testing_csrilu02(Arguments argus)
         hipsparseXcsrilu02_bufferSizeExt(handle, m, nnz, descr, dval, dptr, dcol, info, &size));
 
     // Allocate buffer on the device
-    auto dbuffer_managed = hipsparse_unique_ptr {device_malloc(sizeof(char) * size), device_free};
+    auto dbuffer_managed = hipsparse_unique_ptr{device_malloc(sizeof(char) * size), device_free};
 
     void* dbuffer = (void*)dbuffer_managed.get();
 

--- a/clients/include/testing_csrilusv.hpp
+++ b/clients/include/testing_csrilusv.hpp
@@ -75,10 +75,10 @@ hipsparseStatus_t testing_csrilusv(Arguments argus)
     }
 
     // Allocate memory on device
-    auto dptr_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * (m + 1)), device_free};
-    auto dcol_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
-    auto dval_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto d_position_managed = hipsparse_unique_ptr {device_malloc(sizeof(int)), device_free};
+    auto dptr_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};
+    auto dcol_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
+    auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto d_position_managed = hipsparse_unique_ptr{device_malloc(sizeof(int)), device_free};
 
     int* dptr       = (int*)dptr_managed.get();
     int* dcol       = (int*)dcol_managed.get();
@@ -104,7 +104,7 @@ hipsparseStatus_t testing_csrilusv(Arguments argus)
         hipsparseXcsrilu02_bufferSizeExt(handle, m, nnz, descr_M, dval, dptr, dcol, info_M, &size));
 
     // Allocate buffer on the device
-    auto dbuffer_managed = hipsparse_unique_ptr {device_malloc(sizeof(char) * size), device_free};
+    auto dbuffer_managed = hipsparse_unique_ptr{device_malloc(sizeof(char) * size), device_free};
 
     void* dbuffer = (void*)dbuffer_managed.get();
 
@@ -232,8 +232,7 @@ hipsparseStatus_t testing_csrilusv(Arguments argus)
     size = std::max(size_lower, size_upper);
 
     // Allocate buffer on the device
-    auto dbuffer_sv_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(char) * size), device_free};
+    auto dbuffer_sv_managed = hipsparse_unique_ptr{device_malloc(sizeof(char) * size), device_free};
 
     void* dbuffer_sv = (void*)dbuffer_sv_managed.get();
 
@@ -276,12 +275,12 @@ hipsparseStatus_t testing_csrilusv(Arguments argus)
     std::vector<T> hz_gold(m);
 
     // Allocate device memory
-    auto dx_managed      = hipsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto dy_1_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto dy_2_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto dz_1_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto dz_2_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto d_alpha_managed = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+    auto dx_managed      = hipsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto dy_1_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto dy_2_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto dz_1_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto dz_2_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto d_alpha_managed = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
 
     T* dx      = (T*)dx_managed.get();
     T* dy_1    = (T*)dy_1_managed.get();

--- a/clients/include/testing_csrmm.hpp
+++ b/clients/include/testing_csrmm.hpp
@@ -62,11 +62,11 @@ void testing_csrmm_bad_arg(void)
     std::unique_ptr<descr_struct> unique_ptr_descr(new descr_struct);
     hipsparseMatDescr_t           descr = unique_ptr_descr->descr;
 
-    auto dptr_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-    auto dcol_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-    auto dval_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dB_managed   = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dC_managed   = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dptr_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto dcol_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dB_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dC_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     int* dptr = (int*)dptr_managed.get();
     int* dcol = (int*)dcol_managed.get();
@@ -345,13 +345,12 @@ hipsparseStatus_t testing_csrmm(Arguments argus)
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
         auto dptr_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto dcol_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-        auto dval_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dB_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dC_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+        auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dB_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dC_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         int* dptr = (int*)dptr_managed.get();
         int* dcol = (int*)dcol_managed.get();
@@ -492,15 +491,15 @@ hipsparseStatus_t testing_csrmm(Arguments argus)
 
     // allocate memory on device
     auto dcsr_row_ptrA_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * (M + 1)), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * (M + 1)), device_free};
     auto dcsr_col_indA_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
-    auto dcsr_valA_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dB_managed        = hipsparse_unique_ptr {device_malloc(sizeof(T) * Bnnz), device_free};
-    auto dC_1_managed      = hipsparse_unique_ptr {device_malloc(sizeof(T) * Cnnz), device_free};
-    auto dC_2_managed      = hipsparse_unique_ptr {device_malloc(sizeof(T) * Cnnz), device_free};
-    auto d_alpha_managed   = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
-    auto d_beta_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
+    auto dcsr_valA_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dB_managed        = hipsparse_unique_ptr{device_malloc(sizeof(T) * Bnnz), device_free};
+    auto dC_1_managed      = hipsparse_unique_ptr{device_malloc(sizeof(T) * Cnnz), device_free};
+    auto dC_2_managed      = hipsparse_unique_ptr{device_malloc(sizeof(T) * Cnnz), device_free};
+    auto d_alpha_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
+    auto d_beta_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
 
     int* dcsr_row_ptrA = (int*)dcsr_row_ptrA_managed.get();
     int* dcsr_col_indA = (int*)dcsr_col_indA_managed.get();

--- a/clients/include/testing_csrmv.hpp
+++ b/clients/include/testing_csrmv.hpp
@@ -59,11 +59,11 @@ void testing_csrmv_bad_arg(void)
     std::unique_ptr<descr_struct> unique_ptr_descr(new descr_struct);
     hipsparseMatDescr_t           descr = unique_ptr_descr->descr;
 
-    auto dptr_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-    auto dcol_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-    auto dval_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dx_managed   = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dy_managed   = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dptr_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto dcol_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dy_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     int* dptr = (int*)dptr_managed.get();
     int* dcol = (int*)dcol_managed.get();
@@ -203,13 +203,12 @@ hipsparseStatus_t testing_csrmv(Arguments argus)
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
         auto dptr_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto dcol_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-        auto dval_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dx_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+        auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dx_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         int* dptr = (int*)dptr_managed.get();
         int* dcol = (int*)dcol_managed.get();
@@ -307,14 +306,14 @@ hipsparseStatus_t testing_csrmv(Arguments argus)
     hy_gold = hy_1;
 
     // allocate memory on device
-    auto dptr_managed    = hipsparse_unique_ptr {device_malloc(sizeof(int) * (m + 1)), device_free};
-    auto dcol_managed    = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
-    auto dval_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dx_managed      = hipsparse_unique_ptr {device_malloc(sizeof(T) * n), device_free};
-    auto dy_1_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto dy_2_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto d_alpha_managed = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
-    auto d_beta_managed  = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+    auto dptr_managed    = hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};
+    auto dcol_managed    = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
+    auto dval_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dx_managed      = hipsparse_unique_ptr{device_malloc(sizeof(T) * n), device_free};
+    auto dy_1_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto dy_2_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto d_alpha_managed = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
+    auto d_beta_managed  = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
 
     int* dptr    = (int*)dptr_managed.get();
     int* dcol    = (int*)dcol_managed.get();

--- a/clients/include/testing_csrsort.hpp
+++ b/clients/include/testing_csrsort.hpp
@@ -58,12 +58,12 @@ void testing_csrsort_bad_arg(void)
     size_t buffer_size = 0;
 
     auto csr_row_ptr_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
     auto csr_col_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-    auto perm_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto perm_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
     auto buffer_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
 
     int*  csr_row_ptr = (int*)csr_row_ptr_managed.get();
     int*  csr_col_ind = (int*)csr_col_ind_managed.get();
@@ -212,13 +212,13 @@ hipsparseStatus_t testing_csrsort(Arguments argus)
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
         auto csr_row_ptr_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto csr_col_ind_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto perm_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto buffer_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
 
         int*  csr_row_ptr = (int*)csr_row_ptr_managed.get();
         int*  csr_col_ind = (int*)csr_col_ind_managed.get();
@@ -350,13 +350,12 @@ hipsparseStatus_t testing_csrsort(Arguments argus)
 
     // Allocate memory on the device
     auto dcsr_row_ptr_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * (m + 1)), device_free};
-    auto dcsr_col_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
-    auto dcsr_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(float) * nnz), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};
+    auto dcsr_col_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
+    auto dcsr_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(float) * nnz), device_free};
     auto dcsr_val_sorted_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(float) * nnz), device_free};
-    auto dperm_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(float) * nnz), device_free};
+    auto dperm_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
 
     int*   dcsr_row_ptr    = (int*)dcsr_row_ptr_managed.get();
     int*   dcsr_col_ind    = (int*)dcsr_col_ind_managed.get();
@@ -390,7 +389,7 @@ hipsparseStatus_t testing_csrsort(Arguments argus)
 
         // Allocate buffer on the device
         auto dbuffer_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(char) * buffer_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(char) * buffer_size), device_free};
 
         void* dbuffer = (void*)dbuffer_managed.get();
 
@@ -448,7 +447,7 @@ hipsparseStatus_t testing_csrsort(Arguments argus)
             handle, m, n, nnz, dcsr_row_ptr, dcsr_col_ind, &buffer_size);
 
         auto dbuffer_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(char) * buffer_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(char) * buffer_size), device_free};
         void* dbuffer = (void*)dbuffer_managed.get();
 
         for(int iter = 0; iter < number_cold_calls; ++iter)

--- a/clients/include/testing_csrsv2.hpp
+++ b/clients/include/testing_csrsv2.hpp
@@ -63,13 +63,13 @@ void testing_csrsv2_bad_arg(void)
     std::unique_ptr<csrsv2_struct> unique_ptr_csrsv2_info(new csrsv2_struct);
     csrsv2Info_t                   info = unique_ptr_csrsv2_info->info;
 
-    auto dptr_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-    auto dcol_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-    auto dval_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dx_managed   = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dy_managed   = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dptr_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto dcol_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dy_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
     auto dbuffer_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
+        = hipsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
 
     int*  dptr    = (int*)dptr_managed.get();
     int*  dcol    = (int*)dcol_managed.get();
@@ -496,15 +496,14 @@ hipsparseStatus_t testing_csrsv2(Arguments argus)
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
         auto dptr_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto dcol_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-        auto dval_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dx_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+        auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dx_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
         auto buffer_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(char) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(char) * safe_size), device_free};
 
         int*  dptr   = (int*)dptr_managed.get();
         int*  dcol   = (int*)dcol_managed.get();
@@ -634,14 +633,14 @@ hipsparseStatus_t testing_csrsv2(Arguments argus)
     hipsparseInit<T>(hx, 1, m);
 
     // Allocate memory on device
-    auto dptr_managed    = hipsparse_unique_ptr {device_malloc(sizeof(int) * (m + 1)), device_free};
-    auto dcol_managed    = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
-    auto dval_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dx_managed      = hipsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto dy_1_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * n), device_free};
-    auto dy_2_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * n), device_free};
-    auto d_alpha_managed = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
-    auto d_position_managed = hipsparse_unique_ptr {device_malloc(sizeof(int)), device_free};
+    auto dptr_managed    = hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};
+    auto dcol_managed    = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
+    auto dval_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dx_managed      = hipsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto dy_1_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * n), device_free};
+    auto dy_2_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * n), device_free};
+    auto d_alpha_managed = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
+    auto d_position_managed = hipsparse_unique_ptr{device_malloc(sizeof(int)), device_free};
 
     int* dptr       = (int*)dptr_managed.get();
     int* dcol       = (int*)dcol_managed.get();
@@ -674,7 +673,7 @@ hipsparseStatus_t testing_csrsv2(Arguments argus)
         handle, trans, m, nnz, descr, dval, dptr, dcol, info, &size));
 
     // Allocate buffer on the device
-    auto dbuffer_managed = hipsparse_unique_ptr {device_malloc(sizeof(char) * size), device_free};
+    auto dbuffer_managed = hipsparse_unique_ptr{device_malloc(sizeof(char) * size), device_free};
 
     void* dbuffer = (void*)dbuffer_managed.get();
 

--- a/clients/include/testing_doti.hpp
+++ b/clients/include/testing_doti.hpp
@@ -51,10 +51,9 @@ void testing_doti_bad_arg(void)
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
     hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
-    auto dx_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dx_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-    auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto dy_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     T*   dx_val = (T*)dx_val_managed.get();
     int* dx_ind = (int*)dx_ind_managed.get();
@@ -129,10 +128,10 @@ hipsparseStatus_t testing_doti(Arguments argus)
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
         auto dx_ind_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto dx_val_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         int* dx_ind = (int*)dx_ind_managed.get();
         T*   dx_val = (T*)dx_val_managed.get();
@@ -178,10 +177,10 @@ hipsparseStatus_t testing_doti(Arguments argus)
     hipsparseInit<T>(hy, 1, N);
 
     // allocate memory on device
-    auto dx_ind_managed    = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
-    auto dx_val_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dy_managed        = hipsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
-    auto dresult_2_managed = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+    auto dx_ind_managed    = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
+    auto dx_val_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dy_managed        = hipsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
+    auto dresult_2_managed = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
 
     int* dx_ind    = (int*)dx_ind_managed.get();
     T*   dx_val    = (T*)dx_val_managed.get();

--- a/clients/include/testing_gthr.hpp
+++ b/clients/include/testing_gthr.hpp
@@ -51,10 +51,9 @@ void testing_gthr_bad_arg(void)
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
     hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
-    auto dx_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dx_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-    auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto dy_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     T*   dx_val = (T*)dx_val_managed.get();
     int* dx_ind = (int*)dx_ind_managed.get();
@@ -116,10 +115,10 @@ hipsparseStatus_t testing_gthr(Arguments argus)
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
         auto dx_ind_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto dx_val_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         int* dx_ind = (int*)dx_ind_managed.get();
         T*   dx_val = (T*)dx_val_managed.get();
@@ -159,9 +158,9 @@ hipsparseStatus_t testing_gthr(Arguments argus)
     hipsparseInit<T>(hy, 1, N);
 
     // allocate memory on device
-    auto dx_ind_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
-    auto dx_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dy_managed     = hipsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
+    auto dx_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
+    auto dx_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dy_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
 
     int* dx_ind = (int*)dx_ind_managed.get();
     T*   dx_val = (T*)dx_val_managed.get();

--- a/clients/include/testing_gthrz.hpp
+++ b/clients/include/testing_gthrz.hpp
@@ -51,10 +51,9 @@ void testing_gthrz_bad_arg(void)
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
     hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
-    auto dx_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dx_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-    auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto dy_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     T*   dx_val = (T*)dx_val_managed.get();
     int* dx_ind = (int*)dx_ind_managed.get();
@@ -116,10 +115,10 @@ hipsparseStatus_t testing_gthrz(Arguments argus)
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
         auto dx_ind_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto dx_val_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         int* dx_ind = (int*)dx_ind_managed.get();
         T*   dx_val = (T*)dx_val_managed.get();
@@ -162,9 +161,9 @@ hipsparseStatus_t testing_gthrz(Arguments argus)
     hy_gold = hy;
 
     // allocate memory on device
-    auto dx_ind_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
-    auto dx_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dy_managed     = hipsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
+    auto dx_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
+    auto dx_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dy_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
 
     int* dx_ind = (int*)dx_ind_managed.get();
     T*   dx_val = (T*)dx_val_managed.get();

--- a/clients/include/testing_hybmv.hpp
+++ b/clients/include/testing_hybmv.hpp
@@ -73,8 +73,8 @@ void testing_hybmv_bad_arg(void)
     std::unique_ptr<hyb_struct> unique_ptr_hyb(new hyb_struct);
     hipsparseHybMat_t           hyb = unique_ptr_hyb->hyb;
 
-    auto dx_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dy_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     T* dx = (T*)dx_managed.get();
     T* dy = (T*)dy_managed.get();
@@ -189,13 +189,12 @@ hipsparseStatus_t testing_hybmv(Arguments argus)
     if(m <= 0 || n <= 0 || nnz <= 0)
     {
         auto dptr_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto dcol_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-        auto dval_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dx_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+        auto dval_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dx_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed   = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         int* dptr = (int*)dptr_managed.get();
         int* dcol = (int*)dcol_managed.get();
@@ -291,14 +290,14 @@ hipsparseStatus_t testing_hybmv(Arguments argus)
     hy_gold = hy_1;
 
     // allocate memory on device
-    auto dptr_managed    = hipsparse_unique_ptr {device_malloc(sizeof(int) * (m + 1)), device_free};
-    auto dcol_managed    = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
-    auto dval_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dx_managed      = hipsparse_unique_ptr {device_malloc(sizeof(T) * n), device_free};
-    auto dy_1_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto dy_2_managed    = hipsparse_unique_ptr {device_malloc(sizeof(T) * m), device_free};
-    auto d_alpha_managed = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
-    auto d_beta_managed  = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+    auto dptr_managed    = hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};
+    auto dcol_managed    = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
+    auto dval_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dx_managed      = hipsparse_unique_ptr{device_malloc(sizeof(T) * n), device_free};
+    auto dy_1_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto dy_2_managed    = hipsparse_unique_ptr{device_malloc(sizeof(T) * m), device_free};
+    auto d_alpha_managed = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
+    auto d_beta_managed  = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
 
     int* dptr    = (int*)dptr_managed.get();
     int* dcol    = (int*)dcol_managed.get();

--- a/clients/include/testing_identity.hpp
+++ b/clients/include/testing_identity.hpp
@@ -49,7 +49,7 @@ void testing_identity_bad_arg(void)
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
     hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
-    auto p_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+    auto p_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
 
     int* p = (int*)p_managed.get();
 
@@ -92,7 +92,7 @@ hipsparseStatus_t testing_identity(Arguments argus)
         // Do not test args in cusparse
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
-        auto p_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+        auto p_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
 
         int* p = (int*)p_managed.get();
 
@@ -127,7 +127,7 @@ hipsparseStatus_t testing_identity(Arguments argus)
     }
 
     // Allocate memory on the device
-    auto dp_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * n), device_free};
+    auto dp_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * n), device_free};
 
     int* dp = (int*)dp_managed.get();
 

--- a/clients/include/testing_roti.hpp
+++ b/clients/include/testing_roti.hpp
@@ -53,10 +53,9 @@ void testing_roti_bad_arg(void)
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
     hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
-    auto dx_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dx_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-    auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto dy_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     T*   dx_val = (T*)dx_val_managed.get();
     int* dx_ind = (int*)dx_ind_managed.get();
@@ -134,10 +133,10 @@ hipsparseStatus_t testing_roti(Arguments argus)
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
         auto dx_ind_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto dx_val_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         int* dx_ind = (int*)dx_ind_managed.get();
         T*   dx_val = (T*)dx_val_managed.get();
@@ -186,13 +185,13 @@ hipsparseStatus_t testing_roti(Arguments argus)
     hy_gold     = hy_1;
 
     // allocate memory on device
-    auto dx_ind_managed   = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
-    auto dx_val_1_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dx_val_2_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dy_1_managed     = hipsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
-    auto dy_2_managed     = hipsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
-    auto dc_managed       = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
-    auto ds_managed       = hipsparse_unique_ptr {device_malloc(sizeof(T)), device_free};
+    auto dx_ind_managed   = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
+    auto dx_val_1_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dx_val_2_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dy_1_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
+    auto dy_2_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
+    auto dc_managed       = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
+    auto ds_managed       = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
 
     int* dx_ind   = (int*)dx_ind_managed.get();
     T*   dx_val_1 = (T*)dx_val_1_managed.get();

--- a/clients/include/testing_sctr.hpp
+++ b/clients/include/testing_sctr.hpp
@@ -51,10 +51,9 @@ void testing_sctr_bad_arg(void)
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
     hipsparseHandle_t              handle = unique_ptr_handle->handle;
 
-    auto dx_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-    auto dx_ind_managed
-        = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
-    auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+    auto dx_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
+    auto dy_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
     T*   dx_val = (T*)dx_val_managed.get();
     int* dx_ind = (int*)dx_ind_managed.get();
@@ -116,10 +115,10 @@ hipsparseStatus_t testing_sctr(Arguments argus)
         return HIPSPARSE_STATUS_SUCCESS;
 #endif
         auto dx_ind_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(int) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(int) * safe_size), device_free};
         auto dx_val_managed
-            = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
-        auto dy_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * safe_size), device_free};
+            = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
+        auto dy_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * safe_size), device_free};
 
         int* dx_ind = (int*)dx_ind_managed.get();
         T*   dx_val = (T*)dx_val_managed.get();
@@ -162,9 +161,9 @@ hipsparseStatus_t testing_sctr(Arguments argus)
     hy_gold = hy;
 
     // allocate memory on device
-    auto dx_ind_managed = hipsparse_unique_ptr {device_malloc(sizeof(int) * nnz), device_free};
-    auto dx_val_managed = hipsparse_unique_ptr {device_malloc(sizeof(T) * nnz), device_free};
-    auto dy_managed     = hipsparse_unique_ptr {device_malloc(sizeof(T) * N), device_free};
+    auto dx_ind_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * nnz), device_free};
+    auto dx_val_managed = hipsparse_unique_ptr{device_malloc(sizeof(T) * nnz), device_free};
+    auto dy_managed     = hipsparse_unique_ptr{device_malloc(sizeof(T) * N), device_free};
 
     int* dx_ind = (int*)dx_ind_managed.get();
     T*   dx_val = (T*)dx_val_managed.get();


### PR DESCRIPTION
- Additional options are now available in clang-format, and they need to be applied to Jenkins after I upgraded CI from rocm2.4 to rocm2.5
