### PR TITLE
Turn on tests when using cusparse backend

### DIFF
--- a/.jenkins/precheckin-cuda.groovy
+++ b/.jenkins/precheckin-cuda.groovy
@@ -42,8 +42,16 @@ def runCI =
         commonGroovy.runPackageCommand(platform, project)
     }
 
-    //Temporarily disable testing
-    buildProject(prj, formatCheck, nodes.dockerArray, compileCommand, null, packageCommand)
+    def testCommand =
+    {
+        platform, project->
+
+        def gfilter = "*checkin*csrmv*"
+
+        commonGroovy.runTestCommand(platform, project, gfilter)
+    }
+
+    buildProject(prj, formatCheck, nodes.dockerArray, compileCommand, testCommand, packageCommand)
 }
 
 ci: { 

--- a/clients/include/testing_spsm_coo.hpp
+++ b/clients/include/testing_spsm_coo.hpp
@@ -37,6 +37,11 @@ using namespace hipsparse_test;
 
 void testing_spsm_coo_bad_arg(void)
 {
+#ifdef __HIP_PLATFORM_NVIDIA__
+    // do not test for bad args
+    return;
+#endif
+
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
     int64_t              m         = 100;
     int64_t              n         = 100;

--- a/clients/include/testing_spsm_csr.hpp
+++ b/clients/include/testing_spsm_csr.hpp
@@ -37,6 +37,11 @@ using namespace hipsparse_test;
 
 void testing_spsm_csr_bad_arg(void)
 {
+#ifdef __HIP_PLATFORM_NVIDIA__
+    // do not test for bad args
+    return;
+#endif
+
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
     int64_t              m         = 100;
     int64_t              n         = 100;

--- a/clients/include/testing_spsv_coo.hpp
+++ b/clients/include/testing_spsv_coo.hpp
@@ -38,7 +38,7 @@ using namespace hipsparse_test;
 void testing_spsv_coo_bad_arg(void)
 {
 #ifdef __HIP_PLATFORM_NVIDIA__
-// do not test for bad args
+    // do not test for bad args
     return;
 #endif
 

--- a/clients/include/testing_spsv_coo.hpp
+++ b/clients/include/testing_spsv_coo.hpp
@@ -37,6 +37,11 @@ using namespace hipsparse_test;
 
 void testing_spsv_coo_bad_arg(void)
 {
+#ifdef __HIP_PLATFORM_NVIDIA__
+// do not test for bad args
+    return;
+#endif
+
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11030)
     int64_t              m         = 100;
     int64_t              n         = 100;

--- a/clients/include/testing_spsv_csr.hpp
+++ b/clients/include/testing_spsv_csr.hpp
@@ -37,6 +37,11 @@ using namespace hipsparse_test;
 
 void testing_spsv_csr_bad_arg(void)
 {
+#ifdef __HIP_PLATFORM_NVIDIA__
+// do not test for bad args
+    return;
+#endif
+
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11030)
     int64_t              m         = 100;
     int64_t              n         = 100;

--- a/clients/include/testing_spsv_csr.hpp
+++ b/clients/include/testing_spsv_csr.hpp
@@ -38,7 +38,7 @@ using namespace hipsparse_test;
 void testing_spsv_csr_bad_arg(void)
 {
 #ifdef __HIP_PLATFORM_NVIDIA__
-// do not test for bad args
+    // do not test for bad args
     return;
 #endif
 

--- a/clients/tests/test_csrgeam2.cpp
+++ b/clients/tests/test_csrgeam2.cpp
@@ -151,7 +151,6 @@ TEST_P(parameterized_csrgeam2_bin, csrgeam2_bin_double)
     hipsparseStatus_t status = testing_csrgeam2<double>(arg);
     EXPECT_EQ(status, HIPSPARSE_STATUS_SUCCESS);
 }
-#endif
 
 INSTANTIATE_TEST_SUITE_P(csrgeam2,
                          parameterized_csrgeam2,
@@ -171,3 +170,4 @@ INSTANTIATE_TEST_SUITE_P(csrgeam2_bin,
                                           testing::ValuesIn(csrgeam2_idxbaseB_range),
                                           testing::ValuesIn(csrgeam2_idxbaseC_range),
                                           testing::ValuesIn(csrgeam2_bin)));
+#endif

--- a/clients/tests/test_csrsm2.cpp
+++ b/clients/tests/test_csrsm2.cpp
@@ -157,7 +157,6 @@ TEST_P(parameterized_csrsm2_bin, csrsm2_bin_double)
     hipsparseStatus_t status = testing_csrsm2<double>(arg);
     EXPECT_EQ(status, HIPSPARSE_STATUS_SUCCESS);
 }
-#endif
 
 INSTANTIATE_TEST_SUITE_P(csrsm2,
                          parameterized_csrsm2,
@@ -180,3 +179,4 @@ INSTANTIATE_TEST_SUITE_P(csrsm2_bin,
                                           testing::ValuesIn(csrsm2_diag_range),
                                           testing::ValuesIn(csrsm2_fill_range),
                                           testing::ValuesIn(csrsm2_bin)));
+#endif


### PR DESCRIPTION
Turn on tests when using cusparse backend in hipsparse. DIsable spsv bad arg tests when using cusparse backend.