### PR TITLE
Added hip-clang support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ hipSPARSECI:
     hipsparse.compiler.compiler_path = 'c++'
     
     // Define test architectures, optional rocm version argument is available
-    def nodes = new dockerNodes(['gfx900 && centos7', 'gfx906'], hipsparse)
+    def nodes = new dockerNodes(['gfx900 && centos7', 'gfx906 && ubuntu', 'gfx900 && ubuntu && hip-clang', 'gfx906 && ubuntu && hip-clang'], hipsparse)
 
     boolean formatCheck = true
 
@@ -55,6 +55,14 @@ hipSPARSECI:
                     cd ${project.paths.project_build_prefix}
                     export PATH=/opt/rocm/hsa/include:$PATH
                     LD_LIBRARY_PATH=/opt/rocm/hcc/lib CXX=/opt/rh/devtoolset-7/root/usr/bin/c++ ${project.paths.build_command}
+                """
+        }
+        else if(platform.jenkinsLabel.contains('hip-clang'))
+        {
+            command = """#!/usr/bin/env bash
+                    set -x
+                    cd ${project.paths.project_build_prefix}
+                    LD_LIBRARY_PATH=/opt/rocm/hcc/lib CXX=${project.compiler.compiler_path} ${project.paths.build_command} --hip-clang
                 """
         }
         else
@@ -136,6 +144,10 @@ hipSPARSECI:
 
             platform.runCommand(this, command)
             platform.archiveArtifacts(this, """${project.paths.project_build_prefix}/build/release/package/*.rpm""")        
+        }
+        else if(platform.jenkinsLabel.contains('hip-clang'))
+        {
+            packageCommand = null
         }
         else
         {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 // This shared library is available at https://github.com/ROCmSoftwarePlatform/rocJENKINS/
-@Library('rocJenkins@clang9') _
+@Library('rocJenkins') _
 
 // This is file for internal AMD use.
 // If you are interested in running your own Jenkins, please raise a github issue for assistance.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,14 +29,14 @@ import java.nio.file.Path;
 hipSPARSECI:
 {
 
-    def hipsparse = new rocProject('hipsparse')
+    def hipsparse = new rocProject('hipSPARSE')
     // customize for project
     hipsparse.paths.build_command = './install.sh -c'
     hipsparse.compiler.compiler_name = 'c++'
     hipsparse.compiler.compiler_path = 'c++'
     
     // Define test architectures, optional rocm version argument is available
-    def nodes = new dockerNodes(['gfx900 && centos7', 'gfx906 && ubuntu', 'gfx900 && ubuntu && hip-clang', 'gfx906 && ubuntu && hip-clang'], hipsparse)
+    def nodes = new dockerNodes(['gfx900 && centos7', 'gfx906 && centos7', 'gfx900 && ubuntu && hip-clang', 'gfx906 && ubuntu && hip-clang'], hipsparse)
 
     boolean formatCheck = true
 
@@ -57,22 +57,15 @@ hipSPARSECI:
                     LD_LIBRARY_PATH=/opt/rocm/hcc/lib CXX=/opt/rh/devtoolset-7/root/usr/bin/c++ ${project.paths.build_command}
                 """
         }
-        else if(platform.jenkinsLabel.contains('hip-clang'))
-        {
-            command = """#!/usr/bin/env bash
-                    set -x
-                    cd ${project.paths.project_build_prefix}
-                    LD_LIBRARY_PATH=/opt/rocm/hcc/lib CXX=${project.compiler.compiler_path} ${project.paths.build_command} --hip-clang
-                """
-        }
         else
         {
             command = """#!/usr/bin/env bash
                     set -x
                     cd ${project.paths.project_build_prefix}
-                    LD_LIBRARY_PATH=/opt/rocm/hcc/lib CXX=${project.compiler.compiler_path} ${project.paths.build_command}
+                    LD_LIBRARY_PATH=/opt/rocm/hcc/lib CXX=${project.compiler.compiler_path} ${project.paths.build_command}d --hip-clang
                 """
         }
+    
         platform.runCommand(this, command)
     }
 
@@ -144,10 +137,6 @@ hipSPARSECI:
 
             platform.runCommand(this, command)
             platform.archiveArtifacts(this, """${project.paths.project_build_prefix}/build/release/package/*.rpm""")        
-        }
-        else if(platform.jenkinsLabel.contains('hip-clang'))
-        {
-            packageCommand = null
         }
         else
         {

--- a/docker/dockerfile-build-ubuntu-rock
+++ b/docker/dockerfile-build-ubuntu-rock
@@ -18,7 +18,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     git \
     make \
     cmake \
-    clang-format-3.8 \
     pkg-config \
     libnuma1 \
     rocprim \
@@ -41,8 +40,8 @@ ARG HIPSPARSE_SRC_ROOT=/usr/local/src/hipSPARSE
 RUN mkdir -p ${ROCSPARSE_SRC_ROOT} && cd ${ROCSPARSE_SRC_ROOT} && \
     git clone -b develop --depth=1 https://github.com/ROCmSoftwarePlatform/rocSPARSE . && \
     mkdir -p build && cd build && \
-    HIP_PLATFORM=hcc cmake -DBUILD_CLIENTS_SAMPLES=OFF .. && \
-    HIP_PLATFORM=hcc make -j $(nproc) install && \
+    CXX=hipcc HIP_PLATFORM=hipcc cmake -DBUILD_CLIENTS_SAMPLES=OFF .. && \
+    HIP_PLATFORM=hipcc make -j $(nproc) install && \
     rm -rf ${ROCSPARSE_SRC_ROOT}
 
 # Clone hipsparse repo
@@ -50,6 +49,6 @@ RUN mkdir -p ${ROCSPARSE_SRC_ROOT} && cd ${ROCSPARSE_SRC_ROOT} && \
 RUN mkdir -p ${HIPSPARSE_SRC_ROOT} && cd ${HIPSPARSE_SRC_ROOT} && \
     git clone -b develop --depth=1 https://github.com/ROCmSoftwarePlatform/hipSPARSE . && \
     mkdir -p build/deps && cd build/deps && \
-    HIP_PLATFORM=hcc cmake ${HIPSPARSE_SRC_ROOT}/deps && \
-    HIP_PLATFORM=hcc make -j $(nproc) install && \
+    HIP_PLATFORM=hipcc cmake ${HIPSPARSE_SRC_ROOT}/deps && \
+    HIP_PLATFORM=hipcc make -j $(nproc) install && \
     rm -rf ${HIPSPARSE_SRC_ROOT}


### PR DESCRIPTION
This PR adds CI testing for our new hip-clang compiler. For a period of time, we'll have to support both the hcc and the hip-clang compilers, thus we'll have to test both in CI.