### PR TITLE
Enable Origin header file dump option for wrapper

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -119,6 +119,7 @@ if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
     hipsparse-version.h hipsparse-export.h
     GUARDS SYMLINK WRAPPER
     WRAPPER_LOCATIONS include hipsparse/include
+    ORIGINAL_FILES ${PROJECT_BINARY_DIR}/include/hipsparse/hipsparse-version.h
   )
 endif( )
 


### PR DESCRIPTION
Summary of proposed changes:

- Original Header File Dump enabled for version header wrapper to support backward Compatibility for PT/TF
- ROCM-CMAKE Version needed https://github.com/RadeonOpenCompute/rocm-cmake/commit/d108dbf05e029996d5d7bcbe258abb1166547a30