### PR TITLE
Fix CMAKE_INSTALL_PREFIX in build_relocatable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -389,7 +389,7 @@ pushd .
   # Build library
   if [[ "${build_relocatable}" == true ]]; then
     ${cmake_executable} ${cmake_common_options} ${cmake_client_options} \
-      -DCMAKE_INSTALL_PREFIX="${rocm_path}" \
+      -DCMAKE_INSTALL_PREFIX="${install_prefix}" \
       -DCMAKE_SHARED_LINKER_FLAGS="${rocm_rpath}" \
       -DCMAKE_PREFIX_PATH="${rocm_path} ${rocm_path}/hcc ${rocm_path}/hip" \
       -DCMAKE_MODULE_PATH="${rocm_path}/hip/cmake" \


### PR DESCRIPTION
-> CMAKE_INSTALL_PREFIX set to $install_prefix for 'make install'
-> CPACK_PACKAGING_INSTALL_PREFIX still set to $rocm_path for package install path
-> 'make install' can be called by non-root user to test the build