### PR TITLE
[SWDEV-338627] Add testing_mult as operator overloading no longer works

### DIFF
--- a/clients/include/testing_axpby.hpp
+++ b/clients/include/testing_axpby.hpp
@@ -167,7 +167,7 @@ hipsparseStatus_t testing_axpby(void)
     // CPU
     for(int64_t i = 0; i < size; ++i)
     {
-        hy_gold[i] = beta * hy_gold[i];
+        hy_gold[i] = testing_mult(beta, hy_gold[i]);
     }
 
     for(int64_t i = 0; i < nnz; ++i)

--- a/clients/include/testing_axpyi.hpp
+++ b/clients/include/testing_axpyi.hpp
@@ -213,7 +213,8 @@ hipsparseStatus_t testing_axpyi(Arguments argus)
         // CPU
         for(int i = 0; i < nnz; ++i)
         {
-            hy_gold[hxInd[i] - idx_base] = hy_gold[hxInd[i] - idx_base] + testing_mult(h_alpha, hxVal[i]);
+            hy_gold[hxInd[i] - idx_base]
+                = hy_gold[hxInd[i] - idx_base] + testing_mult(h_alpha, hxVal[i]);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/testing_axpyi.hpp
+++ b/clients/include/testing_axpyi.hpp
@@ -213,7 +213,7 @@ hipsparseStatus_t testing_axpyi(Arguments argus)
         // CPU
         for(int i = 0; i < nnz; ++i)
         {
-            hy_gold[hxInd[i] - idx_base] = hy_gold[hxInd[i] - idx_base] + h_alpha * hxVal[i];
+            hy_gold[hxInd[i] - idx_base] = hy_gold[hxInd[i] - idx_base] + testing_mult(h_alpha, hxVal[i]);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/testing_csrgemm.hpp
+++ b/clients/include/testing_csrgemm.hpp
@@ -773,12 +773,12 @@ static void csrgemm(int                  m,
                 {
                     nnz[col_B]               = row_end_C;
                     csr_col_ind_C[row_end_C] = col_B + idx_base_C;
-                    csr_val_C[row_end_C]     = val_A * val_B;
+                    csr_val_C[row_end_C]     = testing_mult(val_A, val_B);
                     ++row_end_C;
                 }
                 else
                 {
-                    csr_val_C[nnz[col_B]] = csr_val_C[nnz[col_B]] + val_A * val_B;
+                    csr_val_C[nnz[col_B]] = csr_val_C[nnz[col_B]] + testing_mult(val_A, val_B);
                 }
             }
         }

--- a/clients/include/testing_csrmv.hpp
+++ b/clients/include/testing_csrmv.hpp
@@ -420,7 +420,7 @@ hipsparseStatus_t testing_csrmv(Arguments argus)
                         if(j + k < hcsr_row_ptr[i + 1] - idx_base)
                         {
                             sum[k] = testing_fma(
-                                h_alpha * hval[j + k], hx[hcol_ind[j + k] - idx_base], sum[k]);
+                                testing_mult(h_alpha, hval[j + k]), hx[hcol_ind[j + k] - idx_base], sum[k]);
                         }
                     }
                 }
@@ -448,7 +448,7 @@ hipsparseStatus_t testing_csrmv(Arguments argus)
             // Scale y with beta
             for(int i = 0; i < ncol; ++i)
             {
-                hy_gold[i] = hy_gold[i] * h_beta;
+                hy_gold[i] = testing_mult(hy_gold[i], h_beta);
             }
 
             // Transposed SpMV

--- a/clients/include/testing_csrmv.hpp
+++ b/clients/include/testing_csrmv.hpp
@@ -424,6 +424,7 @@ hipsparseStatus_t testing_csrmv(Arguments argus)
                         }
                     }
                 }
+                
 
                 for(int j = 1; j < WF_SIZE; j <<= 1)
                 {

--- a/clients/include/testing_csrmv.hpp
+++ b/clients/include/testing_csrmv.hpp
@@ -419,12 +419,12 @@ hipsparseStatus_t testing_csrmv(Arguments argus)
                     {
                         if(j + k < hcsr_row_ptr[i + 1] - idx_base)
                         {
-                            sum[k] = testing_fma(
-                                testing_mult(h_alpha, hval[j + k]), hx[hcol_ind[j + k] - idx_base], sum[k]);
+                            sum[k] = testing_fma(testing_mult(h_alpha, hval[j + k]),
+                                                 hx[hcol_ind[j + k] - idx_base],
+                                                 sum[k]);
                         }
                     }
                 }
-                
 
                 for(int j = 1; j < WF_SIZE; j <<= 1)
                 {

--- a/clients/include/testing_csrmv.hpp
+++ b/clients/include/testing_csrmv.hpp
@@ -456,7 +456,7 @@ hipsparseStatus_t testing_csrmv(Arguments argus)
             {
                 int row_begin = hcsr_row_ptr[i] - idx_base;
                 int row_end   = hcsr_row_ptr[i + 1] - idx_base;
-                T   row_val   = h_alpha * hx[i];
+                T   row_val   = testing_mult(h_alpha, hx[i]);
 
                 for(int j = row_begin; j < row_end; ++j)
                 {

--- a/clients/include/testing_dotci.hpp
+++ b/clients/include/testing_dotci.hpp
@@ -218,7 +218,7 @@ hipsparseStatus_t testing_dotci(Arguments argus)
         hresult_gold = make_DataType<T>(0.0);
         for(int i = 0; i < nnz; ++i)
         {
-            hresult_gold = hresult_gold + testing_conj(hx_val[i]) * hy[hx_ind[i] - idx_base];
+            hresult_gold = hresult_gold + testing_mult(testing_conj(hx_val[i]), hy[hx_ind[i] - idx_base]);
         }
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/testing_dotci.hpp
+++ b/clients/include/testing_dotci.hpp
@@ -21,6 +21,7 @@
  *
  * ************************************************************************ */
 
+
 #pragma once
 #ifndef TESTING_DOTCI_HPP
 #define TESTING_DOTCI_HPP

--- a/clients/include/testing_dotci.hpp
+++ b/clients/include/testing_dotci.hpp
@@ -21,7 +21,6 @@
  *
  * ************************************************************************ */
 
-
 #pragma once
 #ifndef TESTING_DOTCI_HPP
 #define TESTING_DOTCI_HPP
@@ -219,7 +218,8 @@ hipsparseStatus_t testing_dotci(Arguments argus)
         hresult_gold = make_DataType<T>(0.0);
         for(int i = 0; i < nnz; ++i)
         {
-            hresult_gold = hresult_gold + testing_mult(testing_conj(hx_val[i]), hy[hx_ind[i] - idx_base]);
+            hresult_gold
+                = hresult_gold + testing_mult(testing_conj(hx_val[i]), hy[hx_ind[i] - idx_base]);
         }
         // enable unit check, notice unit check is not invasive, but norm check is,
         // unit check and norm check can not be interchanged their order

--- a/clients/include/testing_doti.hpp
+++ b/clients/include/testing_doti.hpp
@@ -217,7 +217,7 @@ hipsparseStatus_t testing_doti(Arguments argus)
         hresult_gold = make_DataType<T>(0.0);
         for(int i = 0; i < nnz; ++i)
         {
-            hresult_gold = hresult_gold + hy[hx_ind[i] - idx_base] * hx_val[i];
+            hresult_gold = hresult_gold + testing_mult(hy[hx_ind[i] - idx_base], hx_val[i]);
         }
 
         // enable unit check, notice unit check is not invasive, but norm check is,

--- a/clients/include/testing_gemmi.hpp
+++ b/clients/include/testing_gemmi.hpp
@@ -555,7 +555,8 @@ hipsparseStatus_t testing_gemmi(Arguments argus)
                     sum = testing_fma(val_A, val_B, sum);
                 }
 
-                hC_gold[j * ldc + i] = testing_fma(h_beta, hC_gold[j * ldc + i], testing_mult(h_alpha, sum));
+                hC_gold[j * ldc + i]
+                    = testing_fma(h_beta, hC_gold[j * ldc + i], testing_mult(h_alpha, sum));
             }
         }
 

--- a/clients/include/testing_gemmi.hpp
+++ b/clients/include/testing_gemmi.hpp
@@ -555,7 +555,7 @@ hipsparseStatus_t testing_gemmi(Arguments argus)
                     sum = testing_fma(val_A, val_B, sum);
                 }
 
-                hC_gold[j * ldc + i] = testing_fma(h_beta, hC_gold[j * ldc + i], h_alpha * sum);
+                hC_gold[j * ldc + i] = testing_fma(h_beta, hC_gold[j * ldc + i], testing_mult(h_alpha, sum));
             }
         }
 

--- a/clients/include/testing_gemvi.hpp
+++ b/clients/include/testing_gemvi.hpp
@@ -241,7 +241,7 @@ hipsparseStatus_t testing_gemvi(void)
             sum = testing_fma(hx_val[j], hA[hx_ind[j] * lda + i], sum);
         }
 
-        hy_gold[i] = testing_fma(alpha, sum, beta * hy_gold[i]);
+        hy_gold[i] = testing_fma(alpha, sum, testing_mult(beta, hy_gold[i]));
     }
 
     // Verify results against host

--- a/clients/include/testing_gpsv_interleaved_batch.hpp
+++ b/clients/include/testing_gpsv_interleaved_batch.hpp
@@ -219,19 +219,19 @@ hipsparseStatus_t testing_gpsv_interleaved_batch(void)
     {
         for(int i = 0; i < m; ++i)
         {
-            T sum = hd[batch_count * i + b] * hx[batch_count * i + b];
+            T sum = testing_mult(hd[batch_count * i + b], hx[batch_count * i + b]);
 
             sum = sum
-                  + ((i - 2 >= 0) ? hds[batch_count * i + b] * hx[batch_count * (i - 2) + b]
+                  + ((i - 2 >= 0) ? testing_mult(hds[batch_count * i + b], hx[batch_count * (i - 2) + b])
                                   : make_DataType<T>(0));
             sum = sum
-                  + ((i - 1 >= 0) ? hdl[batch_count * i + b] * hx[batch_count * (i - 1) + b]
+                  + ((i - 1 >= 0) ? testing_mult(hdl[batch_count * i + b], hx[batch_count * (i - 1) + b])
                                   : make_DataType<T>(0));
             sum = sum
-                  + ((i + 1 < m) ? hdu[batch_count * i + b] * hx[batch_count * (i + 1) + b]
+                  + ((i + 1 < m) ? testing_mult(hdu[batch_count * i + b], hx[batch_count * (i + 1) + b])
                                  : make_DataType<T>(0));
             sum = sum
-                  + ((i + 2 < m) ? hdw[batch_count * i + b] * hx[batch_count * (i + 2) + b]
+                  + ((i + 2 < m) ? testing_mult(hdw[batch_count * i + b], hx[batch_count * (i + 2) + b])
                                  : make_DataType<T>(0));
 
             hresult[batch_count * i + b] = sum;

--- a/clients/include/testing_gpsv_interleaved_batch.hpp
+++ b/clients/include/testing_gpsv_interleaved_batch.hpp
@@ -189,7 +189,6 @@ hipsparseStatus_t testing_gpsv_interleaved_batch(void)
                                         "!dds || !ddl || !dd || !ddu || !ddw || !dx");
         return HIPSPARSE_STATUS_ALLOC_FAILED;
     }
-    
 
     // copy data from CPU to device
     CHECK_HIP_ERROR(hipMemcpy(dds, hds.data(), sizeof(T) * m * batch_count, hipMemcpyHostToDevice));
@@ -223,17 +222,21 @@ hipsparseStatus_t testing_gpsv_interleaved_batch(void)
             T sum = testing_mult(hd[batch_count * i + b], hx[batch_count * i + b]);
 
             sum = sum
-                  + ((i - 2 >= 0) ? testing_mult(hds[batch_count * i + b], hx[batch_count * (i - 2) + b])
-                                  : make_DataType<T>(0));
+                  + ((i - 2 >= 0)
+                         ? testing_mult(hds[batch_count * i + b], hx[batch_count * (i - 2) + b])
+                         : make_DataType<T>(0));
             sum = sum
-                  + ((i - 1 >= 0) ? testing_mult(hdl[batch_count * i + b], hx[batch_count * (i - 1) + b])
-                                  : make_DataType<T>(0));
+                  + ((i - 1 >= 0)
+                         ? testing_mult(hdl[batch_count * i + b], hx[batch_count * (i - 1) + b])
+                         : make_DataType<T>(0));
             sum = sum
-                  + ((i + 1 < m) ? testing_mult(hdu[batch_count * i + b], hx[batch_count * (i + 1) + b])
-                                 : make_DataType<T>(0));
+                  + ((i + 1 < m)
+                         ? testing_mult(hdu[batch_count * i + b], hx[batch_count * (i + 1) + b])
+                         : make_DataType<T>(0));
             sum = sum
-                  + ((i + 2 < m) ? testing_mult(hdw[batch_count * i + b], hx[batch_count * (i + 2) + b])
-                                 : make_DataType<T>(0));
+                  + ((i + 2 < m)
+                         ? testing_mult(hdw[batch_count * i + b], hx[batch_count * (i + 2) + b])
+                         : make_DataType<T>(0));
 
             hresult[batch_count * i + b] = sum;
         }

--- a/clients/include/testing_gpsv_interleaved_batch.hpp
+++ b/clients/include/testing_gpsv_interleaved_batch.hpp
@@ -189,6 +189,7 @@ hipsparseStatus_t testing_gpsv_interleaved_batch(void)
                                         "!dds || !ddl || !dd || !ddu || !ddw || !dx");
         return HIPSPARSE_STATUS_ALLOC_FAILED;
     }
+    
 
     // copy data from CPU to device
     CHECK_HIP_ERROR(hipMemcpy(dds, hds.data(), sizeof(T) * m * batch_count, hipMemcpyHostToDevice));

--- a/clients/include/testing_gtsv.hpp
+++ b/clients/include/testing_gtsv.hpp
@@ -178,13 +178,13 @@ hipsparseStatus_t testing_gtsv2(void)
     std::vector<T> hresult = hB_original;
     for(int j = 0; j < n; j++)
     {
-        hresult[ldb * j] = hd[0] * hB[ldb * j] + hdu[0] * hB[ldb * j + 1];
+        hresult[ldb * j] = testing_mult(hd[0], hB[ldb * j]) + testing_mult(hdu[0], hB[ldb * j + 1]);
         hresult[ldb * j + m - 1]
-            = hdl[m - 1] * hB[ldb * j + m - 2] + hd[m - 1] * hB[ldb * j + m - 1];
+            = testing_mult(hdl[m - 1], hB[ldb * j + m - 2]) + testing_mult(hd[m - 1], hB[ldb * j + m - 1]);
         for(int i = 1; i < m - 1; i++)
         {
-            hresult[ldb * j + i] = hdl[i] * hB[ldb * j + i - 1] + hd[i] * hB[ldb * j + i]
-                                   + hdu[i] * hB[ldb * j + i + 1];
+            hresult[ldb * j + i] = testing_mult(hdl[i], hB[ldb * j + i - 1]) + testing_mult(hd[i], hB[ldb * j + i])
+                                   + testing_mult(hdu[i], hB[ldb * j + i + 1]);
         }
     }
 

--- a/clients/include/testing_gtsv.hpp
+++ b/clients/include/testing_gtsv.hpp
@@ -21,6 +21,7 @@
  *
  * ************************************************************************ */
 
+
 #pragma once
 #ifndef TESTING_GTSV2_HPP
 #define TESTING_GTSV2_HPP

--- a/clients/include/testing_gtsv.hpp
+++ b/clients/include/testing_gtsv.hpp
@@ -21,7 +21,6 @@
  *
  * ************************************************************************ */
 
-
 #pragma once
 #ifndef TESTING_GTSV2_HPP
 #define TESTING_GTSV2_HPP
@@ -180,11 +179,12 @@ hipsparseStatus_t testing_gtsv2(void)
     for(int j = 0; j < n; j++)
     {
         hresult[ldb * j] = testing_mult(hd[0], hB[ldb * j]) + testing_mult(hdu[0], hB[ldb * j + 1]);
-        hresult[ldb * j + m - 1]
-            = testing_mult(hdl[m - 1], hB[ldb * j + m - 2]) + testing_mult(hd[m - 1], hB[ldb * j + m - 1]);
+        hresult[ldb * j + m - 1] = testing_mult(hdl[m - 1], hB[ldb * j + m - 2])
+                                   + testing_mult(hd[m - 1], hB[ldb * j + m - 1]);
         for(int i = 1; i < m - 1; i++)
         {
-            hresult[ldb * j + i] = testing_mult(hdl[i], hB[ldb * j + i - 1]) + testing_mult(hd[i], hB[ldb * j + i])
+            hresult[ldb * j + i] = testing_mult(hdl[i], hB[ldb * j + i - 1])
+                                   + testing_mult(hd[i], hB[ldb * j + i])
                                    + testing_mult(hdu[i], hB[ldb * j + i + 1]);
         }
     }

--- a/clients/include/testing_gtsv2_nopivot.hpp
+++ b/clients/include/testing_gtsv2_nopivot.hpp
@@ -179,13 +179,13 @@ hipsparseStatus_t testing_gtsv2_nopivot(void)
     std::vector<T> hresult(ldb * n, make_DataType<T>(3));
     for(int j = 0; j < n; j++)
     {
-        hresult[ldb * j] = hd[0] * hB[ldb * j] + hdu[0] * hB[ldb * j + 1];
+        hresult[ldb * j] = testing_mult(hd[0], hB[ldb * j]) + testing_mult(hdu[0], hB[ldb * j + 1]);
         hresult[ldb * j + m - 1]
-            = hdl[m - 1] * hB[ldb * j + m - 2] + hd[m - 1] * hB[ldb * j + m - 1];
+            = testing_mult(hdl[m - 1], hB[ldb * j + m - 2]) + testing_mult(hd[m - 1], hB[ldb * j + m - 1]);
         for(int i = 1; i < m - 1; i++)
         {
-            hresult[ldb * j + i] = hdl[i] * hB[ldb * j + i - 1] + hd[i] * hB[ldb * j + i]
-                                   + hdu[i] * hB[ldb * j + i + 1];
+            hresult[ldb * j + i] = testing_mult(hdl[i], hB[ldb * j + i - 1]) + testing_mult(hd[i], hB[ldb * j + i])
+                                   + testing_mult(hdu[i], hB[ldb * j + i + 1]);
         }
     }
 

--- a/clients/include/testing_gtsv2_nopivot.hpp
+++ b/clients/include/testing_gtsv2_nopivot.hpp
@@ -21,7 +21,6 @@
  *
  * ************************************************************************ */
 
-
 #pragma once
 #ifndef TESTING_GTSV2_NOPIVOT_HPP
 #define TESTING_GTSV2_NOPIVOT_HPP
@@ -181,11 +180,12 @@ hipsparseStatus_t testing_gtsv2_nopivot(void)
     for(int j = 0; j < n; j++)
     {
         hresult[ldb * j] = testing_mult(hd[0], hB[ldb * j]) + testing_mult(hdu[0], hB[ldb * j + 1]);
-        hresult[ldb * j + m - 1]
-            = testing_mult(hdl[m - 1], hB[ldb * j + m - 2]) + testing_mult(hd[m - 1], hB[ldb * j + m - 1]);
+        hresult[ldb * j + m - 1] = testing_mult(hdl[m - 1], hB[ldb * j + m - 2])
+                                   + testing_mult(hd[m - 1], hB[ldb * j + m - 1]);
         for(int i = 1; i < m - 1; i++)
         {
-            hresult[ldb * j + i] = testing_mult(hdl[i], hB[ldb * j + i - 1]) + testing_mult(hd[i], hB[ldb * j + i])
+            hresult[ldb * j + i] = testing_mult(hdl[i], hB[ldb * j + i - 1])
+                                   + testing_mult(hd[i], hB[ldb * j + i])
                                    + testing_mult(hdu[i], hB[ldb * j + i + 1]);
         }
     }

--- a/clients/include/testing_gtsv2_nopivot.hpp
+++ b/clients/include/testing_gtsv2_nopivot.hpp
@@ -21,6 +21,7 @@
  *
  * ************************************************************************ */
 
+
 #pragma once
 #ifndef TESTING_GTSV2_NOPIVOT_HPP
 #define TESTING_GTSV2_NOPIVOT_HPP

--- a/clients/include/testing_gtsv2_strided_batch.hpp
+++ b/clients/include/testing_gtsv2_strided_batch.hpp
@@ -21,7 +21,6 @@
  *
  * ************************************************************************ */
 
-
 #pragma once
 #ifndef TESTING_GTSV2_NOPIVOT_STRIDED_BATCH_HPP
 #define TESTING_GTSV2_NOPIVOT_STRIDED_BATCH_HPP
@@ -204,8 +203,9 @@ hipsparseStatus_t testing_gtsv2_strided_batch(void)
     std::vector<T> hresult(batch_stride * batch_count, make_DataType<T>(3));
     for(int j = 0; j < batch_count; j++)
     {
-        hresult[batch_stride * j] = testing_mult(hd[batch_stride * j + 0], hx[batch_stride * j])
-                                    + testing_mult(hdu[batch_stride * j + 0], hx[batch_stride * j + 1]);
+        hresult[batch_stride * j]
+            = testing_mult(hd[batch_stride * j + 0], hx[batch_stride * j])
+              + testing_mult(hdu[batch_stride * j + 0], hx[batch_stride * j + 1]);
         hresult[batch_stride * j + m - 1]
             = testing_mult(hdl[batch_stride * j + m - 1], hx[batch_stride * j + m - 2])
               + testing_mult(hd[batch_stride * j + m - 1], hx[batch_stride * j + m - 1]);

--- a/clients/include/testing_gtsv2_strided_batch.hpp
+++ b/clients/include/testing_gtsv2_strided_batch.hpp
@@ -21,6 +21,7 @@
  *
  * ************************************************************************ */
 
+
 #pragma once
 #ifndef TESTING_GTSV2_NOPIVOT_STRIDED_BATCH_HPP
 #define TESTING_GTSV2_NOPIVOT_STRIDED_BATCH_HPP

--- a/clients/include/testing_gtsv2_strided_batch.hpp
+++ b/clients/include/testing_gtsv2_strided_batch.hpp
@@ -203,17 +203,17 @@ hipsparseStatus_t testing_gtsv2_strided_batch(void)
     std::vector<T> hresult(batch_stride * batch_count, make_DataType<T>(3));
     for(int j = 0; j < batch_count; j++)
     {
-        hresult[batch_stride * j] = hd[batch_stride * j + 0] * hx[batch_stride * j]
-                                    + hdu[batch_stride * j + 0] * hx[batch_stride * j + 1];
+        hresult[batch_stride * j] = testing_mult(hd[batch_stride * j + 0], hx[batch_stride * j])
+                                    + testing_mult(hdu[batch_stride * j + 0], hx[batch_stride * j + 1]);
         hresult[batch_stride * j + m - 1]
-            = hdl[batch_stride * j + m - 1] * hx[batch_stride * j + m - 2]
-              + hd[batch_stride * j + m - 1] * hx[batch_stride * j + m - 1];
+            = testing_mult(hdl[batch_stride * j + m - 1], hx[batch_stride * j + m - 2])
+              + testing_mult(hd[batch_stride * j + m - 1], hx[batch_stride * j + m - 1]);
         for(int i = 1; i < m - 1; i++)
         {
             hresult[batch_stride * j + i]
-                = hdl[batch_stride * j + i] * hx[batch_stride * j + i - 1]
-                  + hd[batch_stride * j + i] * hx[batch_stride * j + i]
-                  + hdu[batch_stride * j + i] * hx[batch_stride * j + i + 1];
+                = testing_mult(hdl[batch_stride * j + i], hx[batch_stride * j + i - 1])
+                  + testing_mult(hd[batch_stride * j + i], hx[batch_stride * j + i])
+                  + testing_mult(hdu[batch_stride * j + i], hx[batch_stride * j + i + 1]);
         }
     }
 

--- a/clients/include/testing_gtsv_interleaved_batch.hpp
+++ b/clients/include/testing_gtsv_interleaved_batch.hpp
@@ -187,10 +187,10 @@ hipsparseStatus_t testing_gtsv_interleaved_batch(void)
     std::vector<T> hresult(m * batch_count, make_DataType<T>(3));
     for(int j = 0; j < batch_count; j++)
     {
-        hresult[j] = hd[j] * hx[j] + hdu[j] * hx[batch_count + j];
+        hresult[j] = testing_mult(hd[j], hx[j]) + testing_mult(hdu[j], hx[batch_count + j]);
         hresult[batch_count * (m - 1) + j]
-            = hdl[batch_count * (m - 1) + j] * hx[batch_count * (m - 2) + j]
-              + hd[batch_count * (m - 1) + j] * hx[batch_count * (m - 1) + j];
+            = testing_mult(hdl[batch_count * (m - 1) + j], hx[batch_count * (m - 2) + j])
+              + testing_mult(hd[batch_count * (m - 1) + j], hx[batch_count * (m - 1) + j]);
     }
 
     for(int i = 1; i < m - 1; i++)
@@ -198,9 +198,9 @@ hipsparseStatus_t testing_gtsv_interleaved_batch(void)
         for(int j = 0; j < batch_count; j++)
         {
             hresult[batch_count * i + j]
-                = hdl[batch_count * i + j] * hx[batch_count * (i - 1) + j]
-                  + hd[batch_count * i + j] * hx[batch_count * i + j]
-                  + hdu[batch_count * i + j] * hx[batch_count * (i + 1) + j];
+                = testing_mult(hdl[batch_count * i + j], hx[batch_count * (i - 1) + j])
+                  + testing_mult(hd[batch_count * i + j], hx[batch_count * i + j])
+                  + testing_mult(hdu[batch_count * i + j], hx[batch_count * (i + 1) + j]);
         }
     }
 

--- a/clients/include/testing_hybmv.hpp
+++ b/clients/include/testing_hybmv.hpp
@@ -454,7 +454,8 @@ hipsparseStatus_t testing_hybmv(Arguments argus)
                 int row = hcoo_row[i] - idx_base;
                 int col = hcoo_col[i] - idx_base;
 
-                hy_gold[row] = hy_gold[row] + testing_mult(h_alpha, testing_mult(hcoo_val[i], hx[col]));
+                hy_gold[row]
+                    = hy_gold[row] + testing_mult(h_alpha, testing_mult(hcoo_val[i], hx[col]));
             }
         }
 

--- a/clients/include/testing_hybmv.hpp
+++ b/clients/include/testing_hybmv.hpp
@@ -430,11 +430,11 @@ hipsparseStatus_t testing_hybmv(Arguments argus)
 
                 if(h_beta != zero)
                 {
-                    hy_gold[i] = h_beta * hy_gold[i] + h_alpha * sum;
+                    hy_gold[i] = testing_mult(h_beta, hy_gold[i]) + testing_mult(h_alpha, sum);
                 }
                 else
                 {
-                    hy_gold[i] = h_alpha * sum;
+                    hy_gold[i] = testing_mult(h_alpha, sum);
                 }
             }
         }
@@ -446,7 +446,7 @@ hipsparseStatus_t testing_hybmv(Arguments argus)
 
             for(int i = 0; i < m; ++i)
             {
-                hy_gold[i] = hy_gold[i] * coo_beta;
+                hy_gold[i] = testing_mult(hy_gold[i], coo_beta);
             }
 
             for(int i = 0; i < coo_nnz; ++i)
@@ -454,7 +454,7 @@ hipsparseStatus_t testing_hybmv(Arguments argus)
                 int row = hcoo_row[i] - idx_base;
                 int col = hcoo_col[i] - idx_base;
 
-                hy_gold[row] = hy_gold[row] + h_alpha * hcoo_val[i] * hx[col];
+                hy_gold[row] = hy_gold[row] + testing_mult(h_alpha, testing_mult(hcoo_val[i], hx[col]));
             }
         }
 

--- a/clients/include/testing_hybmv.hpp
+++ b/clients/include/testing_hybmv.hpp
@@ -420,7 +420,7 @@ hipsparseStatus_t testing_hybmv(Arguments argus)
 
                     if(col >= 0 && col < n)
                     {
-                        sum = sum + hell_val[idx] * hx[col];
+                        sum = sum + testing_mult(hell_val[idx], hx[col]);
                     }
                     else
                     {

--- a/clients/include/testing_rot.hpp
+++ b/clients/include/testing_rot.hpp
@@ -204,8 +204,8 @@ hipsparseStatus_t testing_rot(void)
         T x = hx_val_gold[i];
         T y = hy_gold[idx];
 
-        hx_val_gold[i] = hc_coeff * x + hs_coeff * y;
-        hy_gold[idx]   = hc_coeff * y - hs_coeff * x;
+        hx_val_gold[i] = testing_mult(hc_coeff, x) + testing_mult(hs_coeff, y);
+        hy_gold[idx]   = testing_mult(hc_coeff, y) - testing_mult(hs_coeff, x);
     }
 
     // Verify results against host

--- a/clients/include/testing_sddmm_coo.hpp
+++ b/clients/include/testing_sddmm_coo.hpp
@@ -352,7 +352,7 @@ hipsparseStatus_t testing_sddmm_coo()
             {
                 sum = testing_fma(x[incx * k_], y[incy * k_], sum);
             }
-            hcsr_val[at] = hcsr_val[at] * h_beta + h_alpha * sum;
+            hcsr_val[at] = testing_mult(hcsr_val[at], h_beta) + testing_mult(h_alpha, sum);
         }
     }
 

--- a/clients/include/testing_sddmm_coo_aos.hpp
+++ b/clients/include/testing_sddmm_coo_aos.hpp
@@ -349,7 +349,7 @@ hipsparseStatus_t testing_sddmm_coo_aos()
             {
                 sum = testing_fma(x[incx * k_], y[incy * k_], sum);
             }
-            hcsr_val[at] = hcsr_val[at] * h_beta + h_alpha * sum;
+            hcsr_val[at] = testing_mult(hcsr_val[at], h_beta) + testing_mult(h_alpha, sum);
         }
     }
 

--- a/clients/include/testing_sddmm_csc.hpp
+++ b/clients/include/testing_sddmm_csc.hpp
@@ -355,7 +355,7 @@ hipsparseStatus_t testing_sddmm_csc()
             {
                 sum = testing_fma(x[incx * k_], y[incy * k_], sum);
             }
-            hcsc_val[at] = hcsc_val[at] * h_beta + h_alpha * sum;
+            hcsc_val[at] = testing_mult(hcsc_val[at], h_beta) + testing_mult(h_alpha, sum);
         }
     }
 

--- a/clients/include/testing_sddmm_csr.hpp
+++ b/clients/include/testing_sddmm_csr.hpp
@@ -346,7 +346,7 @@ hipsparseStatus_t testing_sddmm_csr()
             {
                 sum = testing_fma(x[incx * k_], y[incy * k_], sum);
             }
-            hcsr_val[at] = hcsr_val[at] * h_beta + h_alpha * sum;
+            hcsr_val[at] = testing_mult(hcsr_val[at], h_beta) + testing_mult(h_alpha, sum);
         }
     }
 

--- a/clients/include/testing_spmv_coo.hpp
+++ b/clients/include/testing_spmv_coo.hpp
@@ -287,10 +287,10 @@ hipsparseStatus_t testing_spmv_coo(void)
 
     for(I i = 0; i < nnz; ++i)
     {
-        hy_gold[hrow_ind[i] - idx_base] = testing_fma(
-            testing_mult(h_alpha, hval[i]), hx[hcol_ind[i] - idx_base], hy_gold[hrow_ind[i] - idx_base]);
+        hy_gold[hrow_ind[i] - idx_base] = testing_fma(testing_mult(h_alpha, hval[i]),
+                                                      hx[hcol_ind[i] - idx_base],
+                                                      hy_gold[hrow_ind[i] - idx_base]);
     }
-    
 
     unit_check_near(1, m, 1, hy_gold.data(), hy_1.data());
     unit_check_near(1, m, 1, hy_gold.data(), hy_2.data());

--- a/clients/include/testing_spmv_coo.hpp
+++ b/clients/include/testing_spmv_coo.hpp
@@ -288,7 +288,7 @@ hipsparseStatus_t testing_spmv_coo(void)
     for(I i = 0; i < nnz; ++i)
     {
         hy_gold[hrow_ind[i] - idx_base] = testing_fma(
-            h_alpha * hval[i], hx[hcol_ind[i] - idx_base], hy_gold[hrow_ind[i] - idx_base]);
+            testing_mult(h_alpha, hval[i]), hx[hcol_ind[i] - idx_base], hy_gold[hrow_ind[i] - idx_base]);
     }
 
     unit_check_near(1, m, 1, hy_gold.data(), hy_1.data());

--- a/clients/include/testing_spmv_coo.hpp
+++ b/clients/include/testing_spmv_coo.hpp
@@ -290,6 +290,7 @@ hipsparseStatus_t testing_spmv_coo(void)
         hy_gold[hrow_ind[i] - idx_base] = testing_fma(
             testing_mult(h_alpha, hval[i]), hx[hcol_ind[i] - idx_base], hy_gold[hrow_ind[i] - idx_base]);
     }
+    
 
     unit_check_near(1, m, 1, hy_gold.data(), hy_1.data());
     unit_check_near(1, m, 1, hy_gold.data(), hy_2.data());

--- a/clients/include/testing_spmv_coo_aos.hpp
+++ b/clients/include/testing_spmv_coo_aos.hpp
@@ -271,7 +271,6 @@ hipsparseStatus_t testing_spmv_coo_aos(void)
     CHECK_HIP_ERROR(hipMemcpy(hy_1.data(), dy_1, sizeof(T) * m, hipMemcpyDeviceToHost));
     CHECK_HIP_ERROR(hipMemcpy(hy_2.data(), dy_2, sizeof(T) * m, hipMemcpyDeviceToHost));
 
-
     // Host SpMV
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic, 1024)
@@ -283,8 +282,9 @@ hipsparseStatus_t testing_spmv_coo_aos(void)
 
     for(I i = 0; i < nnz; ++i)
     {
-        hy_gold[hind[2 * i] - idx_base] = testing_fma(
-            testing_mult(h_alpha, hval[i]), hx[hind[2 * i + 1] - idx_base], hy_gold[hind[2 * i] - idx_base]);
+        hy_gold[hind[2 * i] - idx_base] = testing_fma(testing_mult(h_alpha, hval[i]),
+                                                      hx[hind[2 * i + 1] - idx_base],
+                                                      hy_gold[hind[2 * i] - idx_base]);
     }
 
     unit_check_near(1, m, 1, hy_gold.data(), hy_1.data());

--- a/clients/include/testing_spmv_coo_aos.hpp
+++ b/clients/include/testing_spmv_coo_aos.hpp
@@ -283,7 +283,7 @@ hipsparseStatus_t testing_spmv_coo_aos(void)
     for(I i = 0; i < nnz; ++i)
     {
         hy_gold[hind[2 * i] - idx_base] = testing_fma(
-            h_alpha * hval[i], hx[hind[2 * i + 1] - idx_base], hy_gold[hind[2 * i] - idx_base]);
+            testing_mult(h_alpha, hval[i]), hx[hind[2 * i + 1] - idx_base], hy_gold[hind[2 * i] - idx_base]);
     }
 
     unit_check_near(1, m, 1, hy_gold.data(), hy_1.data());

--- a/clients/include/testing_spmv_coo_aos.hpp
+++ b/clients/include/testing_spmv_coo_aos.hpp
@@ -271,6 +271,7 @@ hipsparseStatus_t testing_spmv_coo_aos(void)
     CHECK_HIP_ERROR(hipMemcpy(hy_1.data(), dy_1, sizeof(T) * m, hipMemcpyDeviceToHost));
     CHECK_HIP_ERROR(hipMemcpy(hy_2.data(), dy_2, sizeof(T) * m, hipMemcpyDeviceToHost));
 
+
     // Host SpMV
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic, 1024)

--- a/clients/include/testing_spmv_csr.hpp
+++ b/clients/include/testing_spmv_csr.hpp
@@ -347,7 +347,7 @@ hipsparseStatus_t testing_spmv_csr(void)
                 if(j + k < hcsr_row_ptr[i + 1] - idx_base)
                 {
                     sum[k] = testing_fma(
-                        h_alpha * hval[j + k], hx[hcol_ind[j + k] - idx_base], sum[k]);
+                        testing_mult(h_alpha, hval[j + k]), hx[hcol_ind[j + k] - idx_base], sum[k]);
                 }
             }
         }

--- a/clients/include/testing_spvv.hpp
+++ b/clients/include/testing_spvv.hpp
@@ -21,7 +21,6 @@
  *
  * ************************************************************************ */
 
-
 #pragma once
 #ifndef TESTING_SPVV_HPP
 #define TESTING_SPVV_HPP
@@ -240,7 +239,8 @@ hipsparseStatus_t testing_spvv(void)
         hresult_C_gold = make_DataType<T>(0);
         for(I i = 0; i < nnz; ++i)
         {
-            hresult_C_gold = hresult_C_gold + testing_mult(testing_conj(hx_val[i]), hy[hx_ind[i] - idxBase]);
+            hresult_C_gold
+                = hresult_C_gold + testing_mult(testing_conj(hx_val[i]), hy[hx_ind[i] - idxBase]);
         }
 
         // Verify results against host

--- a/clients/include/testing_spvv.hpp
+++ b/clients/include/testing_spvv.hpp
@@ -227,7 +227,7 @@ hipsparseStatus_t testing_spvv(void)
     hresult_N_gold = make_DataType<T>(0);
     for(I i = 0; i < nnz; ++i)
     {
-        hresult_N_gold = hresult_N_gold + hy[hx_ind[i] - idxBase] * hx_val[i];
+        hresult_N_gold = hresult_N_gold + testing_mult(hy[hx_ind[i] - idxBase], hx_val[i]);
     }
 
     // Verify results against host
@@ -239,7 +239,7 @@ hipsparseStatus_t testing_spvv(void)
         hresult_C_gold = make_DataType<T>(0);
         for(I i = 0; i < nnz; ++i)
         {
-            hresult_C_gold = hresult_C_gold + testing_conj(hx_val[i]) * hy[hx_ind[i] - idxBase];
+            hresult_C_gold = hresult_C_gold + testing_mult(testing_conj(hx_val[i]), hy[hx_ind[i] - idxBase]);
         }
 
         // Verify results against host

--- a/clients/include/testing_spvv.hpp
+++ b/clients/include/testing_spvv.hpp
@@ -21,6 +21,7 @@
  *
  * ************************************************************************ */
 
+
 #pragma once
 #ifndef TESTING_SPVV_HPP
 #define TESTING_SPVV_HPP

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -2561,7 +2561,9 @@ void host_csrmm(J                    M,
 
                     J idx_C = (order == HIPSPARSE_ORDER_COLUMN) ? col + j * ldc : col * ldc + j;
 
-                    C[idx_C] = C[idx_C] + testing_mult(alpha, testing_mult(val, testing_conj(B[idx_B], conj_B)));
+                    C[idx_C]
+                        = C[idx_C]
+                          + testing_mult(alpha, testing_mult(val, testing_conj(B[idx_B], conj_B)));
                 }
             }
         }
@@ -3807,7 +3809,7 @@ static inline void host_lssolve(J                     M,
                     // Lower triangular part
                     J idx     = (transB == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? i * ldb + local_col
                                                                               : local_col * ldb + i;
-                    T neg_val = make_DataType<T>(-1.0) * local_val;
+                    T neg_val = testing_mult(make_DataType<T>(-1.0), local_val);
 
                     if(transB == HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE)
                     {
@@ -3939,7 +3941,7 @@ static inline void host_ussolve(J                     M,
                     // Upper triangular part
                     J idx     = (transB == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? i * ldb + local_col
                                                                               : local_col * ldb + i;
-                    T neg_val = make_DataType<T>(-1.0) * local_val;
+                    T neg_val = testing_mult(make_DataType<T>(-1.0), local_val);
 
                     if(transB == HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE)
                     {

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -4765,7 +4765,7 @@ void bsr_lsolve(hipsparseDirection_t dir,
                         *struct_pivot = std::min(*struct_pivot, bsr_row + base);
                     }
 
-                    X[idx_X] = sum * diag_val;
+                    X[idx_X] = testing_mult(sum, diag_val);
                 }
                 else
                 {
@@ -4872,7 +4872,7 @@ void bsr_usolve(hipsparseDirection_t dir,
                         *struct_pivot = std::min(*struct_pivot, bsr_row + base);
                     }
 
-                    X[idx_X] = sum * diag_val;
+                    X[idx_X] = testing_mult(sum, diag_val);
                 }
                 else
                 {
@@ -5131,7 +5131,7 @@ int csr_lsolve(hipsparseOperation_t trans,
                 pivot = std::min(pivot, i + idx_base);
             }
 
-            y[i] = temp[0] * diag_val;
+            y[i] = testing_mult(temp[0], diag_val);
         }
         else
         {
@@ -5262,7 +5262,7 @@ int csr_usolve(hipsparseOperation_t trans,
                 pivot = std::min(pivot, i + idx_base);
             }
 
-            y[i] = temp[0] * diag_val;
+            y[i] = testing_mult(temp[0], diag_val);
         }
         else
         {

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -276,6 +276,27 @@ inline T make_DataType(double real, double imag = 0.0)
     return make_DataType2<T>(real, imag);
 }
 
+
+/* ============================================================================================ */
+/*! \brief mult */
+template <typename T>
+inline T testing_mult(T p, T q)
+{
+    return p * q;
+}
+
+template <>
+inline hipComplex testing_mult(hipComplex p, hipComplex q)
+{
+    return hipCmulf(p, q);
+}
+
+template <>
+inline hipDoubleComplex testing_mult(hipDoubleComplex p, hipDoubleComplex q)
+{
+    return hipCmul(p, q);
+}
+
 /* ============================================================================================ */
 /*! \brief fma */
 template <typename T>

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -3529,7 +3529,7 @@ inline void host_bsric02(hipsparseDirection_t    direction,
                     }
                 }
 
-                val_j = (val_j - local_sum) * inv_diag;
+                val_j = testing_mult((val_j - local_sum), inv_diag);
                 sum   = testing_fma(val_j, testing_conj(val_j), sum);
 
                 if(direction == HIPSPARSE_DIRECTION_ROW)
@@ -3680,7 +3680,7 @@ void csric0(int                  M,
                 }
             }
 
-            val_j = (val_j - local_sum) * inv_diag;
+            val_j = testing_mult((val_j - local_sum), inv_diag);
             sum   = testing_fma(val_j, testing_conj(val_j), sum);
 
             csr_val[j] = val_j;

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -3837,7 +3837,7 @@ static inline void host_lssolve(J                     M,
                     *struct_pivot = std::min(*struct_pivot, row + base);
                 }
 
-                B[idx_B] = temp[0] * diag_val;
+                B[idx_B] = testing_mult(temp[0], diag_val);
             }
             else
             {
@@ -3969,7 +3969,7 @@ static inline void host_ussolve(J                     M,
                     *struct_pivot = std::min(*struct_pivot, row + base);
                 }
 
-                B[idx_B] = temp[0] * diag_val;
+                B[idx_B] = testing_mult(temp[0], diag_val);
             }
             else
             {
@@ -4214,7 +4214,7 @@ void host_csr_lsolve(J                    M,
                 *struct_pivot = std::min(*struct_pivot, row + base);
             }
 
-            y[row] = temp[0] * diag_val;
+            y[row] = testing_mult(temp[0], diag_val);
         }
         else
         {
@@ -4317,7 +4317,7 @@ void host_csr_usolve(J                    M,
                 *struct_pivot = std::min(*struct_pivot, row + base);
             }
 
-            y[row] = temp[0] * diag_val;
+            y[row] = testing_mult(temp[0], diag_val);
         }
         else
         {

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -5798,12 +5798,12 @@ static void csrgemm2(J                    m,
                         {
                             nnz[col_B]               = row_end_C;
                             csr_col_ind_C[row_end_C] = col_B + idx_base_C;
-                            csr_val_C[row_end_C]     = val_A * val_B;
+                            csr_val_C[row_end_C]     = testing_mult(val_A, val_B);
                             ++row_end_C;
                         }
                         else
                         {
-                            csr_val_C[nnz[col_B]] = csr_val_C[nnz[col_B]] + val_A * val_B;
+                            csr_val_C[nnz[col_B]] = csr_val_C[nnz[col_B]] + testing_mult(val_A, val_B);
                         }
                     }
                 }

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -5803,7 +5803,8 @@ static void csrgemm2(J                    m,
                         }
                         else
                         {
-                            csr_val_C[nnz[col_B]] = csr_val_C[nnz[col_B]] + testing_mult(val_A, val_B);
+                            csr_val_C[nnz[col_B]] 
+                                = csr_val_C[nnz[col_B]] + testing_mult(val_A, val_B);
                         }
                     }
                 }

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -2434,7 +2434,7 @@ inline void host_bsrmm(int                     Mb,
                                     ? j * ldb + block_dim * (bsr_col_ind_A[s] - base) + t
                                     : (block_dim * (bsr_col_ind_A[s] - base) + t) * ldb + j;
 
-                    sum = sum + alpha * testing_mult(bsr_val_A[idx_A], B[idx_B]);
+                    sum = sum + testing_mult(alpha, testing_mult(bsr_val_A[idx_A], B[idx_B]));
                 }
             }
 
@@ -2561,7 +2561,7 @@ void host_csrmm(J                    M,
 
                     J idx_C = (order == HIPSPARSE_ORDER_COLUMN) ? col + j * ldc : col * ldc + j;
 
-                    C[idx_C] = C[idx_C] + alpha * testing_mult(val, testing_conj(B[idx_B], conj_B));
+                    C[idx_C] = C[idx_C] + testing_mult(alpha, testing_mult(val, testing_conj(B[idx_B], conj_B)));
                 }
             }
         }
@@ -3883,7 +3883,7 @@ static inline void host_ussolve(J                     M,
 
             if(transB == HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE)
             {
-                temp[0] = alpha * testing_conj(B[idx_B]);
+                temp[0] = testing_mult(alpha, testing_conj(B[idx_B]));
             }
             else
             {

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -2308,8 +2308,10 @@ inline void host_bsrmv(hipsparseDirection_t dir,
 
             if(beta != make_DataType<T>(0))
             {
-                y[row * bsr_dim + 0] = testing_fma(beta, y[row * bsr_dim + 0], testing_mult(alpha, sum0[0]));
-                y[row * bsr_dim + 1] = testing_fma(beta, y[row * bsr_dim + 1], testing_mult(alpha, sum1[0]));
+                y[row * bsr_dim + 0]
+                    = testing_fma(beta, y[row * bsr_dim + 0], testing_mult(alpha, sum0[0]));
+                y[row * bsr_dim + 1]
+                    = testing_fma(beta, y[row * bsr_dim + 1], testing_mult(alpha, sum1[0]));
             }
             else
             {

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -5803,7 +5803,7 @@ static void csrgemm2(J                    m,
                         }
                         else
                         {
-                            csr_val_C[nnz[col_B]] 
+                            csr_val_C[nnz[col_B]]
                                 = csr_val_C[nnz[col_B]] + testing_mult(val_A, val_B);
                         }
                     }

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -2195,7 +2195,7 @@ inline void host_bsrmv(hipsparseDirection_t dir,
         {
             for(int i = 0; i < mb * bsr_dim; ++i)
             {
-                y[i] = beta * y[i];
+                y[i] = testing_mult(beta, y[i]);
             }
         }
 
@@ -2444,7 +2444,7 @@ inline void host_bsrmm(int                     Mb,
             }
             else
             {
-                C[idx_C] = sum + beta * C[idx_C];
+                C[idx_C] = sum + testing_mult(beta, C[idx_C]);
             }
         }
     }
@@ -2527,7 +2527,7 @@ void host_csrmm(J                    M,
             for(J j = 0; j < N; ++j)
             {
                 J idx_C  = (order == HIPSPARSE_ORDER_COLUMN) ? i + j * ldc : i * ldc + j;
-                C[idx_C] = beta * C[idx_C];
+                C[idx_C] = testing_mult(beta, C[idx_C]);
             }
         }
 
@@ -5552,7 +5552,7 @@ static void host_csrgeam(int                  M,
                 int col_B = csr_col_ind_B[j] - base_B;
 
                 // Current value of B
-                T val_B = beta * csr_val_B[j];
+                T val_B = testing_mult(beta, csr_val_B[j]);
 
                 // Check if a new nnz is generated or if the value is added
                 if(nnz[col_B] < row_begin_C)
@@ -5819,7 +5819,7 @@ static void csrgemm2(J                    m,
                     // Current column of D
                     J col_D = csr_col_ind_D[j] - idx_base_D;
                     // Current value of D
-                    T val_D = *beta * csr_val_D[j];
+                    T val_D = testing_mult(*beta, csr_val_D[j]);
 
                     // Check if a new nnz is generated or if the value is added
                     if(nnz[col_D] < row_begin_C)


### PR DESCRIPTION
Need to add testing_mult to call hipCmul when using hipComplex as operator overloading no longer works in newest hip runtime. 