### PR TITLE
Disable CCache on CI; Enable devtoolset-7 in Centos 7 in CI

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -21,7 +21,7 @@ def runCompileCommand(platform, project, boolean sameOrg=false)
                 set -x
                 cd ${project.paths.project_build_prefix}
                 ${getDependenciesCommand}
-                export PATH=/opt/rocm/hsa/include:$PATH
+                export PATH=/opt/rocm/hsa/include:\$PATH
                 CXX=/opt/rh/devtoolset-7/root/usr/bin/c++ ${project.paths.build_command}
             """
     }

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -14,26 +14,16 @@ def runCompileCommand(platform, project, boolean sameOrg=false)
             getDependenciesCommand += auxiliary.getLibrary(libraryName, platform.jenkinsLabel, 'develop', sameOrg)
         }
     }
-
-    if(platform.jenkinsLabel.contains('centos7'))
-    {
-        command = """#!/usr/bin/env bash
+    String centos7 = platform.jenkinsLabel.contains('centos7') ? 'source scl_source enable devtoolset-7' : ':'
+    
+    command = """#!/usr/bin/env bash
                 set -x
-                cd ${project.paths.project_build_prefix}
-                ${getDependenciesCommand}
-                export PATH=/opt/rocm/hsa/include:\$PATH
-                CXX=/opt/rh/devtoolset-7/root/usr/bin/c++ ${project.paths.build_command}
-            """
-    }
-    else
-    {
-        command = """#!/usr/bin/env bash
-                set -x
+                ${centos7}
                 cd ${project.paths.project_build_prefix}
                 ${getDependenciesCommand}
                 CXX=${project.compiler.compiler_path} ${project.paths.build_command}
             """
-    }
+ 
     platform.runCommand(this, command)
 }
 

--- a/.jenkins/extended.groovy
+++ b/.jenkins/extended.groovy
@@ -19,6 +19,7 @@ def runCI =
     prj.compiler.compiler_name = 'c++'
     prj.compiler.compiler_path = 'c++'
     prj.libraryDependencies = ['rocSPARSE', 'rocPRIM']
+    prj.defaults.ccache = false
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)

--- a/.jenkins/precheckin-cuda.groovy
+++ b/.jenkins/precheckin-cuda.groovy
@@ -18,6 +18,7 @@ def runCI =
     prj.paths.build_command = './install.sh -c --cuda'
     prj.compiler.compiler_name = 'c++'
     prj.compiler.compiler_path = 'c++'
+    prj.defaults.ccache = false
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)

--- a/.jenkins/precheckin.groovy
+++ b/.jenkins/precheckin.groovy
@@ -19,6 +19,7 @@ def runCI =
     prj.compiler.compiler_name = 'c++'
     prj.compiler.compiler_path = 'c++'
     prj.libraryDependencies = ['rocSPARSE', 'rocPRIM']
+    prj.defaults.ccache = false
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)

--- a/.jenkins/staticlibrary.groovy
+++ b/.jenkins/staticlibrary.groovy
@@ -19,6 +19,7 @@ def runCI =
     prj.compiler.compiler_name = 'hipcc'
     prj.compiler.compiler_path = '/opt/rocm/bin/hipcc'
     prj.libraryDependencies = ['rocSPARSE', 'rocPRIM']
+    prj.defaults.ccache = false
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)

--- a/install.sh
+++ b/install.sh
@@ -250,7 +250,7 @@ install_prefix=hipsparse-install
 rocm_path=/opt/rocm
 build_relocatable=false
 build_address_sanitizer=false
-compiler=$CXX
+compiler=
 
 # #################################################
 # Parameter parsing

--- a/install.sh
+++ b/install.sh
@@ -250,7 +250,7 @@ install_prefix=hipsparse-install
 rocm_path=/opt/rocm
 build_relocatable=false
 build_address_sanitizer=false
-compiler=
+compiler=$CXX
 
 # #################################################
 # Parameter parsing


### PR DESCRIPTION
Install.sh was not honouring CXX set in an environment variable prior to calling the script. This fixes that and also includes a syntax fix for reference to $PATH in a groovy script.