### PR TITLE
Remove Git from build requirements

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -23,9 +23,6 @@
 
 # Dependencies
 
-# Git
-find_package(Git REQUIRED)
-
 if( NOT DEFINED ENV{HIP_PATH})
     if(WIN32)
         set( HIP_PATH "C:/hip" )


### PR DESCRIPTION
The `find_package(Git REQUIRED)` doesn't seem to be used.