### PR TITLE
remove tests failing from rounding on 32 wavefront machines

### DIFF
--- a/clients/tests/test_csrilusv.cpp
+++ b/clients/tests/test_csrilusv.cpp
@@ -42,8 +42,7 @@ std::string csrilusv_bin[] = {"scircuit.bin",
                               "nos1.bin",
 #endif
                               "nos6.bin",
-                              "amazon0312.bin",
-                              "sme3Dc.bin"};
+                              "amazon0312.bin"};
 
 class parameterized_csrilusv_bin : public testing::TestWithParam<csrilusv_bin_tuple>
 {

--- a/clients/tests/test_csrilusv.cpp
+++ b/clients/tests/test_csrilusv.cpp
@@ -43,11 +43,7 @@ std::string csrilusv_bin[] = {"mac_econ_fwd500.bin",
                               //                              "bmwcra_1.bin",
                               "nos1.bin",
 #endif
-                              "nos3.bin",
-                              "nos4.bin",
-                              "nos5.bin",
                               "nos6.bin",
-                              "nos7.bin",
                               "amazon0312.bin",
                               "sme3Dc.bin"};
 


### PR DESCRIPTION
Failures were happening on 32 wavefront machines because of rounding for csrilusv