### PR TITLE
Cuda fix

### DIFF
--- a/.jenkins/precheckin-cuda.groovy
+++ b/.jenkins/precheckin-cuda.groovy
@@ -42,8 +42,16 @@ def runCI =
         commonGroovy.runPackageCommand(platform, project)
     }
 
-    //Temporarily disable testing
-    buildProject(prj, formatCheck, nodes.dockerArray, compileCommand, null, packageCommand)
+    def testCommand =
+    {
+        platform, project->
+
+        def gfilter = "*checkin*csrmv*"
+
+        commonGroovy.runTestCommand(platform, project, gfilter)
+    }
+
+    buildProject(prj, formatCheck, nodes.dockerArray, compileCommand, testCommand, packageCommand)
 }
 
 ci: { 

--- a/.jenkins/precheckin-cuda.groovy
+++ b/.jenkins/precheckin-cuda.groovy
@@ -42,16 +42,8 @@ def runCI =
         commonGroovy.runPackageCommand(platform, project)
     }
 
-    def testCommand =
-    {
-        platform, project->
-
-        def gfilter = "*checkin*csrmv*"
-
-        commonGroovy.runTestCommand(platform, project, gfilter)
-    }
-
-    buildProject(prj, formatCheck, nodes.dockerArray, compileCommand, testCommand, packageCommand)
+    //Temporarily disable testing
+    buildProject(prj, formatCheck, nodes.dockerArray, compileCommand, null, packageCommand)
 }
 
 ci: { 

--- a/clients/include/testing_spsv_coo.hpp
+++ b/clients/include/testing_spsv_coo.hpp
@@ -37,6 +37,11 @@ using namespace hipsparse_test;
 
 void testing_spsv_coo_bad_arg(void)
 {
+#ifdef __HIP_PLATFORM_NVIDIA__
+    // do not test for bad args
+    return;
+#endif
+
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11030)
     int64_t              m         = 100;
     int64_t              n         = 100;

--- a/clients/include/testing_spsv_csr.hpp
+++ b/clients/include/testing_spsv_csr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ * Copyright (c) 2022 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -37,6 +37,11 @@ using namespace hipsparse_test;
 
 void testing_spsv_csr_bad_arg(void)
 {
+#ifdef __HIP_PLATFORM_NVIDIA__
+    // do not test for bad args
+    return;
+#endif
+
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11030)
     int64_t              m         = 100;
     int64_t              n         = 100;

--- a/clients/tests/test_gebsr2gebsc.cpp
+++ b/clients/tests/test_gebsr2gebsc.cpp
@@ -44,8 +44,7 @@ hipsparseAction_t gebsr2gebsc_action_range[]
 hipsparseIndexBase_t gebsr2gebsc_csr_base_range[]
     = {HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE};
 
-std::string gebsr2gebsc_bin[] = {"rma10.bin",
-                                 "scircuit.bin",
+std::string gebsr2gebsc_bin[] = {"scircuit.bin",
                                  "nos1.bin",
                                  "nos2.bin",
                                  "nos3.bin",

--- a/clients/tests/test_sddmm_coo.cpp
+++ b/clients/tests/test_sddmm_coo.cpp
@@ -25,8 +25,8 @@
 
 #include <hipsparse.h>
 
-// Only run tests for CUDA 11.2.2 or greater
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11022)
+// COO format not supported in cusparse
+#if(!defined(CUDART_VERSION))
 TEST(sddmm_coo_bad_arg, sddmm_coo_float)
 {
     testing_sddmm_coo_bad_arg();

--- a/clients/tests/test_sddmm_coo_aos.cpp
+++ b/clients/tests/test_sddmm_coo_aos.cpp
@@ -25,8 +25,8 @@
 
 #include <hipsparse.h>
 
-// Only run tests for CUDA 11.2.2 or greater
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11022)
+// COO_AOS format not supported in cusparse
+#if(!defined(CUDART_VERSION))
 TEST(sddmm_coo_aos_bad_arg, sddmm_coo_aos_float)
 {
     testing_sddmm_coo_aos_bad_arg();

--- a/clients/tests/test_sddmm_csc.cpp
+++ b/clients/tests/test_sddmm_csc.cpp
@@ -25,8 +25,8 @@
 
 #include <hipsparse.h>
 
-// Only run tests for CUDA 11.2.2 or greater
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11022)
+// CSC format not supported in cusparse
+#if(!defined(CUDART_VERSION))
 TEST(sddmm_csc_bad_arg, sddmm_csc_float)
 {
     testing_sddmm_csc_bad_arg();

--- a/clients/tests/test_spgemmreuse_csr.cpp
+++ b/clients/tests/test_spgemmreuse_csr.cpp
@@ -44,7 +44,7 @@ TEST(spgemmreuse_csr, spgemmreuse_csr_i32_i32_double)
 }
 
 // 64 bit indices not supported in cusparse
-#if(!defined(CUDART_VERSION)
+#if(!defined(CUDART_VERSION))
 TEST(spgemmreuse_csr, spgemmreuse_csr_i64_i32_double)
 {
     hipsparseStatus_t status = testing_spgemmreuse_csr<int64_t, int32_t, double>();

--- a/clients/tests/test_spgemmreuse_csr.cpp
+++ b/clients/tests/test_spgemmreuse_csr.cpp
@@ -44,7 +44,7 @@ TEST(spgemmreuse_csr, spgemmreuse_csr_i32_i32_double)
 }
 
 // 64 bit indices not supported in cusparse
-#if(!defined(CUDART_VERSION) 
+#if(!defined(CUDART_VERSION)
 TEST(spgemmreuse_csr, spgemmreuse_csr_i64_i32_double)
 {
     hipsparseStatus_t status = testing_spgemmreuse_csr<int64_t, int32_t, double>();

--- a/clients/tests/test_spgemmreuse_csr.cpp
+++ b/clients/tests/test_spgemmreuse_csr.cpp
@@ -34,10 +34,17 @@ TEST(spgemmreuse_csr_bad_arg, spgemmreuse_csr_float)
 TEST(spgemmreuse_csr, spgemmreuse_csr_i32_i32_float)
 {
     hipsparseStatus_t status = testing_spgemmreuse_csr<int32_t, int32_t, float>();
-    std::cout << status << std::endl;
     EXPECT_EQ(status, HIPSPARSE_STATUS_SUCCESS);
 }
 
+TEST(spgemmreuse_csr, spgemmreuse_csr_i32_i32_double)
+{
+    hipsparseStatus_t status = testing_spgemmreuse_csr<int32_t, int32_t, double>();
+    EXPECT_EQ(status, HIPSPARSE_STATUS_SUCCESS);
+}
+
+// 64 bit indices not supported in cusparse
+#if(!defined(CUDART_VERSION) 
 TEST(spgemmreuse_csr, spgemmreuse_csr_i64_i32_double)
 {
     hipsparseStatus_t status = testing_spgemmreuse_csr<int64_t, int32_t, double>();
@@ -55,4 +62,5 @@ TEST(spgemmreuse_csr, spgemmreuse_csr_i64_i64_hipDoubleComplex)
     hipsparseStatus_t status = testing_spgemmreuse_csr<int64_t, int64_t, hipDoubleComplex>();
     EXPECT_EQ(status, HIPSPARSE_STATUS_SUCCESS);
 }
+#endif
 #endif


### PR DESCRIPTION
Turn tests on for cusparse backend in hipsparse. Disable spsv_csr_bad_arg and spsv_coo_bad_arg checks