### PR TITLE
Hotfixes from release/rocm-rel-4.5 at release 4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Change Log for hipSPARSE
 
-## (Unreleased) hipSPARSE 1.11.2
+## hipSPARSE 1.11.2 for ROCm 4.5.0
 ### Added
+- Triangular solve for multiple right-hand sides using BSR format
+- SpMV for BSRX format
+- SpMM in CSR format enhanced to work with transposed A
+- Matrix coloring for CSR matrices
+- Added batched tridiagonal solve (gtsv\_strided\_batch)
 - SpMM for BLOCKED ELL format
 - Generic routines for SpSV and SpSM
 - Enabling beta support for Windows 10
@@ -10,37 +15,27 @@
 ### Changed
 - Packaging split into a runtime package called hipsparse and a development package called hipsparse-devel. The development package depends on runtime. The runtime package suggests the development package for all supported OSes except CentOS 7 to aid in the transition. The suggests feature in packaging is introduced as a deprecated feature and will be removed in a future rocm release.
 - GTest dependency updated to v1.10.0
-### Known Issues
-- none
-
-## (Unreleased) hipSPARSE 1.10.9
-### Added
-- Triangular solve for multiple right-hand sides using BSR format
-- SpMV for BSRX format
-- SpMM in CSR format enhanced to work with transposed A
-- Matrix coloring for CSR matrices
-- Added batched tridiagonal solve (gtsv\_strided\_batch)
 ### Improved
 - Fixed a bug with gemvi on Navi21
 - Optimization for pivot based gtsv
 ### Known Issues
 - none
 
-## [hipSPARSE 1.10.7 for ROCm 4.3.0]
+## hipSPARSE 1.10.7 for ROCm 4.3.0
 ### Added
 - (batched) tridiagonal solve with and without pivoting
 - dense matrix sparse vector multiplication (gemvi)
 - sampled dense-dense matrix multiplication (sddmm)
 
-## [hipSPARSE 1.10.6 for ROCm 4.2.0]
+## hipSPARSE 1.10.6 for ROCm 4.2.0
 ### Added
 - Generic API support, including SpMM
 
-## [hipSPARSE 1.10.4 for ROCm 4.1.0]
+## hipSPARSE 1.10.4 for ROCm 4.1.0
 ### Added
 - Generic API support, including Axpby, Gather, Scatter, Rot, SpVV, SpMV, SparseToDense, DenseToSparse and SpGEMM
 
-## [hipSPARSE 1.9.6 for ROCm 4.0.0]
+## hipSPARSE 1.9.6 for ROCm 4.0.0
 ### Added
 - changelog
 - csr2gebsr
@@ -50,20 +45,20 @@
 ### Improved
 - Updates to debian package name.
 
-## [hipSPARSE 1.9.4 for ROCm 3.9]
+## hipSPARSE 1.9.4 for ROCm 3.9
 ### Added
 - prune_csr2csr, prune_dense2csr_percentage and prune_csr2csr_percentage
 - bsrilu0
 ### Known Issues
 - none
 
-## [hipSPARSE 1.8.1 for ROCm 3.8]
+## hipSPARSE 1.8.1 for ROCm 3.8
 ### Added
 - bsric0 added.
 ### Known Issues
 - none
 
-## [hipSPARSE 1.7.1 for ROCm 3.7]
+## hipSPARSE 1.7.1 for ROCm 3.7
 ### Added
 - Fortran bindings
 - Triangular solve for BSR format (bsrsv)
@@ -71,7 +66,7 @@
 ### Known Issues
 - none
 
-## [hipSPARSE 1.7.1 for ROCm 3.6]
+## hipSPARSE 1.7.1 for ROCm 3.6
 ### Added
 - Fortran bindings
 - Triangular solve for BSR format (bsrsv)
@@ -79,7 +74,7 @@
 ### Known Issues
 - none
 
-## [hipSPARSE 1.6.5 for ROCm 3.5]
+## hipSPARSE 1.6.5 for ROCm 3.5
 ### Added
 - Switched to hip-clang as default compiler
 - csr2dense, csc2dense, csr2csr_compress, nnz_compress, bsr2csr, csr2bsr, bsrmv, csrgeam


### PR DESCRIPTION
This is an autogenerated PR.
This is intended to pull any hotfixes for ROCm release 4.5 (including changelogs and documentation) back into develop.