### PR TITLE
Add more detailed warning when a test matrix file is not found

### DIFF
--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -732,7 +732,9 @@ int read_mtx_matrix(const char*          filename,
     FILE* f = fopen(filename, "r");
     if(!f)
     {
-        printf("Failed to open matrix file %s because it does not exist. Please download the matrix file using the install script with -c flag.", filename);
+        printf("Failed to open matrix file %s because it does not exist. Please download the "
+               "matrix file using the install script with -c flag.",
+               filename);
         return -1;
     }
 

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -732,6 +732,7 @@ int read_mtx_matrix(const char*          filename,
     FILE* f = fopen(filename, "r");
     if(!f)
     {
+        printf("Failed to open matrix file %s because it does not exist. Please download the matrix file using the install script with -c flag.", filename);
         return -1;
     }
 

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -732,9 +732,10 @@ int read_mtx_matrix(const char*          filename,
     FILE* f = fopen(filename, "r");
     if(!f)
     {
-        fprintf(stderr, "Failed to open matrix file %s because it does not exist. Please download the "
-               "matrix file using the install script with -c flag.",
-               filename);
+        fprintf(stderr,
+                "Failed to open matrix file %s because it does not exist. Please download the "
+                "matrix file using the install script with -c flag.",
+                filename);
         return -1;
     }
 

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -732,7 +732,7 @@ int read_mtx_matrix(const char*          filename,
     FILE* f = fopen(filename, "r");
     if(!f)
     {
-        printf("Failed to open matrix file %s because it does not exist. Please download the "
+        fprintf(stderr, "Failed to open matrix file %s because it does not exist. Please download the "
                "matrix file using the install script with -c flag.",
                filename);
         return -1;


### PR DESCRIPTION
Adds more detailed warning when a test matrix file is not found to aid users and QA when running the test suite fails because a file was not found.