### PR TITLE
Fixed email notification link

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ import java.nio.file.Path;
 hipSPARSECI:
 {
 
-    def hipsparse = new rocProject('hipsparse')
+    def hipsparse = new rocProject('hipSPARSE')
     // customize for project
     hipsparse.paths.build_command = './install.sh -c'
     hipsparse.compiler.compiler_name = 'c++'


### PR DESCRIPTION
When a build fails, you will get an email with a link like so: http://hsautil.amd.com/job/ROCmSoftwarePlatform/job/hipsparse ... all this does is change that link to .../hipSPARSE. This way, the link will actually work. Also am doing this for rocSPARSE and rocALUTION