### PR TITLE
Adding RUNPATH to the hipSparse sample elfs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -379,6 +379,7 @@ pushd .
       -DCMAKE_SHARED_LINKER_FLAGS=${rocm_rpath} \
       -DCMAKE_PREFIX_PATH="${rocm_path} ${rocm_path}/hcc ${rocm_path}/hip" \
       -DCMAKE_MODULE_PATH="${rocm_path}/hip/cmake" \
+      -DCMAKE_EXE_LINKER_FLAGS=" -Wl,--enable-new-dtags -Wl,--rpath,${rocm_path}/lib:${rocm_path}/lib64" \
       -DROCM_DISABLE_LDCONFIG=ON \
       -DROCM_PATH=${rocm_path} ../..
   else


### PR DESCRIPTION
- lib path is added for ubuntu
- lib64 path is added for CentOS/SLES