### PR TITLE
Spmv fix

### DIFF
--- a/clients/include/testing_spmv_csr.hpp
+++ b/clients/include/testing_spmv_csr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ * Copyright (c) 2022 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -110,6 +110,28 @@ void testing_spmv_csr_bad_arg(void)
     verify_hipsparse_status_invalid_pointer(
         hipsparseSpMV_bufferSize(handle, transA, &alpha, A, x, &beta, y, dataType, alg, nullptr),
         "Error: bsize is nullptr");
+
+    // SpMV preprocess (optional)
+    verify_hipsparse_status_invalid_handle(
+        hipsparseSpMV_preprocess(nullptr, transA, &alpha, A, x, &beta, y, dataType, alg, dbuf));
+    verify_hipsparse_status_invalid_pointer(
+        hipsparseSpMV_preprocess(handle, transA, nullptr, A, x, &beta, y, dataType, alg, dbuf),
+        "Error: alpha is nullptr");
+    verify_hipsparse_status_invalid_pointer(
+        hipsparseSpMV_preprocess(handle, transA, &alpha, nullptr, x, &beta, y, dataType, alg, dbuf),
+        "Error: A is nullptr");
+    verify_hipsparse_status_invalid_pointer(
+        hipsparseSpMV_preprocess(handle, transA, &alpha, A, nullptr, &beta, y, dataType, alg, dbuf),
+        "Error: x is nullptr");
+    verify_hipsparse_status_invalid_pointer(
+        hipsparseSpMV_preprocess(handle, transA, &alpha, A, x, nullptr, y, dataType, alg, dbuf),
+        "Error: beta is nullptr");
+    verify_hipsparse_status_invalid_pointer(
+        hipsparseSpMV_preprocess(handle, transA, &alpha, A, x, &beta, nullptr, dataType, alg, dbuf),
+        "Error: y is nullptr");
+    verify_hipsparse_status_invalid_pointer(
+        hipsparseSpMV_preprocess(handle, transA, &alpha, A, x, &beta, nullptr, dataType, alg, nullptr),
+        "Error: dbuf is nullptr");
 
     // SpMV
     verify_hipsparse_status_invalid_handle(
@@ -255,6 +277,10 @@ hipsparseStatus_t testing_spmv_csr(void)
 
     void* buffer;
     CHECK_HIP_ERROR(hipMalloc(&buffer, bufferSize));
+
+    // Preprocess (optional)
+    CHECK_HIPSPARSE_ERROR(
+        hipsparseSpMV_preprocess(handle, transA, &h_alpha, A, x, &h_beta, y1, typeT, alg, buffer));
 
     // ROCSPARSE pointer mode host
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_HOST));

--- a/clients/include/testing_spmv_csr.hpp
+++ b/clients/include/testing_spmv_csr.hpp
@@ -130,7 +130,8 @@ void testing_spmv_csr_bad_arg(void)
         hipsparseSpMV_preprocess(handle, transA, &alpha, A, x, &beta, nullptr, dataType, alg, dbuf),
         "Error: y is nullptr");
     verify_hipsparse_status_invalid_pointer(
-        hipsparseSpMV_preprocess(handle, transA, &alpha, A, x, &beta, nullptr, dataType, alg, nullptr),
+        hipsparseSpMV_preprocess(
+            handle, transA, &alpha, A, x, &beta, nullptr, dataType, alg, nullptr),
         "Error: dbuf is nullptr");
 
     // SpMV

--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -9338,7 +9338,6 @@ hipsparseStatus_t hipsparseSpMV_preprocess(hipsparseHandle_t           handle,
                                            void*                       externalBuffer);
 #endif
 
-
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 10010)
 /* Description: Compute the sparse matrix multiplication with a dense matrix */
 HIPSPARSE_EXPORT

--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
-* Copyright (c) 2018-2021 Advanced Micro Devices, Inc.
+* Copyright (c) 2018-2022 Advanced Micro Devices, Inc.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -9308,8 +9308,8 @@ hipsparseStatus_t hipsparseSpVV(hipsparseHandle_t     handle,
                                 void*                 externalBuffer);
 #endif
 
-/* Description: Compute the sparse matrix multiplication with a dense vector */
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 10010)
+/* Description: Buffer size step of the sparse matrix multiplication with a dense vector */
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseSpMV_bufferSize(hipsparseHandle_t           handle,
                                            hipsparseOperation_t        opA,
@@ -9324,6 +9324,23 @@ hipsparseStatus_t hipsparseSpMV_bufferSize(hipsparseHandle_t           handle,
 #endif
 
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 10010)
+/* Description: Preprocess step of the sparse matrix multiplication with a dense vector (optional)*/
+HIPSPARSE_EXPORT
+hipsparseStatus_t hipsparseSpMV_preprocess(hipsparseHandle_t           handle,
+                                           hipsparseOperation_t        opA,
+                                           const void*                 alpha,
+                                           const hipsparseSpMatDescr_t matA,
+                                           const hipsparseDnVecDescr_t vecX,
+                                           const void*                 beta,
+                                           const hipsparseDnVecDescr_t vecY,
+                                           hipDataType                 computeType,
+                                           hipsparseSpMVAlg_t          alg,
+                                           void*                       externalBuffer);
+#endif
+
+
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 10010)
+/* Description: Compute the sparse matrix multiplication with a dense matrix */
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseSpMV(hipsparseHandle_t           handle,
                                 hipsparseOperation_t        opA,

--- a/library/src/hcc_detail/hipsparse.cpp
+++ b/library/src/hcc_detail/hipsparse.cpp
@@ -13381,8 +13381,6 @@ hipsparseStatus_t hipsparseSpMV_bufferSize(hipsparseHandle_t           handle,
         return rocSPARSEStatusToHIPStatus(rocsparse_status_invalid_pointer);
     }
 
-    std::cout << "hipsparseSpMV_bufferSize called" << std::endl;
-
     *bufferSize = 4;
     return HIPSPARSE_STATUS_SUCCESS;
 }
@@ -13398,7 +13396,6 @@ hipsparseStatus_t hipsparseSpMV_preprocess(hipsparseHandle_t           handle,
                                            hipsparseSpMVAlg_t          alg,
                                            void*                       externalBuffer)
 {
-    std::cout << "hipsparseSpMV_preprocess called" << std::endl;
     size_t bufferSize;
     return rocSPARSEStatusToHIPStatus(rocsparse_spmv((rocsparse_handle)handle,
                                                      hipOperationToHCCOperation(opA),

--- a/library/src/hcc_detail/hipsparse.cpp
+++ b/library/src/hcc_detail/hipsparse.cpp
@@ -13370,6 +13370,21 @@ hipsparseStatus_t hipsparseSpMV_bufferSize(hipsparseHandle_t           handle,
                                            hipsparseSpMVAlg_t          alg,
                                            size_t*                     bufferSize)
 {
+    if(handle == nullptr)
+    {
+        return rocSPARSEStatusToHIPStatus(rocsparse_status_invalid_handle);
+    }
+
+    if(matA == nullptr || 
+       vecX == nullptr || 
+       vecY == nullptr || 
+       alpha == nullptr || 
+       beta == nullptr || 
+       bufferSize == nullptr)
+    {
+        return rocSPARSEStatusToHIPStatus(rocsparse_status_invalid_pointer);
+    }
+
     *bufferSize = 0;
     return HIPSPARSE_STATUS_SUCCESS;
 }

--- a/library/src/hcc_detail/hipsparse.cpp
+++ b/library/src/hcc_detail/hipsparse.cpp
@@ -13385,18 +13385,19 @@ hipsparseStatus_t hipsparseSpMV(hipsparseHandle_t           handle,
                                 hipsparseSpMVAlg_t          alg,
                                 void*                       externalBuffer)
 {
-    size_t bufferSize;
-    hipsparseStatus_t status =  rocSPARSEStatusToHIPStatus(rocsparse_spmv((rocsparse_handle)handle,
-                                                                          hipOperationToHCCOperation(opA),
-                                                                          alpha,
-                                                                          (const rocsparse_spmat_descr)matA,
-                                                                          (const rocsparse_dnvec_descr)vecX,
-                                                                          beta,
-                                                                          (const rocsparse_dnvec_descr)vecY,
-                                                                          hipDataTypeToHCCDataType(computeType),
-                                                                          hipSpMVAlgToHCCSpMVAlg(alg),
-                                                                          &bufferSize,
-                                                                          nullptr));
+    size_t            bufferSize;
+    hipsparseStatus_t status
+        = rocSPARSEStatusToHIPStatus(rocsparse_spmv((rocsparse_handle)handle,
+                                                    hipOperationToHCCOperation(opA),
+                                                    alpha,
+                                                    (const rocsparse_spmat_descr)matA,
+                                                    (const rocsparse_dnvec_descr)vecX,
+                                                    beta,
+                                                    (const rocsparse_dnvec_descr)vecY,
+                                                    hipDataTypeToHCCDataType(computeType),
+                                                    hipSpMVAlgToHCCSpMVAlg(alg),
+                                                    &bufferSize,
+                                                    nullptr));
 
     if(status != HIPSPARSE_STATUS_SUCCESS)
     {
@@ -13407,16 +13408,16 @@ hipsparseStatus_t hipsparseSpMV(hipsparseHandle_t           handle,
     RETURN_IF_HIP_ERROR(hipMalloc(&buffer, bufferSize));
 
     status = rocSPARSEStatusToHIPStatus(rocsparse_spmv((rocsparse_handle)handle,
-                                                     hipOperationToHCCOperation(opA),
-                                                     alpha,
-                                                     (const rocsparse_spmat_descr)matA,
-                                                     (const rocsparse_dnvec_descr)vecX,
-                                                     beta,
-                                                     (const rocsparse_dnvec_descr)vecY,
-                                                     hipDataTypeToHCCDataType(computeType),
-                                                     hipSpMVAlgToHCCSpMVAlg(alg),
-                                                     &bufferSize,
-                                                     buffer));
+                                                       hipOperationToHCCOperation(opA),
+                                                       alpha,
+                                                       (const rocsparse_spmat_descr)matA,
+                                                       (const rocsparse_dnvec_descr)vecX,
+                                                       beta,
+                                                       (const rocsparse_dnvec_descr)vecY,
+                                                       hipDataTypeToHCCDataType(computeType),
+                                                       hipSpMVAlgToHCCSpMVAlg(alg),
+                                                       &bufferSize,
+                                                       buffer));
 
     RETURN_IF_HIP_ERROR(hipFree(&buffer));
 

--- a/library/src/hcc_detail/hipsparse.cpp
+++ b/library/src/hcc_detail/hipsparse.cpp
@@ -13375,12 +13375,8 @@ hipsparseStatus_t hipsparseSpMV_bufferSize(hipsparseHandle_t           handle,
         return rocSPARSEStatusToHIPStatus(rocsparse_status_invalid_handle);
     }
 
-    if(matA == nullptr || 
-       vecX == nullptr || 
-       vecY == nullptr || 
-       alpha == nullptr || 
-       beta == nullptr || 
-       bufferSize == nullptr)
+    if(matA == nullptr || vecX == nullptr || vecY == nullptr || alpha == nullptr || beta == nullptr
+       || bufferSize == nullptr)
     {
         return rocSPARSEStatusToHIPStatus(rocsparse_status_invalid_pointer);
     }

--- a/library/src/hcc_detail/hipsparse.cpp
+++ b/library/src/hcc_detail/hipsparse.cpp
@@ -13401,16 +13401,16 @@ hipsparseStatus_t hipsparseSpMV_preprocess(hipsparseHandle_t           handle,
     std::cout << "hipsparseSpMV_preprocess called" << std::endl;
     size_t bufferSize;
     return rocSPARSEStatusToHIPStatus(rocsparse_spmv((rocsparse_handle)handle,
-                                                    hipOperationToHCCOperation(opA),
-                                                    alpha,
-                                                    (const rocsparse_spmat_descr)matA,
-                                                    (const rocsparse_dnvec_descr)vecX,
-                                                    beta,
-                                                    (const rocsparse_dnvec_descr)vecY,
-                                                    hipDataTypeToHCCDataType(computeType),
-                                                    hipSpMVAlgToHCCSpMVAlg(alg),
-                                                    &bufferSize,
-                                                    nullptr)); 
+                                                     hipOperationToHCCOperation(opA),
+                                                     alpha,
+                                                     (const rocsparse_spmat_descr)matA,
+                                                     (const rocsparse_dnvec_descr)vecX,
+                                                     beta,
+                                                     (const rocsparse_dnvec_descr)vecY,
+                                                     hipDataTypeToHCCDataType(computeType),
+                                                     hipSpMVAlgToHCCSpMVAlg(alg),
+                                                     &bufferSize,
+                                                     nullptr));
 }
 
 hipsparseStatus_t hipsparseSpMV(hipsparseHandle_t           handle,

--- a/library/src/hcc_detail/hipsparse.cpp
+++ b/library/src/hcc_detail/hipsparse.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
-* Copyright (c) 2018-2021 Advanced Micro Devices, Inc.
+* Copyright (c) 2018-2022 Advanced Micro Devices, Inc.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -13381,8 +13381,36 @@ hipsparseStatus_t hipsparseSpMV_bufferSize(hipsparseHandle_t           handle,
         return rocSPARSEStatusToHIPStatus(rocsparse_status_invalid_pointer);
     }
 
+    std::cout << "hipsparseSpMV_bufferSize called" << std::endl;
+
     *bufferSize = 4;
     return HIPSPARSE_STATUS_SUCCESS;
+}
+
+hipsparseStatus_t hipsparseSpMV_preprocess(hipsparseHandle_t           handle,
+                                           hipsparseOperation_t        opA,
+                                           const void*                 alpha,
+                                           const hipsparseSpMatDescr_t matA,
+                                           const hipsparseDnVecDescr_t vecX,
+                                           const void*                 beta,
+                                           const hipsparseDnVecDescr_t vecY,
+                                           hipDataType                 computeType,
+                                           hipsparseSpMVAlg_t          alg,
+                                           void*                       externalBuffer)
+{
+    std::cout << "hipsparseSpMV_preprocess called" << std::endl;
+    size_t bufferSize;
+    return rocSPARSEStatusToHIPStatus(rocsparse_spmv((rocsparse_handle)handle,
+                                                    hipOperationToHCCOperation(opA),
+                                                    alpha,
+                                                    (const rocsparse_spmat_descr)matA,
+                                                    (const rocsparse_dnvec_descr)vecX,
+                                                    beta,
+                                                    (const rocsparse_dnvec_descr)vecY,
+                                                    hipDataTypeToHCCDataType(computeType),
+                                                    hipSpMVAlgToHCCSpMVAlg(alg),
+                                                    &bufferSize,
+                                                    nullptr)); 
 }
 
 hipsparseStatus_t hipsparseSpMV(hipsparseHandle_t           handle,
@@ -13396,43 +13424,18 @@ hipsparseStatus_t hipsparseSpMV(hipsparseHandle_t           handle,
                                 hipsparseSpMVAlg_t          alg,
                                 void*                       externalBuffer)
 {
-    size_t            bufferSize;
-    hipsparseStatus_t status
-        = rocSPARSEStatusToHIPStatus(rocsparse_spmv((rocsparse_handle)handle,
-                                                    hipOperationToHCCOperation(opA),
-                                                    alpha,
-                                                    (const rocsparse_spmat_descr)matA,
-                                                    (const rocsparse_dnvec_descr)vecX,
-                                                    beta,
-                                                    (const rocsparse_dnvec_descr)vecY,
-                                                    hipDataTypeToHCCDataType(computeType),
-                                                    hipSpMVAlgToHCCSpMVAlg(alg),
-                                                    &bufferSize,
-                                                    nullptr));
-
-    if(status != HIPSPARSE_STATUS_SUCCESS)
-    {
-        return status;
-    }
-
-    void* buffer;
-    RETURN_IF_HIP_ERROR(hipMalloc(&buffer, bufferSize));
-
-    status = rocSPARSEStatusToHIPStatus(rocsparse_spmv((rocsparse_handle)handle,
-                                                       hipOperationToHCCOperation(opA),
-                                                       alpha,
-                                                       (const rocsparse_spmat_descr)matA,
-                                                       (const rocsparse_dnvec_descr)vecX,
-                                                       beta,
-                                                       (const rocsparse_dnvec_descr)vecY,
-                                                       hipDataTypeToHCCDataType(computeType),
-                                                       hipSpMVAlgToHCCSpMVAlg(alg),
-                                                       &bufferSize,
-                                                       buffer));
-
-    RETURN_IF_HIP_ERROR(hipFree(buffer));
-
-    return status;
+    size_t bufferSize;
+    return rocSPARSEStatusToHIPStatus(rocsparse_spmv((rocsparse_handle)handle,
+                                                     hipOperationToHCCOperation(opA),
+                                                     alpha,
+                                                     (const rocsparse_spmat_descr)matA,
+                                                     (const rocsparse_dnvec_descr)vecX,
+                                                     beta,
+                                                     (const rocsparse_dnvec_descr)vecY,
+                                                     hipDataTypeToHCCDataType(computeType),
+                                                     hipSpMVAlgToHCCSpMVAlg(alg),
+                                                     &bufferSize,
+                                                     externalBuffer));
 }
 
 hipsparseStatus_t hipsparseSpMM_bufferSize(hipsparseHandle_t           handle,
@@ -13741,7 +13744,6 @@ hipsparseStatus_t hipsparseSpGEMM_copy(hipsparseHandle_t      handle,
     return status;
 }
 
-HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseSpGEMMreuse_workEstimation(hipsparseHandle_t      handle,
                                                       hipsparseOperation_t   opA,
                                                       hipsparseOperation_t   opB,
@@ -13777,7 +13779,6 @@ hipsparseStatus_t hipsparseSpGEMMreuse_workEstimation(hipsparseHandle_t      han
     return HIPSPARSE_STATUS_SUCCESS;
 }
 
-HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseSpGEMMreuse_nnz(hipsparseHandle_t      handle,
                                            hipsparseOperation_t   opA,
                                            hipsparseOperation_t   opB,
@@ -13886,7 +13887,6 @@ hipsparseStatus_t hipsparseSpGEMMreuse_nnz(hipsparseHandle_t      handle,
     return HIPSPARSE_STATUS_SUCCESS;
 }
 
-HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseSpGEMMreuse_compute(hipsparseHandle_t      handle,
                                                hipsparseOperation_t   opA,
                                                hipsparseOperation_t   opB,
@@ -13925,7 +13925,6 @@ hipsparseStatus_t hipsparseSpGEMMreuse_compute(hipsparseHandle_t      handle,
                                                        spgemmDescr->externalBuffer));
 }
 
-HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseSpGEMMreuse_copy(hipsparseHandle_t      handle,
                                             hipsparseOperation_t   opA,
                                             hipsparseOperation_t   opB,
@@ -15231,7 +15230,6 @@ hipsparseStatus_t hipsparseZgpsvInterleavedBatch(hipsparseHandle_t handle,
                                           pBuffer));
 }
 
-HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseScsrcolor(hipsparseHandle_t         handle,
                                      int                       m,
                                      int                       nnz,
@@ -15259,7 +15257,6 @@ hipsparseStatus_t hipsparseScsrcolor(hipsparseHandle_t         handle,
                                                           (rocsparse_mat_info)info));
 }
 
-HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseDcsrcolor(hipsparseHandle_t         handle,
                                      int                       m,
                                      int                       nnz,
@@ -15287,7 +15284,6 @@ hipsparseStatus_t hipsparseDcsrcolor(hipsparseHandle_t         handle,
                                                           (rocsparse_mat_info)info));
 }
 
-HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseCcsrcolor(hipsparseHandle_t         handle,
                                      int                       m,
                                      int                       nnz,
@@ -15315,7 +15311,6 @@ hipsparseStatus_t hipsparseCcsrcolor(hipsparseHandle_t         handle,
                                                           (rocsparse_mat_info)info));
 }
 
-HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseZcsrcolor(hipsparseHandle_t         handle,
                                      int                       m,
                                      int                       nnz,

--- a/library/src/hcc_detail/hipsparse.cpp
+++ b/library/src/hcc_detail/hipsparse.cpp
@@ -13381,7 +13381,7 @@ hipsparseStatus_t hipsparseSpMV_bufferSize(hipsparseHandle_t           handle,
         return rocSPARSEStatusToHIPStatus(rocsparse_status_invalid_pointer);
     }
 
-    *bufferSize = 0;
+    *bufferSize = 4;
     return HIPSPARSE_STATUS_SUCCESS;
 }
 
@@ -13430,7 +13430,7 @@ hipsparseStatus_t hipsparseSpMV(hipsparseHandle_t           handle,
                                                        &bufferSize,
                                                        buffer));
 
-    RETURN_IF_HIP_ERROR(hipFree(&buffer));
+    RETURN_IF_HIP_ERROR(hipFree(buffer));
 
     return status;
 }

--- a/library/src/nvcc_detail/hipsparse.cpp
+++ b/library/src/nvcc_detail/hipsparse.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
-* Copyright (c) 2018-2021 Advanced Micro Devices, Inc.
+* Copyright (c) 2018-2022 Advanced Micro Devices, Inc.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -11056,8 +11056,7 @@ hipsparseStatus_t hipsparseDnMatSetValues(hipsparseDnMatDescr_t dnMatDescr, void
 }
 #endif
 
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
-HIPSPARSE_EXPORT
+#if(CUDART_VERSION >= 11031)
 hipsparseStatus_t hipsparseSpMatGetAttribute(hipsparseSpMatDescr_t     spMatDescr,
                                              hipsparseSpMatAttribute_t attribute,
                                              void*                     data,
@@ -11068,8 +11067,7 @@ hipsparseStatus_t hipsparseSpMatGetAttribute(hipsparseSpMatDescr_t     spMatDesc
 }
 #endif
 
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
-HIPSPARSE_EXPORT
+#if(CUDART_VERSION >= 11031)
 hipsparseStatus_t hipsparseSpMatSetAttribute(hipsparseSpMatDescr_t     spMatDescr,
                                              hipsparseSpMatAttribute_t attribute,
                                              const void*               data,
@@ -11274,6 +11272,33 @@ hipsparseStatus_t hipsparseSpMV_bufferSize(hipsparseHandle_t           handle,
                                 hipDataTypeToCudaDataType(computeType),
                                 hipSpMVAlgToCudaSpMVAlg(alg),
                                 bufferSize));
+}
+#endif
+
+#if(CUDART_VERSION >= 10010)
+hipsparseStatus_t hipsparseSpMV_preprocess(hipsparseHandle_t           handle,
+                                           hipsparseOperation_t        opA,
+                                           const void*                 alpha,
+                                           const hipsparseSpMatDescr_t matA,
+                                           const hipsparseDnVecDescr_t vecX,
+                                           const void*                 beta,
+                                           const hipsparseDnVecDescr_t vecY,
+                                           hipDataType                 computeType,
+                                           hipsparseSpMVAlg_t          alg,
+                                           void*                       externalBuffer)
+{
+    if(handle == nullptr)
+    {
+        return rocSPARSEStatusToHIPStatus(rocsparse_status_invalid_handle);
+    }
+
+    if(matA == nullptr || vecX == nullptr || vecY == nullptr || alpha == nullptr || beta == nullptr
+       || externalBuffer == nullptr)
+    {
+        return rocSPARSEStatusToHIPStatus(rocsparse_status_invalid_pointer);
+    }
+
+    return HIPSPARSE_STATUS_SUCCESS;
 }
 #endif
 
@@ -11489,8 +11514,7 @@ hipsparseStatus_t hipsparseSpGEMM_copy(hipsparseHandle_t      handle,
 }
 #endif
 
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
-HIPSPARSE_EXPORT
+#if(CUDART_VERSION >= 11031)
 hipsparseStatus_t hipsparseSpGEMMreuse_workEstimation(hipsparseHandle_t      handle,
                                                       hipsparseOperation_t   opA,
                                                       hipsparseOperation_t   opB,
@@ -11516,8 +11540,7 @@ hipsparseStatus_t hipsparseSpGEMMreuse_workEstimation(hipsparseHandle_t      han
 }
 #endif
 
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
-HIPSPARSE_EXPORT
+#if(CUDART_VERSION >= 11031)
 hipsparseStatus_t hipsparseSpGEMMreuse_nnz(hipsparseHandle_t      handle,
                                            hipsparseOperation_t   opA,
                                            hipsparseOperation_t   opB,
@@ -11551,8 +11574,7 @@ hipsparseStatus_t hipsparseSpGEMMreuse_nnz(hipsparseHandle_t      handle,
 
 #endif
 
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
-HIPSPARSE_EXPORT
+#if(CUDART_VERSION >= 11031)
 hipsparseStatus_t hipsparseSpGEMMreuse_compute(hipsparseHandle_t      handle,
                                                hipsparseOperation_t   opA,
                                                hipsparseOperation_t   opB,
@@ -11580,8 +11602,7 @@ hipsparseStatus_t hipsparseSpGEMMreuse_compute(hipsparseHandle_t      handle,
 }
 #endif
 
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
-HIPSPARSE_EXPORT
+#if(CUDART_VERSION >= 11031)
 hipsparseStatus_t hipsparseSpGEMMreuse_copy(hipsparseHandle_t      handle,
                                             hipsparseOperation_t   opA,
                                             hipsparseOperation_t   opB,
@@ -12583,7 +12604,6 @@ hipsparseStatus_t hipsparseZgpsvInterleavedBatch(hipsparseHandle_t handle,
         (cusparseHandle_t)handle, algo, m, ds, dl, d, du, dw, x, batchCount, pBuffer));
 }
 
-HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseScsrcolor(hipsparseHandle_t         handle,
                                      int                       m,
                                      int                       nnz,
@@ -12611,7 +12631,6 @@ hipsparseStatus_t hipsparseScsrcolor(hipsparseHandle_t         handle,
                                                           (cusparseColorInfo_t)info));
 }
 
-HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseDcsrcolor(hipsparseHandle_t         handle,
                                      int                       m,
                                      int                       nnz,
@@ -12639,7 +12658,6 @@ hipsparseStatus_t hipsparseDcsrcolor(hipsparseHandle_t         handle,
                                                           (cusparseColorInfo_t)info));
 }
 
-HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseCcsrcolor(hipsparseHandle_t         handle,
                                      int                       m,
                                      int                       nnz,
@@ -12667,7 +12685,6 @@ hipsparseStatus_t hipsparseCcsrcolor(hipsparseHandle_t         handle,
                                                           (cusparseColorInfo_t)info));
 }
 
-HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseZcsrcolor(hipsparseHandle_t         handle,
                                      int                       m,
                                      int                       nnz,

--- a/library/src/nvcc_detail/hipsparse.cpp
+++ b/library/src/nvcc_detail/hipsparse.cpp
@@ -11289,13 +11289,13 @@ hipsparseStatus_t hipsparseSpMV_preprocess(hipsparseHandle_t           handle,
 {
     if(handle == nullptr)
     {
-        return rocSPARSEStatusToHIPStatus(rocsparse_status_invalid_handle);
+        return HIPSPARSE_STATUS_INVALID_VALUE;
     }
 
     if(matA == nullptr || vecX == nullptr || vecY == nullptr || alpha == nullptr || beta == nullptr
        || externalBuffer == nullptr)
     {
-        return rocSPARSEStatusToHIPStatus(rocsparse_status_invalid_pointer);
+        return HIPSPARSE_STATUS_INVALID_VALUE;
     }
 
     return HIPSPARSE_STATUS_SUCCESS;


### PR DESCRIPTION
Ensure behaviour in hipsparse is consistent regardless of which backend is used.