### PR TITLE
Set fortran samples to depend on hipsparse_fortran

### DIFF
--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -28,6 +28,10 @@ function(add_hipsparse_example EXAMPLE_SOURCE)
   get_filename_component(EXAMPLE_TARGET ${EXAMPLE_SOURCE} NAME_WE)
   add_executable(${EXAMPLE_TARGET} ${EXAMPLE_SOURCE} ${HIPSPARSE_CLIENTS_COMMON})
 
+  if("${EXAMPLE_TARGET}" MATCHES ".*fortran.*")
+    add_dependencies(${EXAMPLE_TARGET} hipsparse_fortran)
+  endif()
+
   # Include common client headers
   target_include_directories(${EXAMPLE_TARGET} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 


### PR DESCRIPTION
Previously the hipSPARSE samples used hipsparse_fortran, but didn't declare a CMake dependency on it. If ccache was enabled, the C library would build faster than the fortran module, and the fortran samples would start building. Declaring a CMake dependency should prevent this issue.