### PR TITLE
Fix bug in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -324,6 +324,12 @@ while true; do
   esac
 done
 
+# Note 'compiler' variable not changed after this point. This ensures that everything is built with the same compiler
+# provided by the user through either setting CXX externally (in which case compiler=${CXX} followed by CXX=${compiler})
+# or through using --compiler option. This is important so that googletest and hipsparse are built with the same 
+# compiler to ensure settings like position independent code is consistent when linking.
+CXX=${compiler}
+
 if [[ "${build_relocatable}" == true ]]; then
     if ! [ -z ${ROCM_PATH+x} ]; then
         rocm_path=${ROCM_PATH}

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,7 @@ function display_help()
   echo "    [-g|--debug] -DCMAKE_BUILD_TYPE=Debug (default is =Release)"
   echo "    [-k|--relwithdebinfo] -DCMAKE_BUILD_TYPE=RelWithDebInfo"
   echo "    [--codecoverage] build with code coverage profiling enabled"
+  echo "    [--compiler] specify host compiler"
   echo "    [--cuda] build library for cuda backend"
   echo "    [--static] build static library"
   echo "    [--address-sanitizer] build with address sanitizer enabled. Uses hipcc to compile"
@@ -250,7 +251,7 @@ install_prefix=hipsparse-install
 rocm_path=/opt/rocm
 build_relocatable=false
 build_address_sanitizer=false
-compiler=
+compiler=${CXX}
 
 # #################################################
 # Parameter parsing
@@ -259,7 +260,7 @@ compiler=
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,cuda,static,relocatable,codecoverage,relwithdebinfo,address-sanitizer --options hicdgrk -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,compiler:,cuda,static,relocatable,codecoverage,relwithdebinfo,address-sanitizer --options hicdgrk -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -293,6 +294,9 @@ while true; do
     -g|--debug)
         build_release=false
         shift ;;
+    --compiler)
+        compiler=${2}
+        shift 2 ;;
     --cuda)
         build_cuda=true
         shift ;;
@@ -319,6 +323,8 @@ while true; do
         ;;
   esac
 done
+
+printf "AAAAAAAAAAAAA compiler ${compiler}\n"
 
 if [[ "${build_relocatable}" == true ]]; then
     if ! [ -z ${ROCM_PATH+x} ]; then
@@ -440,6 +446,9 @@ pushd .
     cmake_common_options="${cmake_common_options} -DUSE_CUDA=ON"
   fi
 
+  printf "BBBBBBBBBB CXX ${CXX}\n"
+  printf "BBBBBBBBBB compiler ${compiler}\n"
+
   # Build library
   if [[ "${build_relocatable}" == true ]]; then
     CXX=${compiler} ${cmake_executable} ${cmake_common_options} ${cmake_client_options} \
@@ -453,6 +462,9 @@ pushd .
   else
     CXX=${compiler} ${cmake_executable} -DCMAKE_EXE_LINKER_FLAGS=" ${cmake_build_static_options}" ${cmake_common_options} ${cmake_client_options} -DCMAKE_INSTALL_PREFIX=hipsparse-install -DROCM_PATH=${rocm_path} ../..
   fi
+
+  printf "CCCCCCCCCC CXX ${CXX}\n"
+  printf "CCCCCCCCCCCCC compiler ${compiler}\n"
 
   check_exit_code "$?"
 

--- a/install.sh
+++ b/install.sh
@@ -324,8 +324,6 @@ while true; do
   esac
 done
 
-printf "AAAAAAAAAAAAA compiler ${compiler}\n"
-
 if [[ "${build_relocatable}" == true ]]; then
     if ! [ -z ${ROCM_PATH+x} ]; then
         rocm_path=${ROCM_PATH}
@@ -446,9 +444,6 @@ pushd .
     cmake_common_options="${cmake_common_options} -DUSE_CUDA=ON"
   fi
 
-  printf "BBBBBBBBBB CXX ${CXX}\n"
-  printf "BBBBBBBBBB compiler ${compiler}\n"
-
   # Build library
   if [[ "${build_relocatable}" == true ]]; then
     CXX=${compiler} ${cmake_executable} ${cmake_common_options} ${cmake_client_options} \
@@ -462,10 +457,7 @@ pushd .
   else
     CXX=${compiler} ${cmake_executable} -DCMAKE_EXE_LINKER_FLAGS=" ${cmake_build_static_options}" ${cmake_common_options} ${cmake_client_options} -DCMAKE_INSTALL_PREFIX=hipsparse-install -DROCM_PATH=${rocm_path} ../..
   fi
-
-  printf "CCCCCCCCCC CXX ${CXX}\n"
-  printf "CCCCCCCCCCCCC compiler ${compiler}\n"
-
+  
   check_exit_code "$?"
 
   make -j$(nproc) install


### PR DESCRIPTION
If exporting CXX=hipcc and then calling the install script, this will result in googletest being built with CXX compiler (in this case hipcc) but hipsparse will be built with whatever c++ compiler cmake finds (the install script changes what CXX is). This means then that if googletest is built with hipcc it will generate a position dependent static library for googletest. Then when running the install script cmake will likely pick up either g++ or c++ compiler to build hipsparse. This is fine except that these compilers will build the hipsparse-test executable using position independent code. SInce our googletest static library is not position independent then this causes an error saying we must compile googtest with fPIC flag when linking. This proposed change makes it so that the compiler defaults to whatever is set by CXX so that everything is built with the same compiler. Additionally it adds the option to explicitly set the compiler used (useful for example if you are not exporting CXX variables outside the install script but still want to choose what c++ compiler you use) 