### PR TITLE
Fix gtsv null parameter

### DIFF
--- a/clients/include/testing_gpsv_interleaved_batch.hpp
+++ b/clients/include/testing_gpsv_interleaved_batch.hpp
@@ -88,30 +88,6 @@ void testing_gpsv_interleaved_batch_bad_arg(void)
         "Error: batch_count is invalid");
     verify_hipsparse_status_invalid_pointer(
         hipsparseXgpsvInterleavedBatch_bufferSizeExt(
-            handle, algo, m, (const T*)nullptr, dds, dd, ddu, ddw, dx, batch_count, &bsize),
-        "Error: dds is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgpsvInterleavedBatch_bufferSizeExt(
-            handle, algo, m, dds, (const T*)nullptr, dd, ddu, ddw, dx, batch_count, &bsize),
-        "Error: ddl is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgpsvInterleavedBatch_bufferSizeExt(
-            handle, algo, m, dds, ddl, (const T*)nullptr, ddu, ddw, dx, batch_count, &bsize),
-        "Error: dd is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgpsvInterleavedBatch_bufferSizeExt(
-            handle, algo, m, dds, ddl, dd, (const T*)nullptr, ddw, dx, batch_count, &bsize),
-        "Error: ddu is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgpsvInterleavedBatch_bufferSizeExt(
-            handle, algo, m, dds, ddl, dd, ddu, (const T*)nullptr, dx, batch_count, &bsize),
-        "Error: ddw is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgpsvInterleavedBatch_bufferSizeExt(
-            handle, algo, m, dds, ddl, dd, ddu, ddw, (const T*)nullptr, batch_count, &bsize),
-        "Error: dx is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgpsvInterleavedBatch_bufferSizeExt(
             handle, algo, m, dds, ddl, dd, ddu, ddw, dx, batch_count, nullptr),
         "Error: bsize is nullptr");
 

--- a/clients/include/testing_gtsv.hpp
+++ b/clients/include/testing_gtsv.hpp
@@ -84,18 +84,6 @@ void testing_gtsv2_bad_arg(void)
         hipsparseXgtsv2_bufferSizeExt(handle, m, n, ddl, dd, ddu, dB, -1, &bsize),
         "Error: ldb is invalid");
     verify_hipsparse_status_invalid_pointer(
-        hipsparseXgtsv2_bufferSizeExt(handle, m, n, (const T*)nullptr, dd, ddu, dB, ldb, &bsize),
-        "Error: ddl is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgtsv2_bufferSizeExt(handle, m, n, ddl, (const T*)nullptr, ddu, dB, ldb, &bsize),
-        "Error: dd is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgtsv2_bufferSizeExt(handle, m, n, ddl, dd, (const T*)nullptr, dB, ldb, &bsize),
-        "Error: ddu is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgtsv2_bufferSizeExt(handle, m, n, ddl, dd, ddu, (const T*)nullptr, ldb, &bsize),
-        "Error: dB is nullptr");
-    verify_hipsparse_status_invalid_pointer(
         hipsparseXgtsv2_bufferSizeExt(handle, m, n, ddl, dd, ddu, dB, ldb, nullptr),
         "Error: bsize is nullptr");
 

--- a/clients/include/testing_gtsv2_nopivot.hpp
+++ b/clients/include/testing_gtsv2_nopivot.hpp
@@ -84,22 +84,6 @@ void testing_gtsv2_nopivot_bad_arg(void)
         hipsparseXgtsv2_nopivot_bufferSizeExt(handle, m, n, ddl, dd, ddu, dB, -1, &bsize),
         "Error: ldb is invalid");
     verify_hipsparse_status_invalid_pointer(
-        hipsparseXgtsv2_nopivot_bufferSizeExt(
-            handle, m, n, (const T*)nullptr, dd, ddu, dB, ldb, &bsize),
-        "Error: ddl is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgtsv2_nopivot_bufferSizeExt(
-            handle, m, n, ddl, (const T*)nullptr, ddu, dB, ldb, &bsize),
-        "Error: dd is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgtsv2_nopivot_bufferSizeExt(
-            handle, m, n, ddl, dd, (const T*)nullptr, dB, ldb, &bsize),
-        "Error: ddu is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgtsv2_nopivot_bufferSizeExt(
-            handle, m, n, ddl, dd, ddu, (const T*)nullptr, ldb, &bsize),
-        "Error: dB is nullptr");
-    verify_hipsparse_status_invalid_pointer(
         hipsparseXgtsv2_nopivot_bufferSizeExt(handle, m, n, ddl, dd, ddu, dB, ldb, nullptr),
         "Error: bsize is nullptr");
 

--- a/clients/include/testing_gtsv2_strided_batch.hpp
+++ b/clients/include/testing_gtsv2_strided_batch.hpp
@@ -87,22 +87,6 @@ void testing_gtsv2_strided_batch_bad_arg(void)
                                           "Error: batch_stride is invalid");
     verify_hipsparse_status_invalid_pointer(
         hipsparseXgtsv2StridedBatch_bufferSizeExt(
-            handle, m, (const T*)nullptr, dd, ddu, dx, batch_count, batch_stride, &bsize),
-        "Error: ddl is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgtsv2StridedBatch_bufferSizeExt(
-            handle, m, ddl, (const T*)nullptr, ddu, dx, batch_count, batch_stride, &bsize),
-        "Error: dd is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgtsv2StridedBatch_bufferSizeExt(
-            handle, m, ddl, dd, (const T*)nullptr, dx, batch_count, batch_stride, &bsize),
-        "Error: ddu is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgtsv2StridedBatch_bufferSizeExt(
-            handle, m, ddl, dd, ddu, (const T*)nullptr, batch_count, batch_stride, &bsize),
-        "Error: dx is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgtsv2StridedBatch_bufferSizeExt(
             handle, m, ddl, dd, ddu, dx, batch_count, batch_stride, nullptr),
         "Error: bsize is nullptr");
 

--- a/clients/include/testing_gtsv_interleaved_batch.hpp
+++ b/clients/include/testing_gtsv_interleaved_batch.hpp
@@ -83,22 +83,6 @@ void testing_gtsv_interleaved_batch_bad_arg(void)
         "Error: batch_count is invalid");
     verify_hipsparse_status_invalid_pointer(
         hipsparseXgtsvInterleavedBatch_bufferSizeExt(
-            handle, algo, m, (const T*)nullptr, dd, ddu, dx, batch_count, &bsize),
-        "Error: ddl is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgtsvInterleavedBatch_bufferSizeExt(
-            handle, algo, m, ddl, (const T*)nullptr, ddu, dx, batch_count, &bsize),
-        "Error: dd is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgtsvInterleavedBatch_bufferSizeExt(
-            handle, algo, m, ddl, dd, (const T*)nullptr, dx, batch_count, &bsize),
-        "Error: ddu is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgtsvInterleavedBatch_bufferSizeExt(
-            handle, algo, m, ddl, dd, ddu, (const T*)nullptr, batch_count, &bsize),
-        "Error: dx is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgtsvInterleavedBatch_bufferSizeExt(
             handle, algo, m, ddl, dd, ddu, dx, batch_count, nullptr),
         "Error: bsize is nullptr");
 

--- a/library/src/hcc_detail/hipsparse.cpp
+++ b/library/src/hcc_detail/hipsparse.cpp
@@ -14532,14 +14532,19 @@ hipsparseStatus_t hipsparseSgtsvInterleavedBatch_bufferSizeExt(hipsparseHandle_t
                                                                int               batchCount,
                                                                size_t*           pBufferSizeInBytes)
 {
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are
+    // never actually de-referenced. In order to work in the same way regardless of the backend
+    // that a user chooses, just pass in non-null dummy pointer.
+    const float* dummy = static_cast<const float*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(
         rocsparse_sgtsv_interleaved_batch_buffer_size((rocsparse_handle)handle,
                                                       (rocsparse_gtsv_interleaved_alg)algo,
                                                       m,
-                                                      dl,
-                                                      d,
-                                                      du,
-                                                      x,
+                                                      dummy,
+                                                      dummy,
+                                                      dummy,
+                                                      dummy,
                                                       batchCount,
                                                       batchCount,
                                                       pBufferSizeInBytes));
@@ -14555,14 +14560,19 @@ hipsparseStatus_t hipsparseDgtsvInterleavedBatch_bufferSizeExt(hipsparseHandle_t
                                                                int               batchCount,
                                                                size_t*           pBufferSizeInBytes)
 {
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are
+    // never actually de-referenced. In order to work in the same way regardless of the backend
+    // that a user chooses, just pass in non-null dummy pointer.
+    const double* dummy = static_cast<const double*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(
         rocsparse_dgtsv_interleaved_batch_buffer_size((rocsparse_handle)handle,
                                                       (rocsparse_gtsv_interleaved_alg)algo,
                                                       m,
-                                                      dl,
-                                                      d,
-                                                      du,
-                                                      x,
+                                                      dummy,
+                                                      dummy,
+                                                      dummy,
+                                                      dummy,
                                                       batchCount,
                                                       batchCount,
                                                       pBufferSizeInBytes));
@@ -14578,14 +14588,19 @@ hipsparseStatus_t hipsparseCgtsvInterleavedBatch_bufferSizeExt(hipsparseHandle_t
                                                                int               batchCount,
                                                                size_t*           pBufferSizeInBytes)
 {
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are
+    // never actually de-referenced. In order to work in the same way regardless of the backend
+    // that a user chooses, just pass in non-null dummy pointer.
+    const hipComplex* dummy = static_cast<const hipComplex*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(
         rocsparse_cgtsv_interleaved_batch_buffer_size((rocsparse_handle)handle,
                                                       (rocsparse_gtsv_interleaved_alg)algo,
                                                       m,
-                                                      (const rocsparse_float_complex*)dl,
-                                                      (const rocsparse_float_complex*)d,
-                                                      (const rocsparse_float_complex*)du,
-                                                      (const rocsparse_float_complex*)x,
+                                                      (const rocsparse_float_complex*)dummy,
+                                                      (const rocsparse_float_complex*)dummy,
+                                                      (const rocsparse_float_complex*)dummy,
+                                                      (const rocsparse_float_complex*)dummy,
                                                       batchCount,
                                                       batchCount,
                                                       pBufferSizeInBytes));
@@ -14601,14 +14616,19 @@ hipsparseStatus_t hipsparseZgtsvInterleavedBatch_bufferSizeExt(hipsparseHandle_t
                                                                int                     batchCount,
                                                                size_t* pBufferSizeInBytes)
 {
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are
+    // never actually de-referenced. In order to work in the same way regardless of the backend
+    // that a user chooses, just pass in non-null dummy pointer.
+    const hipDoubleComplex* dummy = static_cast<const hipDoubleComplex*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(
         rocsparse_zgtsv_interleaved_batch_buffer_size((rocsparse_handle)handle,
                                                       (rocsparse_gtsv_interleaved_alg)algo,
                                                       m,
-                                                      (const rocsparse_double_complex*)dl,
-                                                      (const rocsparse_double_complex*)d,
-                                                      (const rocsparse_double_complex*)du,
-                                                      (const rocsparse_double_complex*)x,
+                                                      (const rocsparse_double_complex*)dummy,
+                                                      (const rocsparse_double_complex*)dummy,
+                                                      (const rocsparse_double_complex*)dummy,
+                                                      (const rocsparse_double_complex*)dummy,
                                                       batchCount,
                                                       batchCount,
                                                       pBufferSizeInBytes));
@@ -14721,16 +14741,21 @@ hipsparseStatus_t hipsparseSgpsvInterleavedBatch_bufferSizeExt(hipsparseHandle_t
                                                                int               batchCount,
                                                                size_t*           pBufferSizeInBytes)
 {
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are
+    // never actually de-referenced. In order to work in the same way regardless of the backend
+    // that a user chooses, just pass in non-null dummy pointer.
+    const float* dummy = static_cast<const float*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(
         rocsparse_sgpsv_interleaved_batch_buffer_size((rocsparse_handle)handle,
                                                       (rocsparse_gpsv_interleaved_alg)algo,
                                                       m,
-                                                      ds,
-                                                      dl,
-                                                      d,
-                                                      du,
-                                                      dw,
-                                                      x,
+                                                      dummy,
+                                                      dummy,
+                                                      dummy,
+                                                      dummy,
+                                                      dummy,
+                                                      dummy,
                                                       batchCount,
                                                       batchCount,
                                                       pBufferSizeInBytes));
@@ -14748,16 +14773,21 @@ hipsparseStatus_t hipsparseDgpsvInterleavedBatch_bufferSizeExt(hipsparseHandle_t
                                                                int               batchCount,
                                                                size_t*           pBufferSizeInBytes)
 {
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are
+    // never actually de-referenced. In order to work in the same way regardless of the backend
+    // that a user chooses, just pass in non-null dummy pointer.
+    const double* dummy = static_cast<const double*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(
         rocsparse_dgpsv_interleaved_batch_buffer_size((rocsparse_handle)handle,
                                                       (rocsparse_gpsv_interleaved_alg)algo,
                                                       m,
-                                                      ds,
-                                                      dl,
-                                                      d,
-                                                      du,
-                                                      dw,
-                                                      x,
+                                                      dummy,
+                                                      dummy,
+                                                      dummy,
+                                                      dummy,
+                                                      dummy,
+                                                      dummy,
                                                       batchCount,
                                                       batchCount,
                                                       pBufferSizeInBytes));
@@ -14775,16 +14805,21 @@ hipsparseStatus_t hipsparseCgpsvInterleavedBatch_bufferSizeExt(hipsparseHandle_t
                                                                int               batchCount,
                                                                size_t*           pBufferSizeInBytes)
 {
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are
+    // never actually de-referenced. In order to work in the same way regardless of the backend
+    // that a user chooses, just pass in non-null dummy pointer.
+    const hipComplex* dummy = static_cast<const hipComplex*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(
         rocsparse_cgpsv_interleaved_batch_buffer_size((rocsparse_handle)handle,
                                                       (rocsparse_gpsv_interleaved_alg)algo,
                                                       m,
-                                                      (const rocsparse_float_complex*)ds,
-                                                      (const rocsparse_float_complex*)dl,
-                                                      (const rocsparse_float_complex*)d,
-                                                      (const rocsparse_float_complex*)du,
-                                                      (const rocsparse_float_complex*)dw,
-                                                      (const rocsparse_float_complex*)x,
+                                                      (const rocsparse_float_complex*)dummy,
+                                                      (const rocsparse_float_complex*)dummy,
+                                                      (const rocsparse_float_complex*)dummy,
+                                                      (const rocsparse_float_complex*)dummy,
+                                                      (const rocsparse_float_complex*)dummy,
+                                                      (const rocsparse_float_complex*)dummy,
                                                       batchCount,
                                                       batchCount,
                                                       pBufferSizeInBytes));
@@ -14802,16 +14837,21 @@ hipsparseStatus_t hipsparseZgpsvInterleavedBatch_bufferSizeExt(hipsparseHandle_t
                                                                int                     batchCount,
                                                                size_t* pBufferSizeInBytes)
 {
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are
+    // never actually de-referenced. In order to work in the same way regardless of the backend
+    // that a user chooses, just pass in non-null dummy pointer.
+    const hipDoubleComplex* dummy = static_cast<const hipDoubleComplex*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(
         rocsparse_zgpsv_interleaved_batch_buffer_size((rocsparse_handle)handle,
                                                       (rocsparse_gpsv_interleaved_alg)algo,
                                                       m,
-                                                      (const rocsparse_double_complex*)ds,
-                                                      (const rocsparse_double_complex*)dl,
-                                                      (const rocsparse_double_complex*)d,
-                                                      (const rocsparse_double_complex*)du,
-                                                      (const rocsparse_double_complex*)dw,
-                                                      (const rocsparse_double_complex*)x,
+                                                      (const rocsparse_double_complex*)dummy,
+                                                      (const rocsparse_double_complex*)dummy,
+                                                      (const rocsparse_double_complex*)dummy,
+                                                      (const rocsparse_double_complex*)dummy,
+                                                      (const rocsparse_double_complex*)dummy,
+                                                      (const rocsparse_double_complex*)dummy,
                                                       batchCount,
                                                       batchCount,
                                                       pBufferSizeInBytes));

--- a/library/src/hcc_detail/hipsparse.cpp
+++ b/library/src/hcc_detail/hipsparse.cpp
@@ -13721,8 +13721,13 @@ hipsparseStatus_t hipsparseSgtsv2StridedBatch_bufferSizeExt(hipsparseHandle_t ha
                                                             int               batchStride,
                                                             size_t*           pBufferSizeInBytes)
 {
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
+    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // that a user chooses, just pass in non-null dummy pointer.
+    const float* dummy = static_cast<const float*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(rocsparse_sgtsv_no_pivot_strided_batch_buffer_size(
-        (rocsparse_handle)handle, m, dl, d, du, x, batchCount, batchStride, pBufferSizeInBytes));
+        (rocsparse_handle)handle, m, dummy, dummy, dummy, dummy, batchCount, batchStride, pBufferSizeInBytes));
 }
 
 hipsparseStatus_t hipsparseDgtsv2StridedBatch_bufferSizeExt(hipsparseHandle_t handle,
@@ -13735,8 +13740,13 @@ hipsparseStatus_t hipsparseDgtsv2StridedBatch_bufferSizeExt(hipsparseHandle_t ha
                                                             int               batchStride,
                                                             size_t*           pBufferSizeInBytes)
 {
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
+    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // that a user chooses, just pass in non-null dummy pointer.
+    const double* dummy = static_cast<const double*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(rocsparse_dgtsv_no_pivot_strided_batch_buffer_size(
-        (rocsparse_handle)handle, m, dl, d, du, x, batchCount, batchStride, pBufferSizeInBytes));
+        (rocsparse_handle)handle, m, dummy, dummy, dummy, dummy, batchCount, batchStride, pBufferSizeInBytes));
 }
 
 hipsparseStatus_t hipsparseCgtsv2StridedBatch_bufferSizeExt(hipsparseHandle_t handle,
@@ -13749,13 +13759,18 @@ hipsparseStatus_t hipsparseCgtsv2StridedBatch_bufferSizeExt(hipsparseHandle_t ha
                                                             int               batchStride,
                                                             size_t*           pBufferSizeInBytes)
 {
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
+    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // that a user chooses, just pass in non-null dummy pointer.
+    const hipComplex* dummy = static_cast<const hipComplex*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(
         rocsparse_cgtsv_no_pivot_strided_batch_buffer_size((rocsparse_handle)handle,
                                                            m,
-                                                           (const rocsparse_float_complex*)dl,
-                                                           (const rocsparse_float_complex*)d,
-                                                           (const rocsparse_float_complex*)du,
-                                                           (const rocsparse_float_complex*)x,
+                                                           (const rocsparse_float_complex*)dummy,
+                                                           (const rocsparse_float_complex*)dummy,
+                                                           (const rocsparse_float_complex*)dummy,
+                                                           (const rocsparse_float_complex*)dummy,
                                                            batchCount,
                                                            batchStride,
                                                            pBufferSizeInBytes));
@@ -13771,13 +13786,18 @@ hipsparseStatus_t hipsparseZgtsv2StridedBatch_bufferSizeExt(hipsparseHandle_t   
                                                             int                     batchStride,
                                                             size_t* pBufferSizeInBytes)
 {
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
+    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // that a user chooses, just pass in non-null dummy pointer.
+    const hipDoubleComplex* dummy = static_cast<const hipDoubleComplex*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(
         rocsparse_zgtsv_no_pivot_strided_batch_buffer_size((rocsparse_handle)handle,
                                                            m,
-                                                           (const rocsparse_double_complex*)dl,
-                                                           (const rocsparse_double_complex*)d,
-                                                           (const rocsparse_double_complex*)du,
-                                                           (const rocsparse_double_complex*)x,
+                                                           (const rocsparse_double_complex*)dummy,
+                                                           (const rocsparse_double_complex*)dummy,
+                                                           (const rocsparse_double_complex*)dummy,
+                                                           (const rocsparse_double_complex*)dummy,
                                                            batchCount,
                                                            batchStride,
                                                            pBufferSizeInBytes));
@@ -13868,8 +13888,13 @@ hipsparseStatus_t hipsparseSgtsv2_bufferSizeExt(hipsparseHandle_t handle,
                                                 int               ldb,
                                                 size_t*           pBufferSizeInBytes)
 {
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
+    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // that a user chooses, just pass in non-null dummy pointer.
+    const float* dummy = static_cast<const float*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(rocsparse_sgtsv_buffer_size(
-        (rocsparse_handle)handle, m, n, dl, d, du, B, ldb, pBufferSizeInBytes));
+        (rocsparse_handle)handle, m, n, dummy, dummy, dummy, dummy, ldb, pBufferSizeInBytes));
 }
 
 hipsparseStatus_t hipsparseDgtsv2_bufferSizeExt(hipsparseHandle_t handle,
@@ -13882,8 +13907,13 @@ hipsparseStatus_t hipsparseDgtsv2_bufferSizeExt(hipsparseHandle_t handle,
                                                 int               ldb,
                                                 size_t*           pBufferSizeInBytes)
 {
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
+    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // that a user chooses, just pass in non-null dummy pointer.
+    const double* dummy = static_cast<const double*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(rocsparse_dgtsv_buffer_size(
-        (rocsparse_handle)handle, m, n, dl, d, du, B, ldb, pBufferSizeInBytes));
+        (rocsparse_handle)handle, m, n, dummy, dummy, dummy, dummy, ldb, pBufferSizeInBytes));
 }
 
 hipsparseStatus_t hipsparseCgtsv2_bufferSizeExt(hipsparseHandle_t handle,
@@ -13896,14 +13926,19 @@ hipsparseStatus_t hipsparseCgtsv2_bufferSizeExt(hipsparseHandle_t handle,
                                                 int               ldb,
                                                 size_t*           pBufferSizeInBytes)
 {
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
+    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // that a user chooses, just pass in non-null dummy pointer.
+    const hipComplex* dummy = static_cast<const hipComplex*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(
         rocsparse_cgtsv_buffer_size((rocsparse_handle)handle,
                                     m,
                                     n,
-                                    (const rocsparse_float_complex*)dl,
-                                    (const rocsparse_float_complex*)d,
-                                    (const rocsparse_float_complex*)du,
-                                    (const rocsparse_float_complex*)B,
+                                    (const rocsparse_float_complex*)dummy,
+                                    (const rocsparse_float_complex*)dummy,
+                                    (const rocsparse_float_complex*)dummy,
+                                    (const rocsparse_float_complex*)dummy,
                                     ldb,
                                     pBufferSizeInBytes));
 }
@@ -13918,14 +13953,19 @@ hipsparseStatus_t hipsparseZgtsv2_bufferSizeExt(hipsparseHandle_t       handle,
                                                 int                     ldb,
                                                 size_t*                 pBufferSizeInBytes)
 {
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
+    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // that a user chooses, just pass in non-null dummy pointer.
+    const hipDoubleComplex* dummy = static_cast<const hipDoubleComplex*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(
         rocsparse_zgtsv_buffer_size((rocsparse_handle)handle,
                                     m,
                                     n,
-                                    (const rocsparse_double_complex*)dl,
-                                    (const rocsparse_double_complex*)d,
-                                    (const rocsparse_double_complex*)du,
-                                    (const rocsparse_double_complex*)B,
+                                    (const rocsparse_double_complex*)dummy,
+                                    (const rocsparse_double_complex*)dummy,
+                                    (const rocsparse_double_complex*)dummy,
+                                    (const rocsparse_double_complex*)dummy,
                                     ldb,
                                     pBufferSizeInBytes));
 }
@@ -14013,8 +14053,13 @@ hipsparseStatus_t hipsparseSgtsv2_nopivot_bufferSizeExt(hipsparseHandle_t handle
                                                         int               ldb,
                                                         size_t*           pBufferSizeInBytes)
 {
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
+    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // that a user chooses, just pass in non-null dummy pointer.
+    const float* dummy = static_cast<const float*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(rocsparse_sgtsv_no_pivot_buffer_size(
-        (rocsparse_handle)handle, m, n, dl, d, du, B, ldb, pBufferSizeInBytes));
+        (rocsparse_handle)handle, m, n, dummy, dummy, dummy, dummy, ldb, pBufferSizeInBytes));
 }
 
 hipsparseStatus_t hipsparseDgtsv2_nopivot_bufferSizeExt(hipsparseHandle_t handle,
@@ -14027,8 +14072,13 @@ hipsparseStatus_t hipsparseDgtsv2_nopivot_bufferSizeExt(hipsparseHandle_t handle
                                                         int               ldb,
                                                         size_t*           pBufferSizeInBytes)
 {
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
+    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // that a user chooses, just pass in non-null dummy pointer.
+    const double* dummy = static_cast<const double*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(rocsparse_dgtsv_no_pivot_buffer_size(
-        (rocsparse_handle)handle, m, n, dl, d, du, B, ldb, pBufferSizeInBytes));
+        (rocsparse_handle)handle, m, n, dummy, dummy, dummy, dummy, ldb, pBufferSizeInBytes));
 }
 
 hipsparseStatus_t hipsparseCgtsv2_nopivot_bufferSizeExt(hipsparseHandle_t handle,
@@ -14041,14 +14091,19 @@ hipsparseStatus_t hipsparseCgtsv2_nopivot_bufferSizeExt(hipsparseHandle_t handle
                                                         int               ldb,
                                                         size_t*           pBufferSizeInBytes)
 {
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
+    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // that a user chooses, just pass in non-null dummy pointer.
+    const hipComplex* dummy = static_cast<const hipComplex*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(
         rocsparse_cgtsv_no_pivot_buffer_size((rocsparse_handle)handle,
                                              m,
                                              n,
-                                             (const rocsparse_float_complex*)dl,
-                                             (const rocsparse_float_complex*)d,
-                                             (const rocsparse_float_complex*)du,
-                                             (const rocsparse_float_complex*)B,
+                                             (const rocsparse_float_complex*)dummy,
+                                             (const rocsparse_float_complex*)dummy,
+                                             (const rocsparse_float_complex*)dummy,
+                                             (const rocsparse_float_complex*)dummy,
                                              ldb,
                                              pBufferSizeInBytes));
 }
@@ -14063,14 +14118,19 @@ hipsparseStatus_t hipsparseZgtsv2_nopivot_bufferSizeExt(hipsparseHandle_t       
                                                         int                     ldb,
                                                         size_t*                 pBufferSizeInBytes)
 {
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
+    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // that a user chooses, just pass in non-null dummy pointer.
+    const hipDoubleComplex* dummy = static_cast<const hipDoubleComplex*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(
         rocsparse_zgtsv_no_pivot_buffer_size((rocsparse_handle)handle,
                                              m,
                                              n,
-                                             (const rocsparse_double_complex*)dl,
-                                             (const rocsparse_double_complex*)d,
-                                             (const rocsparse_double_complex*)du,
-                                             (const rocsparse_double_complex*)B,
+                                             (const rocsparse_double_complex*)dummy,
+                                             (const rocsparse_double_complex*)dummy,
+                                             (const rocsparse_double_complex*)dummy,
+                                             (const rocsparse_double_complex*)dummy,
                                              ldb,
                                              pBufferSizeInBytes));
 }

--- a/library/src/hcc_detail/hipsparse.cpp
+++ b/library/src/hcc_detail/hipsparse.cpp
@@ -13721,13 +13721,21 @@ hipsparseStatus_t hipsparseSgtsv2StridedBatch_bufferSizeExt(hipsparseHandle_t ha
                                                             int               batchStride,
                                                             size_t*           pBufferSizeInBytes)
 {
-    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
-    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
-    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are
+    // never actually de-referenced. In order to work in the same way regardless of the backend
     // that a user chooses, just pass in non-null dummy pointer.
     const float* dummy = static_cast<const float*>((void*)0x4);
-    return rocSPARSEStatusToHIPStatus(rocsparse_sgtsv_no_pivot_strided_batch_buffer_size(
-        (rocsparse_handle)handle, m, dummy, dummy, dummy, dummy, batchCount, batchStride, pBufferSizeInBytes));
+    return rocSPARSEStatusToHIPStatus(
+        rocsparse_sgtsv_no_pivot_strided_batch_buffer_size((rocsparse_handle)handle,
+                                                           m,
+                                                           dummy,
+                                                           dummy,
+                                                           dummy,
+                                                           dummy,
+                                                           batchCount,
+                                                           batchStride,
+                                                           pBufferSizeInBytes));
 }
 
 hipsparseStatus_t hipsparseDgtsv2StridedBatch_bufferSizeExt(hipsparseHandle_t handle,
@@ -13740,13 +13748,21 @@ hipsparseStatus_t hipsparseDgtsv2StridedBatch_bufferSizeExt(hipsparseHandle_t ha
                                                             int               batchStride,
                                                             size_t*           pBufferSizeInBytes)
 {
-    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
-    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
-    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are
+    // never actually de-referenced. In order to work in the same way regardless of the backend
     // that a user chooses, just pass in non-null dummy pointer.
     const double* dummy = static_cast<const double*>((void*)0x4);
-    return rocSPARSEStatusToHIPStatus(rocsparse_dgtsv_no_pivot_strided_batch_buffer_size(
-        (rocsparse_handle)handle, m, dummy, dummy, dummy, dummy, batchCount, batchStride, pBufferSizeInBytes));
+    return rocSPARSEStatusToHIPStatus(
+        rocsparse_dgtsv_no_pivot_strided_batch_buffer_size((rocsparse_handle)handle,
+                                                           m,
+                                                           dummy,
+                                                           dummy,
+                                                           dummy,
+                                                           dummy,
+                                                           batchCount,
+                                                           batchStride,
+                                                           pBufferSizeInBytes));
 }
 
 hipsparseStatus_t hipsparseCgtsv2StridedBatch_bufferSizeExt(hipsparseHandle_t handle,
@@ -13759,9 +13775,9 @@ hipsparseStatus_t hipsparseCgtsv2StridedBatch_bufferSizeExt(hipsparseHandle_t ha
                                                             int               batchStride,
                                                             size_t*           pBufferSizeInBytes)
 {
-    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
-    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
-    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are
+    // never actually de-referenced. In order to work in the same way regardless of the backend
     // that a user chooses, just pass in non-null dummy pointer.
     const hipComplex* dummy = static_cast<const hipComplex*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(
@@ -13786,9 +13802,9 @@ hipsparseStatus_t hipsparseZgtsv2StridedBatch_bufferSizeExt(hipsparseHandle_t   
                                                             int                     batchStride,
                                                             size_t* pBufferSizeInBytes)
 {
-    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
-    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
-    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are
+    // never actually de-referenced. In order to work in the same way regardless of the backend
     // that a user chooses, just pass in non-null dummy pointer.
     const hipDoubleComplex* dummy = static_cast<const hipDoubleComplex*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(
@@ -13888,9 +13904,9 @@ hipsparseStatus_t hipsparseSgtsv2_bufferSizeExt(hipsparseHandle_t handle,
                                                 int               ldb,
                                                 size_t*           pBufferSizeInBytes)
 {
-    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
-    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
-    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are
+    // never actually de-referenced. In order to work in the same way regardless of the backend
     // that a user chooses, just pass in non-null dummy pointer.
     const float* dummy = static_cast<const float*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(rocsparse_sgtsv_buffer_size(
@@ -13907,9 +13923,9 @@ hipsparseStatus_t hipsparseDgtsv2_bufferSizeExt(hipsparseHandle_t handle,
                                                 int               ldb,
                                                 size_t*           pBufferSizeInBytes)
 {
-    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
-    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
-    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are
+    // never actually de-referenced. In order to work in the same way regardless of the backend
     // that a user chooses, just pass in non-null dummy pointer.
     const double* dummy = static_cast<const double*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(rocsparse_dgtsv_buffer_size(
@@ -13926,9 +13942,9 @@ hipsparseStatus_t hipsparseCgtsv2_bufferSizeExt(hipsparseHandle_t handle,
                                                 int               ldb,
                                                 size_t*           pBufferSizeInBytes)
 {
-    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
-    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
-    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are
+    // never actually de-referenced. In order to work in the same way regardless of the backend
     // that a user chooses, just pass in non-null dummy pointer.
     const hipComplex* dummy = static_cast<const hipComplex*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(
@@ -13953,9 +13969,9 @@ hipsparseStatus_t hipsparseZgtsv2_bufferSizeExt(hipsparseHandle_t       handle,
                                                 int                     ldb,
                                                 size_t*                 pBufferSizeInBytes)
 {
-    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
-    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
-    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are
+    // never actually de-referenced. In order to work in the same way regardless of the backend
     // that a user chooses, just pass in non-null dummy pointer.
     const hipDoubleComplex* dummy = static_cast<const hipDoubleComplex*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(
@@ -14053,9 +14069,9 @@ hipsparseStatus_t hipsparseSgtsv2_nopivot_bufferSizeExt(hipsparseHandle_t handle
                                                         int               ldb,
                                                         size_t*           pBufferSizeInBytes)
 {
-    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
-    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
-    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are
+    // never actually de-referenced. In order to work in the same way regardless of the backend
     // that a user chooses, just pass in non-null dummy pointer.
     const float* dummy = static_cast<const float*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(rocsparse_sgtsv_no_pivot_buffer_size(
@@ -14072,9 +14088,9 @@ hipsparseStatus_t hipsparseDgtsv2_nopivot_bufferSizeExt(hipsparseHandle_t handle
                                                         int               ldb,
                                                         size_t*           pBufferSizeInBytes)
 {
-    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
-    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
-    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are
+    // never actually de-referenced. In order to work in the same way regardless of the backend
     // that a user chooses, just pass in non-null dummy pointer.
     const double* dummy = static_cast<const double*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(rocsparse_dgtsv_no_pivot_buffer_size(
@@ -14091,9 +14107,9 @@ hipsparseStatus_t hipsparseCgtsv2_nopivot_bufferSizeExt(hipsparseHandle_t handle
                                                         int               ldb,
                                                         size_t*           pBufferSizeInBytes)
 {
-    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
-    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
-    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are
+    // never actually de-referenced. In order to work in the same way regardless of the backend
     // that a user chooses, just pass in non-null dummy pointer.
     const hipComplex* dummy = static_cast<const hipComplex*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(
@@ -14118,9 +14134,9 @@ hipsparseStatus_t hipsparseZgtsv2_nopivot_bufferSizeExt(hipsparseHandle_t       
                                                         int                     ldb,
                                                         size_t*                 pBufferSizeInBytes)
 {
-    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks 
-    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are 
-    // never actually de-referenced. In order to work in the same way regardless of the backend 
+    // cusparse allows passing nullptr's for dl, d, du, and B. On the other hand rocsparse checks
+    // if they are nullptr and returns invalid pointer if they are. In both cases the pointers are
+    // never actually de-referenced. In order to work in the same way regardless of the backend
     // that a user chooses, just pass in non-null dummy pointer.
     const hipDoubleComplex* dummy = static_cast<const hipDoubleComplex*>((void*)0x4);
     return rocSPARSEStatusToHIPStatus(


### PR DESCRIPTION
Allow passing nullptrs to hipsparse gtsv/gpsv buffer size routines to make them have behaviour consistent with cusparse.