### PR TITLE
Updates to debian package name

### DIFF
--- a/docker/dockerfile-install-ubuntu
+++ b/docker/dockerfile-install-ubuntu
@@ -9,7 +9,7 @@ COPY *.deb /tmp/
 
 # Install the debian package
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --allow-unauthenticated -y \
-    /tmp/hipsparse-*.deb \
+    /tmp/hipsparse[-\_]*.deb \
   && rm -f /tmp/*.deb \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \

--- a/install.sh
+++ b/install.sh
@@ -432,7 +432,7 @@ pushd .
 
     case "${ID}" in
       ubuntu)
-        elevate_if_not_root dpkg -i hipsparse-*.deb
+        elevate_if_not_root dpkg -i hipsparse[-\_]*.deb
       ;;
       centos|rhel)
         elevate_if_not_root yum -y localinstall hipsparse-*.rpm


### PR DESCRIPTION
- According to debian standards, package name and package
  version should be seperated by '_'.
- Changes to support rocm-cmake - https://github.com/RadeonOpenCompute/rocm-cmake/pull/38