### PR TITLE
Get hipSPARSE compiling with Cuda 12

### DIFF
--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -8817,22 +8817,29 @@ typedef enum
     HIPSPARSE_FORMAT_BLOCKED_ELL = 5 /* Blocked ELL */
 } hipsparseFormat_t;
 #else
-#if(CUDART_VERSION >= 10010)
+#if(CUDART_VERSION >= 12000)
 typedef enum
 {
-    HIPSPARSE_FORMAT_CSR = 1, /* Compressed Sparse Row */
-#if(CUDART_VERSION >= 11021)
-    HIPSPARSE_FORMAT_CSC = 2, /* Compressed Sparse Column */
-#endif
-    HIPSPARSE_FORMAT_COO = 3 /* Coordinate - Structure of Arrays */
-#if(CUDART_VERSION < 12000)
-    ,
-    HIPSPARSE_FORMAT_COO_AOS = 4 /* Coordinate - Array of Structures */
-#endif
-#if(CUDART_VERSION >= 11021)
-    ,
+    HIPSPARSE_FORMAT_CSR         = 1, /* Compressed Sparse Row */
+    HIPSPARSE_FORMAT_CSC         = 2, /* Compressed Sparse Column */
+    HIPSPARSE_FORMAT_COO         = 3, /* Coordinate - Structure of Arrays */
     HIPSPARSE_FORMAT_BLOCKED_ELL = 5 /* Blocked ELL */
-#endif
+} hipsparseFormat_t;
+#elif(CUDART_VERSION >= 11021 && CUDART_VERSION < 12000)
+typedef enum
+{
+    HIPSPARSE_FORMAT_CSR         = 1, /* Compressed Sparse Row */
+    HIPSPARSE_FORMAT_CSC         = 2, /* Compressed Sparse Column */
+    HIPSPARSE_FORMAT_COO         = 3, /* Coordinate - Structure of Arrays */
+    HIPSPARSE_FORMAT_COO_AOS     = 4, /* Coordinate - Array of Structures */
+    HIPSPARSE_FORMAT_BLOCKED_ELL = 5 /* Blocked ELL */
+} hipsparseFormat_t;
+#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 11021)
+typedef enum
+{
+    HIPSPARSE_FORMAT_CSR         = 1, /* Compressed Sparse Row */
+    HIPSPARSE_FORMAT_COO         = 3, /* Coordinate - Structure of Arrays */
+    HIPSPARSE_FORMAT_COO_AOS     = 4, /* Coordinate - Array of Structures */
 } hipsparseFormat_t;
 #endif
 #endif

--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -8837,9 +8837,9 @@ typedef enum
 #elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 11021)
 typedef enum
 {
-    HIPSPARSE_FORMAT_CSR         = 1, /* Compressed Sparse Row */
-    HIPSPARSE_FORMAT_COO         = 3, /* Coordinate - Structure of Arrays */
-    HIPSPARSE_FORMAT_COO_AOS     = 4, /* Coordinate - Array of Structures */
+    HIPSPARSE_FORMAT_CSR     = 1, /* Compressed Sparse Row */
+    HIPSPARSE_FORMAT_COO     = 3, /* Coordinate - Structure of Arrays */
+    HIPSPARSE_FORMAT_COO_AOS = 4, /* Coordinate - Array of Structures */
 } hipsparseFormat_t;
 #endif
 #endif

--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -52,21 +52,21 @@
 #define DEPRECATED_CUDA_9000(warning)
 
 #ifdef __cplusplus
-    #ifndef __has_cpp_attribute
-        #define __has_cpp_attribute(X) 0
-    #endif
-    #define HIPSPARSE_HAS_DEPRECATED_MSG __has_cpp_attribute(deprecated) >= 201309L
+#ifndef __has_cpp_attribute
+#define __has_cpp_attribute(X) 0
+#endif
+#define HIPSPARSE_HAS_DEPRECATED_MSG __has_cpp_attribute(deprecated) >= 201309L
 #else
-    #ifndef __has_c_attribute
-        #define __has_c_attribute(X) 0
-    #endif
-    #define HIPSPARSE_HAS_DEPRECATED_MSG __has_c_attribute(deprecated) >= 201904L
+#ifndef __has_c_attribute
+#define __has_c_attribute(X) 0
+#endif
+#define HIPSPARSE_HAS_DEPRECATED_MSG __has_c_attribute(deprecated) >= 201904L
 #endif
 
 #if HIPSPARSE_HAS_DEPRECATED_MSG
-    #define HIPSPARSE_DEPRECATED_MSG(MSG) [[deprecated(MSG)]]
+#define HIPSPARSE_DEPRECATED_MSG(MSG) [[deprecated(MSG)]]
 #else
-    #define HIPSPARSE_DEPRECATED_MSG(MSG) HIPSPARSE_DEPRECATED // defined in hipsparse-export.h
+#define HIPSPARSE_DEPRECATED_MSG(MSG) HIPSPARSE_DEPRECATED // defined in hipsparse-export.h
 #endif
 /// \endcond
 
@@ -3129,22 +3129,6 @@ hipsparseStatus_t hipsparseZbsrsm2_solve(hipsparseHandle_t         handle,
                                          hipsparseSolvePolicy_t    policy,
                                          void*                     pBuffer);
 /**@}*/
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 #if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
 /*! \ingroup level3_module
@@ -6636,29 +6620,6 @@ hipsparseStatus_t hipsparseDpruneDense2csrByPercentage(hipsparseHandle_t        
                                                        void*                     buffer);
 /**@}*/
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 #if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
 /*! \ingroup conv_module
 *  \brief
@@ -8844,11 +8805,11 @@ typedef enum
 #if(CUDART_VERSION >= 10010)
 typedef enum
 {
-    HIPSPARSE_FORMAT_CSR     = 1, /* Compressed Sparse Row */
+    HIPSPARSE_FORMAT_CSR = 1, /* Compressed Sparse Row */
 #if(CUDART_VERSION >= 11021)
-    HIPSPARSE_FORMAT_CSC     = 2, /* Compressed Sparse Column */
+    HIPSPARSE_FORMAT_CSC = 2, /* Compressed Sparse Column */
 #endif
-    HIPSPARSE_FORMAT_COO     = 3 /* Coordinate - Structure of Arrays */
+    HIPSPARSE_FORMAT_COO = 3 /* Coordinate - Structure of Arrays */
 #if(CUDART_VERSION < 12000)
     ,
     HIPSPARSE_FORMAT_COO_AOS = 4 /* Coordinate - Array of Structures */

--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -9032,52 +9032,6 @@ typedef enum
     HIPSPARSE_CSRMM_ALG1     = 4
 } hipsparseSpMMAlg_t;
 #endif
-
-// #if(CUDART_VERSION >= 11021)
-// typedef enum
-// {
-//     HIPSPARSE_MM_ALG_DEFAULT        = 0,
-//     HIPSPARSE_COOMM_ALG1            = 1,
-//     HIPSPARSE_COOMM_ALG2            = 2,
-//     HIPSPARSE_COOMM_ALG3            = 3,
-//     HIPSPARSE_CSRMM_ALG1            = 4,
-//     HIPSPARSE_SPMM_ALG_DEFAULT      = 5,
-//     HIPSPARSE_SPMM_COO_ALG1         = 6,
-//     HIPSPARSE_SPMM_COO_ALG2         = 7,
-//     HIPSPARSE_SPMM_COO_ALG3         = 8,
-//     HIPSPARSE_SPMM_COO_ALG4         = 9,
-//     HIPSPARSE_SPMM_CSR_ALG1         = 10,
-//     HIPSPARSE_SPMM_CSR_ALG2         = 11,
-//     HIPSPARSE_SPMM_BLOCKED_ELL_ALG1 = 12,
-//     HIPSPARSE_SPMM_CSR_ALG3         = 13
-// } hipsparseSpMMAlg_t;
-// #elif(CUDART_VERSION >= 11003)
-// typedef enum
-// {
-//     HIPSPARSE_MM_ALG_DEFAULT        = 0,
-//     HIPSPARSE_COOMM_ALG1            = 1,
-//     HIPSPARSE_COOMM_ALG2            = 2,
-//     HIPSPARSE_COOMM_ALG3            = 3,
-//     HIPSPARSE_CSRMM_ALG1            = 4,
-//     HIPSPARSE_SPMM_ALG_DEFAULT      = 5,
-//     HIPSPARSE_SPMM_COO_ALG1         = 6,
-//     HIPSPARSE_SPMM_COO_ALG2         = 7,
-//     HIPSPARSE_SPMM_COO_ALG3         = 8,
-//     HIPSPARSE_SPMM_COO_ALG4         = 9,
-//     HIPSPARSE_SPMM_CSR_ALG1         = 10,
-//     HIPSPARSE_SPMM_CSR_ALG2         = 11,
-//     HIPSPARSE_SPMM_BLOCKED_ELL_ALG1 = 12
-// } hipsparseSpMMAlg_t;
-// #elif(CUDART_VERSION >= 10010)
-// typedef enum
-// {
-//     HIPSPARSE_MM_ALG_DEFAULT = 0,
-//     HIPSPARSE_COOMM_ALG1     = 1,
-//     HIPSPARSE_COOMM_ALG2     = 2,
-//     HIPSPARSE_COOMM_ALG3     = 3,
-//     HIPSPARSE_CSRMM_ALG1     = 4
-// } hipsparseSpMMAlg_t;
-// #endif
 #endif
 
 /*! \ingroup generic_module

--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -46,6 +46,7 @@
 #include <hip/hip_runtime.h>
 
 /// \cond DO_NOT_DOCUMENT
+#define DEPRECATED_CUDA_12000(warning)
 #define DEPRECATED_CUDA_11000(warning)
 #define DEPRECATED_CUDA_10000(warning)
 #define DEPRECATED_CUDA_9000(warning)
@@ -79,6 +80,9 @@
 #elif CUDART_VERSION < 12000
 #undef DEPRECATED_CUDA_11000
 #define DEPRECATED_CUDA_11000(warning) HIPSPARSE_DEPRECATED_MSG(warning)
+#elif CUDART_VERSION < 13000
+#undef DEPRECATED_CUDA_12000
+#define DEPRECATED_CUDA_12000(warning) HIPSPARSE_DEPRECATED_MSG(warning)
 #endif
 #endif
 
@@ -687,6 +691,7 @@ hipsparseStatus_t hipsparseCreateBsric02Info(bsric02Info_t* info);
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseDestroyBsric02Info(bsric02Info_t info);
 
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
 /* Info structures */
 /*! \ingroup aux_module
  *  \brief Create a csrsv2 info structure
@@ -696,6 +701,7 @@ hipsparseStatus_t hipsparseDestroyBsric02Info(bsric02Info_t info);
  *  that is gathered during the analysis routines available. It should be destroyed
  *  at the end using hipsparseDestroyCsrsv2Info().
  */
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseCreateCsrsv2Info(csrsv2Info_t* info);
 
@@ -705,6 +711,7 @@ hipsparseStatus_t hipsparseCreateCsrsv2Info(csrsv2Info_t* info);
  *  \details
  *  \p hipsparseDestroyCsrsv2Info destroys a csrsv2 info structure.
  */
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseDestroyCsrsv2Info(csrsv2Info_t info);
 
@@ -717,6 +724,7 @@ hipsparseStatus_t hipsparseDestroyCsrsv2Info(csrsv2Info_t info);
  *  that is gathered during the analysis routines available. It should be destroyed
  *  at the end using hipsparseDestroyCsrsm2Info().
  */
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseCreateCsrsm2Info(csrsm2Info_t* info);
 
@@ -726,8 +734,10 @@ hipsparseStatus_t hipsparseCreateCsrsm2Info(csrsm2Info_t* info);
  *  \details
  *  \p hipsparseDestroyCsrsm2Info destroys a csrsm2 info structure.
  */
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseDestroyCsrsm2Info(csrsm2Info_t info);
+#endif
 
 /* Info structures */
 /*! \ingroup aux_module
@@ -1366,6 +1376,7 @@ hipsparseStatus_t hipsparseZcsrmv(hipsparseHandle_t         handle,
 /**@}*/
 #endif
 
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
 /*! \ingroup level2_module
 *  \brief Sparse triangular solve using CSR storage format
 *
@@ -1382,10 +1393,13 @@ hipsparseStatus_t hipsparseZcsrmv(hipsparseHandle_t         handle,
 *  \note \p hipsparseXcsrsv2_zeroPivot is a blocking function. It might influence
 *  performance negatively.
 */
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t
     hipsparseXcsrsv2_zeroPivot(hipsparseHandle_t handle, csrsv2Info_t info, int* position);
+#endif
 
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
 /*! \ingroup level2_module
 *  \brief Sparse triangular solve using CSR storage format
 *
@@ -1397,6 +1411,7 @@ hipsparseStatus_t
 *  temporary storage buffer must be allocated by the user.
 */
 /**@{*/
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseScsrsv2_bufferSize(hipsparseHandle_t         handle,
                                               hipsparseOperation_t      transA,
@@ -1408,6 +1423,7 @@ hipsparseStatus_t hipsparseScsrsv2_bufferSize(hipsparseHandle_t         handle,
                                               const int*                csrSortedColIndA,
                                               csrsv2Info_t              info,
                                               int*                      pBufferSizeInBytes);
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseDcsrsv2_bufferSize(hipsparseHandle_t         handle,
                                               hipsparseOperation_t      transA,
@@ -1419,6 +1435,7 @@ hipsparseStatus_t hipsparseDcsrsv2_bufferSize(hipsparseHandle_t         handle,
                                               const int*                csrSortedColIndA,
                                               csrsv2Info_t              info,
                                               int*                      pBufferSizeInBytes);
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseCcsrsv2_bufferSize(hipsparseHandle_t         handle,
                                               hipsparseOperation_t      transA,
@@ -1430,6 +1447,7 @@ hipsparseStatus_t hipsparseCcsrsv2_bufferSize(hipsparseHandle_t         handle,
                                               const int*                csrSortedColIndA,
                                               csrsv2Info_t              info,
                                               int*                      pBufferSizeInBytes);
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseZcsrsv2_bufferSize(hipsparseHandle_t         handle,
                                               hipsparseOperation_t      transA,
@@ -1442,6 +1460,7 @@ hipsparseStatus_t hipsparseZcsrsv2_bufferSize(hipsparseHandle_t         handle,
                                               csrsv2Info_t              info,
                                               int*                      pBufferSizeInBytes);
 /**@}*/
+#endif
 
 /*! \ingroup level2_module
 *  \brief Sparse triangular solve using CSR storage format
@@ -1500,6 +1519,7 @@ hipsparseStatus_t hipsparseZcsrsv2_bufferSizeExt(hipsparseHandle_t         handl
                                                  size_t*                   pBufferSize);
 /**@}*/
 
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
 /*! \ingroup level2_module
 *  \brief Sparse triangular solve using CSR storage format
 *
@@ -1512,6 +1532,7 @@ hipsparseStatus_t hipsparseZcsrsv2_bufferSizeExt(hipsparseHandle_t         handl
 *  It may return before the actual computation has finished.
 */
 /**@{*/
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseScsrsv2_analysis(hipsparseHandle_t         handle,
                                             hipsparseOperation_t      transA,
@@ -1524,6 +1545,7 @@ hipsparseStatus_t hipsparseScsrsv2_analysis(hipsparseHandle_t         handle,
                                             csrsv2Info_t              info,
                                             hipsparseSolvePolicy_t    policy,
                                             void*                     pBuffer);
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseDcsrsv2_analysis(hipsparseHandle_t         handle,
                                             hipsparseOperation_t      transA,
@@ -1536,6 +1558,7 @@ hipsparseStatus_t hipsparseDcsrsv2_analysis(hipsparseHandle_t         handle,
                                             csrsv2Info_t              info,
                                             hipsparseSolvePolicy_t    policy,
                                             void*                     pBuffer);
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseCcsrsv2_analysis(hipsparseHandle_t         handle,
                                             hipsparseOperation_t      transA,
@@ -1548,6 +1571,7 @@ hipsparseStatus_t hipsparseCcsrsv2_analysis(hipsparseHandle_t         handle,
                                             csrsv2Info_t              info,
                                             hipsparseSolvePolicy_t    policy,
                                             void*                     pBuffer);
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseZcsrsv2_analysis(hipsparseHandle_t         handle,
                                             hipsparseOperation_t      transA,
@@ -1561,7 +1585,9 @@ hipsparseStatus_t hipsparseZcsrsv2_analysis(hipsparseHandle_t         handle,
                                             hipsparseSolvePolicy_t    policy,
                                             void*                     pBuffer);
 /**@}*/
+#endif
 
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
 /*! \ingroup level2_module
 *  \brief Sparse triangular solve using CSR storage format
 *
@@ -1605,6 +1631,7 @@ hipsparseStatus_t hipsparseZcsrsv2_analysis(hipsparseHandle_t         handle,
 *  \p trans == \ref HIPSPARSE_OPERATION_TRANSPOSE is supported.
 */
 /**@{*/
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseScsrsv2_solve(hipsparseHandle_t         handle,
                                          hipsparseOperation_t      transA,
@@ -1620,6 +1647,7 @@ hipsparseStatus_t hipsparseScsrsv2_solve(hipsparseHandle_t         handle,
                                          float*                    x,
                                          hipsparseSolvePolicy_t    policy,
                                          void*                     pBuffer);
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseDcsrsv2_solve(hipsparseHandle_t         handle,
                                          hipsparseOperation_t      transA,
@@ -1635,6 +1663,7 @@ hipsparseStatus_t hipsparseDcsrsv2_solve(hipsparseHandle_t         handle,
                                          double*                   x,
                                          hipsparseSolvePolicy_t    policy,
                                          void*                     pBuffer);
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseCcsrsv2_solve(hipsparseHandle_t         handle,
                                          hipsparseOperation_t      transA,
@@ -1650,6 +1679,7 @@ hipsparseStatus_t hipsparseCcsrsv2_solve(hipsparseHandle_t         handle,
                                          hipComplex*               x,
                                          hipsparseSolvePolicy_t    policy,
                                          void*                     pBuffer);
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseZcsrsv2_solve(hipsparseHandle_t         handle,
                                          hipsparseOperation_t      transA,
@@ -1666,6 +1696,7 @@ hipsparseStatus_t hipsparseZcsrsv2_solve(hipsparseHandle_t         handle,
                                          hipsparseSolvePolicy_t    policy,
                                          void*                     pBuffer);
 /**@}*/
+#endif
 
 #if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
 /*! \ingroup level2_module
@@ -3099,6 +3130,23 @@ hipsparseStatus_t hipsparseZbsrsm2_solve(hipsparseHandle_t         handle,
                                          void*                     pBuffer);
 /**@}*/
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
 /*! \ingroup level3_module
 *  \brief Sparse triangular system solve using CSR storage format
 *
@@ -3114,10 +3162,13 @@ hipsparseStatus_t hipsparseZbsrsm2_solve(hipsparseHandle_t         handle,
 *  \note \p hipsparseXcsrsm2_zeroPivot is a blocking function. It might influence
 *  performance negatively.
 */
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t
     hipsparseXcsrsm2_zeroPivot(hipsparseHandle_t handle, csrsm2Info_t info, int* position);
+#endif
 
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
 /*! \ingroup level3_module
 *  \brief Sparse triangular system solve using CSR storage format
 *
@@ -3127,6 +3178,7 @@ hipsparseStatus_t
 *  temporary storage buffer must be allocated by the user.
 */
 /**@{*/
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseScsrsm2_bufferSizeExt(hipsparseHandle_t         handle,
                                                  int                       algo,
@@ -3145,7 +3197,7 @@ hipsparseStatus_t hipsparseScsrsm2_bufferSizeExt(hipsparseHandle_t         handl
                                                  csrsm2Info_t              info,
                                                  hipsparseSolvePolicy_t    policy,
                                                  size_t*                   pBufferSize);
-
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseDcsrsm2_bufferSizeExt(hipsparseHandle_t         handle,
                                                  int                       algo,
@@ -3164,7 +3216,7 @@ hipsparseStatus_t hipsparseDcsrsm2_bufferSizeExt(hipsparseHandle_t         handl
                                                  csrsm2Info_t              info,
                                                  hipsparseSolvePolicy_t    policy,
                                                  size_t*                   pBufferSize);
-
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseCcsrsm2_bufferSizeExt(hipsparseHandle_t         handle,
                                                  int                       algo,
@@ -3183,7 +3235,7 @@ hipsparseStatus_t hipsparseCcsrsm2_bufferSizeExt(hipsparseHandle_t         handl
                                                  csrsm2Info_t              info,
                                                  hipsparseSolvePolicy_t    policy,
                                                  size_t*                   pBufferSize);
-
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseZcsrsm2_bufferSizeExt(hipsparseHandle_t         handle,
                                                  int                       algo,
@@ -3203,7 +3255,9 @@ hipsparseStatus_t hipsparseZcsrsm2_bufferSizeExt(hipsparseHandle_t         handl
                                                  hipsparseSolvePolicy_t    policy,
                                                  size_t*                   pBufferSize);
 /**@}*/
+#endif
 
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
 /*! \ingroup level3_module
 *  \brief Sparse triangular system solve using CSR storage format
 *
@@ -3218,6 +3272,7 @@ hipsparseStatus_t hipsparseZcsrsm2_bufferSizeExt(hipsparseHandle_t         handl
 *  It may return before the actual computation has finished.
 */
 /**@{*/
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseScsrsm2_analysis(hipsparseHandle_t         handle,
                                             int                       algo,
@@ -3236,7 +3291,7 @@ hipsparseStatus_t hipsparseScsrsm2_analysis(hipsparseHandle_t         handle,
                                             csrsm2Info_t              info,
                                             hipsparseSolvePolicy_t    policy,
                                             void*                     pBuffer);
-
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseDcsrsm2_analysis(hipsparseHandle_t         handle,
                                             int                       algo,
@@ -3255,7 +3310,7 @@ hipsparseStatus_t hipsparseDcsrsm2_analysis(hipsparseHandle_t         handle,
                                             csrsm2Info_t              info,
                                             hipsparseSolvePolicy_t    policy,
                                             void*                     pBuffer);
-
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseCcsrsm2_analysis(hipsparseHandle_t         handle,
                                             int                       algo,
@@ -3274,7 +3329,7 @@ hipsparseStatus_t hipsparseCcsrsm2_analysis(hipsparseHandle_t         handle,
                                             csrsm2Info_t              info,
                                             hipsparseSolvePolicy_t    policy,
                                             void*                     pBuffer);
-
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseZcsrsm2_analysis(hipsparseHandle_t         handle,
                                             int                       algo,
@@ -3294,7 +3349,9 @@ hipsparseStatus_t hipsparseZcsrsm2_analysis(hipsparseHandle_t         handle,
                                             hipsparseSolvePolicy_t    policy,
                                             void*                     pBuffer);
 /**@}*/
+#endif
 
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
 /*! \ingroup level3_module
 *  \brief Sparse triangular system solve using CSR storage format
 *
@@ -3357,6 +3414,7 @@ hipsparseStatus_t hipsparseZcsrsm2_analysis(hipsparseHandle_t         handle,
 *  \p trans_B != \ref HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE is supported.
 */
 /**@{*/
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseScsrsm2_solve(hipsparseHandle_t         handle,
                                          int                       algo,
@@ -3375,7 +3433,7 @@ hipsparseStatus_t hipsparseScsrsm2_solve(hipsparseHandle_t         handle,
                                          csrsm2Info_t              info,
                                          hipsparseSolvePolicy_t    policy,
                                          void*                     pBuffer);
-
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseDcsrsm2_solve(hipsparseHandle_t         handle,
                                          int                       algo,
@@ -3394,7 +3452,7 @@ hipsparseStatus_t hipsparseDcsrsm2_solve(hipsparseHandle_t         handle,
                                          csrsm2Info_t              info,
                                          hipsparseSolvePolicy_t    policy,
                                          void*                     pBuffer);
-
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseCcsrsm2_solve(hipsparseHandle_t         handle,
                                          int                       algo,
@@ -3413,7 +3471,7 @@ hipsparseStatus_t hipsparseCcsrsm2_solve(hipsparseHandle_t         handle,
                                          csrsm2Info_t              info,
                                          hipsparseSolvePolicy_t    policy,
                                          void*                     pBuffer);
-
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseZcsrsm2_solve(hipsparseHandle_t         handle,
                                          int                       algo,
@@ -3433,6 +3491,7 @@ hipsparseStatus_t hipsparseZcsrsm2_solve(hipsparseHandle_t         handle,
                                          hipsparseSolvePolicy_t    policy,
                                          void*                     pBuffer);
 /**@}*/
+#endif
 
 #if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
 /*! \ingroup level3_module
@@ -4227,7 +4286,9 @@ hipsparseStatus_t hipsparseZcsrgemm2_bufferSizeExt(hipsparseHandle_t         han
                                                    csrgemm2Info_t            info,
                                                    size_t*                   pBufferSizeInBytes);
 /**@}*/
+#endif
 
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
 /*! \ingroup extra_module
 *  \brief Sparse matrix sparse matrix multiplication using CSR storage format
 *
@@ -4272,7 +4333,9 @@ hipsparseStatus_t hipsparseXcsrgemm2Nnz(hipsparseHandle_t         handle,
                                         int*                      nnzTotalDevHostPtr,
                                         const csrgemm2Info_t      info,
                                         void*                     pBuffer);
+#endif
 
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
 /*! \ingroup extra_module
 *  \brief Sparse matrix sparse matrix multiplication using CSR storage format
 *
@@ -6573,6 +6636,30 @@ hipsparseStatus_t hipsparseDpruneDense2csrByPercentage(hipsparseHandle_t        
                                                        void*                     buffer);
 /**@}*/
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
 /*! \ingroup conv_module
 *  \brief
 *
@@ -6581,6 +6668,7 @@ hipsparseStatus_t hipsparseDpruneDense2csrByPercentage(hipsparseHandle_t        
 *  It is executed asynchronously with respect to the host and may return control to the application on the host before the entire result is ready.
 */
 /**@{*/
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseSdense2csc(hipsparseHandle_t         handle,
                                       int                       m,
@@ -6592,7 +6680,7 @@ hipsparseStatus_t hipsparseSdense2csc(hipsparseHandle_t         handle,
                                       float*                    csc_val,
                                       int*                      csc_row_ind,
                                       int*                      csc_col_ptr);
-
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseDdense2csc(hipsparseHandle_t         handle,
                                       int                       m,
@@ -6604,6 +6692,7 @@ hipsparseStatus_t hipsparseDdense2csc(hipsparseHandle_t         handle,
                                       double*                   csc_val,
                                       int*                      csc_row_ind,
                                       int*                      csc_col_ptr);
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseCdense2csc(hipsparseHandle_t         handle,
                                       int                       m,
@@ -6615,7 +6704,7 @@ hipsparseStatus_t hipsparseCdense2csc(hipsparseHandle_t         handle,
                                       hipComplex*               csc_val,
                                       int*                      csc_row_ind,
                                       int*                      csc_col_ptr);
-
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseZdense2csc(hipsparseHandle_t         handle,
                                       int                       m,
@@ -6628,13 +6717,16 @@ hipsparseStatus_t hipsparseZdense2csc(hipsparseHandle_t         handle,
                                       int*                      csc_row_ind,
                                       int*                      csc_col_ptr);
 /**@}*/
+#endif
 
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
 /*! \ingroup conv_module
 *  \brief
 *  This function converts the sparse matrix in CSR format into a dense matrix.
 *  It is executed asynchronously with respect to the host and may return control to the application on the host before the entire result is ready.
 */
 /**@{*/
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseScsr2dense(hipsparseHandle_t         handle,
                                       int                       m,
@@ -6645,7 +6737,7 @@ hipsparseStatus_t hipsparseScsr2dense(hipsparseHandle_t         handle,
                                       const int*                csr_col_ind,
                                       float*                    A,
                                       int                       ld);
-
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseDcsr2dense(hipsparseHandle_t         handle,
                                       int                       m,
@@ -6656,7 +6748,7 @@ hipsparseStatus_t hipsparseDcsr2dense(hipsparseHandle_t         handle,
                                       const int*                csr_col_ind,
                                       double*                   A,
                                       int                       ld);
-
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseCcsr2dense(hipsparseHandle_t         handle,
                                       int                       m,
@@ -6667,7 +6759,7 @@ hipsparseStatus_t hipsparseCcsr2dense(hipsparseHandle_t         handle,
                                       const int*                csr_col_ind,
                                       hipComplex*               A,
                                       int                       ld);
-
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseZcsr2dense(hipsparseHandle_t         handle,
                                       int                       m,
@@ -6679,13 +6771,16 @@ hipsparseStatus_t hipsparseZcsr2dense(hipsparseHandle_t         handle,
                                       hipDoubleComplex*         A,
                                       int                       ld);
 /**@}*/
+#endif
 
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
 /*! \ingroup conv_module
 *  \brief
 *  This function converts the sparse matrix in CSC format into a dense matrix.
 *  It is executed asynchronously with respect to the host and may return control to the application on the host before the entire result is ready.
 */
 /**@{*/
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseScsc2dense(hipsparseHandle_t         handle,
                                       int                       m,
@@ -6696,7 +6791,7 @@ hipsparseStatus_t hipsparseScsc2dense(hipsparseHandle_t         handle,
                                       const int*                csc_col_ptr,
                                       float*                    A,
                                       int                       ld);
-
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseDcsc2dense(hipsparseHandle_t         handle,
                                       int                       m,
@@ -6707,7 +6802,7 @@ hipsparseStatus_t hipsparseDcsc2dense(hipsparseHandle_t         handle,
                                       const int*                csc_col_ptr,
                                       double*                   A,
                                       int                       ld);
-
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseCcsc2dense(hipsparseHandle_t         handle,
                                       int                       m,
@@ -6718,7 +6813,7 @@ hipsparseStatus_t hipsparseCcsc2dense(hipsparseHandle_t         handle,
                                       const int*                csc_col_ptr,
                                       hipComplex*               A,
                                       int                       ld);
-
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseZcsc2dense(hipsparseHandle_t         handle,
                                       int                       m,
@@ -6730,6 +6825,7 @@ hipsparseStatus_t hipsparseZcsc2dense(hipsparseHandle_t         handle,
                                       hipDoubleComplex*         A,
                                       int                       ld);
 /**@}*/
+#endif
 
 /*! \ingroup conv_module
 *  \brief
@@ -8752,8 +8848,11 @@ typedef enum
 #if(CUDART_VERSION >= 11021)
     HIPSPARSE_FORMAT_CSC     = 2, /* Compressed Sparse Column */
 #endif
-    HIPSPARSE_FORMAT_COO     = 3, /* Coordinate - Structure of Arrays */
+    HIPSPARSE_FORMAT_COO     = 3 /* Coordinate - Structure of Arrays */
+#if(CUDART_VERSION < 12000)
+    ,
     HIPSPARSE_FORMAT_COO_AOS = 4 /* Coordinate - Array of Structures */
+#endif
 #if(CUDART_VERSION >= 11021)
     ,
     HIPSPARSE_FORMAT_BLOCKED_ELL = 5 /* Blocked ELL */
@@ -9140,7 +9239,8 @@ hipsparseStatus_t hipsparseCreateCoo(hipsparseSpMatDescr_t* spMatDescr,
 *  \p hipsparseCreateCooAoS creates a sparse COO (AoS) matrix descriptor. It should be
 *  destroyed at the end using \p hipsparseDestroySpMat.
 */
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 10010)
+#if(!defined(CUDART_VERSION) || (CUDART_VERSION >= 10010 && CUDART_VERSION < 12000))
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseCreateCooAoS(hipsparseSpMatDescr_t* spMatDescr,
                                         int64_t                rows,
@@ -9250,7 +9350,8 @@ hipsparseStatus_t hipsparseCooGet(const hipsparseSpMatDescr_t spMatDescr,
 *  \details
 *  \p hipsparseCooAoSGet gets the fields of the sparse COO (AoS) matrix descriptor
 */
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 10010)
+#if(!defined(CUDART_VERSION) || (CUDART_VERSION >= 10010 && CUDART_VERSION < 12000))
+DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseCooAoSGet(const hipsparseSpMatDescr_t spMatDescr,
                                      int64_t*                    rows,
@@ -9397,7 +9498,7 @@ hipsparseStatus_t hipsparseSpMatGetStridedBatch(hipsparseSpMatDescr_t spMatDescr
 /*! \ingroup generic_module
 *  \brief Description: Set the batch count of the sparse matrix
 */
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 10010)
+#if(!defined(CUDART_VERSION) || (CUDART_VERSION >= 10010 && CUDART_VERSION < 12000))
 DEPRECATED_CUDA_11000("The routine will be removed in CUDA 12")
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseSpMatSetStridedBatch(hipsparseSpMatDescr_t spMatDescr, int batchCount);

--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -6960,15 +6960,15 @@ hipsparseStatus_t hipsparseZcsr2csc(hipsparseHandle_t       handle,
 typedef enum
 {
     HIPSPARSE_CSR2CSC_ALG_DEFAULT = 0,
-    HIPSPARSE_CSR2CSC_ALG1 = 1,
-    HIPSPARSE_CSR2CSC_ALG2 = 2
+    HIPSPARSE_CSR2CSC_ALG1        = 1,
+    HIPSPARSE_CSR2CSC_ALG2        = 2
 } hipsparseCsr2CscAlg_t;
 #else
 #if(CUDART_VERSION >= 12000)
 typedef enum
 {
     HIPSPARSE_CSR2CSC_ALG_DEFAULT = 1,
-    HIPSPARSE_CSR2CSC_ALG1 = 2
+    HIPSPARSE_CSR2CSC_ALG1        = 2
 } hipsparseCsr2CscAlg_t;
 #elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
 typedef enum

--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -6956,12 +6956,27 @@ hipsparseStatus_t hipsparseZcsr2csc(hipsparseHandle_t       handle,
 /**@}*/
 #endif
 
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 10010)
+#if(!defined(CUDART_VERSION))
+typedef enum
+{
+    HIPSPARSE_CSR2CSC_ALG_DEFAULT = 0,
+    HIPSPARSE_CSR2CSC_ALG1 = 1,
+    HIPSPARSE_CSR2CSC_ALG2 = 2
+} hipsparseCsr2CscAlg_t;
+#else
+#if(CUDART_VERSION >= 12000)
+typedef enum
+{
+    HIPSPARSE_CSR2CSC_ALG_DEFAULT = 1,
+    HIPSPARSE_CSR2CSC_ALG1 = 2
+} hipsparseCsr2CscAlg_t;
+#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
 typedef enum
 {
     HIPSPARSE_CSR2CSC_ALG1 = 1,
     HIPSPARSE_CSR2CSC_ALG2 = 2
 } hipsparseCsr2CscAlg_t;
+#endif
 #endif
 
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 10010)
@@ -8893,7 +8908,16 @@ typedef enum
     HIPSPARSE_SPMV_CSR_ALG2    = 8
 } hipsparseSpMVAlg_t;
 #else
-#if(CUDART_VERSION >= 11021)
+#if(CUDART_VERSION >= 12000)
+typedef enum
+{
+    HIPSPARSE_SPMV_ALG_DEFAULT = 4,
+    HIPSPARSE_SPMV_COO_ALG1    = 5,
+    HIPSPARSE_SPMV_COO_ALG2    = 6,
+    HIPSPARSE_SPMV_CSR_ALG1    = 7,
+    HIPSPARSE_SPMV_CSR_ALG2    = 8
+} hipsparseSpMVAlg_t;
+#elif(CUDART_VERSION >= 11021 && CUDART_VERSION < 12000)
 typedef enum
 {
     HIPSPARSE_MV_ALG_DEFAULT   = 0,
@@ -8906,7 +8930,7 @@ typedef enum
     HIPSPARSE_SPMV_CSR_ALG1    = 7,
     HIPSPARSE_SPMV_CSR_ALG2    = 8
 } hipsparseSpMVAlg_t;
-#elif(CUDART_VERSION >= 10010)
+#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 11021)
 typedef enum
 {
     HIPSPARSE_MV_ALG_DEFAULT = 0,
@@ -8943,7 +8967,20 @@ typedef enum
     HIPSPARSE_SPMM_CSR_ALG3         = 13
 } hipsparseSpMMAlg_t;
 #else
-#if(CUDART_VERSION >= 11021)
+#if(CUDART_VERSION >= 12000)
+typedef enum
+{
+    HIPSPARSE_SPMM_ALG_DEFAULT      = 5,
+    HIPSPARSE_SPMM_COO_ALG1         = 6,
+    HIPSPARSE_SPMM_COO_ALG2         = 7,
+    HIPSPARSE_SPMM_COO_ALG3         = 8,
+    HIPSPARSE_SPMM_COO_ALG4         = 9,
+    HIPSPARSE_SPMM_CSR_ALG1         = 10,
+    HIPSPARSE_SPMM_CSR_ALG2         = 11,
+    HIPSPARSE_SPMM_BLOCKED_ELL_ALG1 = 12,
+    HIPSPARSE_SPMM_CSR_ALG3         = 13
+} hipsparseSpMMAlg_t;
+#elif(CUDART_VERSION >= 11021 && CUDART_VERSION < 12000)
 typedef enum
 {
     HIPSPARSE_MM_ALG_DEFAULT        = 0,
@@ -8961,7 +8998,7 @@ typedef enum
     HIPSPARSE_SPMM_BLOCKED_ELL_ALG1 = 12,
     HIPSPARSE_SPMM_CSR_ALG3         = 13
 } hipsparseSpMMAlg_t;
-#elif(CUDART_VERSION >= 11003)
+#elif(CUDART_VERSION >= 11003 && CUDART_VERSION < 11021)
 typedef enum
 {
     HIPSPARSE_MM_ALG_DEFAULT        = 0,
@@ -8978,7 +9015,7 @@ typedef enum
     HIPSPARSE_SPMM_CSR_ALG2         = 11,
     HIPSPARSE_SPMM_BLOCKED_ELL_ALG1 = 12
 } hipsparseSpMMAlg_t;
-#elif(CUDART_VERSION >= 10010)
+#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 11003)
 typedef enum
 {
     HIPSPARSE_MM_ALG_DEFAULT = 0,
@@ -8988,6 +9025,52 @@ typedef enum
     HIPSPARSE_CSRMM_ALG1     = 4
 } hipsparseSpMMAlg_t;
 #endif
+
+// #if(CUDART_VERSION >= 11021)
+// typedef enum
+// {
+//     HIPSPARSE_MM_ALG_DEFAULT        = 0,
+//     HIPSPARSE_COOMM_ALG1            = 1,
+//     HIPSPARSE_COOMM_ALG2            = 2,
+//     HIPSPARSE_COOMM_ALG3            = 3,
+//     HIPSPARSE_CSRMM_ALG1            = 4,
+//     HIPSPARSE_SPMM_ALG_DEFAULT      = 5,
+//     HIPSPARSE_SPMM_COO_ALG1         = 6,
+//     HIPSPARSE_SPMM_COO_ALG2         = 7,
+//     HIPSPARSE_SPMM_COO_ALG3         = 8,
+//     HIPSPARSE_SPMM_COO_ALG4         = 9,
+//     HIPSPARSE_SPMM_CSR_ALG1         = 10,
+//     HIPSPARSE_SPMM_CSR_ALG2         = 11,
+//     HIPSPARSE_SPMM_BLOCKED_ELL_ALG1 = 12,
+//     HIPSPARSE_SPMM_CSR_ALG3         = 13
+// } hipsparseSpMMAlg_t;
+// #elif(CUDART_VERSION >= 11003)
+// typedef enum
+// {
+//     HIPSPARSE_MM_ALG_DEFAULT        = 0,
+//     HIPSPARSE_COOMM_ALG1            = 1,
+//     HIPSPARSE_COOMM_ALG2            = 2,
+//     HIPSPARSE_COOMM_ALG3            = 3,
+//     HIPSPARSE_CSRMM_ALG1            = 4,
+//     HIPSPARSE_SPMM_ALG_DEFAULT      = 5,
+//     HIPSPARSE_SPMM_COO_ALG1         = 6,
+//     HIPSPARSE_SPMM_COO_ALG2         = 7,
+//     HIPSPARSE_SPMM_COO_ALG3         = 8,
+//     HIPSPARSE_SPMM_COO_ALG4         = 9,
+//     HIPSPARSE_SPMM_CSR_ALG1         = 10,
+//     HIPSPARSE_SPMM_CSR_ALG2         = 11,
+//     HIPSPARSE_SPMM_BLOCKED_ELL_ALG1 = 12
+// } hipsparseSpMMAlg_t;
+// #elif(CUDART_VERSION >= 10010)
+// typedef enum
+// {
+//     HIPSPARSE_MM_ALG_DEFAULT = 0,
+//     HIPSPARSE_COOMM_ALG1     = 1,
+//     HIPSPARSE_COOMM_ALG2     = 2,
+//     HIPSPARSE_COOMM_ALG3     = 3,
+//     HIPSPARSE_CSRMM_ALG1     = 4
+// } hipsparseSpMMAlg_t;
+// #endif
 #endif
 
 /*! \ingroup generic_module

--- a/library/src/nvcc_detail/hipsparse.cpp
+++ b/library/src/nvcc_detail/hipsparse.cpp
@@ -10245,52 +10245,106 @@ hipsparseStatus_t hipsparseZcsr2csru(hipsparseHandle_t         handle,
 }
 
 /* Generic API */
-#if(CUDART_VERSION >= 10010)
+#if(CUDART_VERSION >= 12000)
 cusparseFormat_t hipFormatToCudaFormat(hipsparseFormat_t format)
 {
     switch(format)
     {
     case HIPSPARSE_FORMAT_CSR:
         return CUSPARSE_FORMAT_CSR;
-#if(CUDART_VERSION >= 11021)
     case HIPSPARSE_FORMAT_CSC:
         return CUSPARSE_FORMAT_CSC;
-#endif
     case HIPSPARSE_FORMAT_COO:
         return CUSPARSE_FORMAT_COO;
-#if(CUDART_VERSION < 12000)
-    case HIPSPARSE_FORMAT_COO_AOS:
-        return CUSPARSE_FORMAT_COO_AOS;
-#endif
-#if(CUDART_VERSION >= 11021)
     case HIPSPARSE_FORMAT_BLOCKED_ELL:
         return CUSPARSE_FORMAT_BLOCKED_ELL;
-#endif
     default:
         throw "Non existent hipsparseFormat_t";
     }
 }
+#elif(CUDART_VERSION >= 11021 && CUDART_VERSION < 12000)
+cusparseFormat_t hipFormatToCudaFormat(hipsparseFormat_t format)
+{
+    switch(format)
+    {
+    case HIPSPARSE_FORMAT_CSR:
+        return CUSPARSE_FORMAT_CSR;
+    case HIPSPARSE_FORMAT_CSC:
+        return CUSPARSE_FORMAT_CSC;
+    case HIPSPARSE_FORMAT_COO:
+        return CUSPARSE_FORMAT_COO;
+    case HIPSPARSE_FORMAT_COO_AOS:
+        return CUSPARSE_FORMAT_COO_AOS;
+    case HIPSPARSE_FORMAT_BLOCKED_ELL:
+        return CUSPARSE_FORMAT_BLOCKED_ELL;
+    default:
+        throw "Non existent hipsparseFormat_t";
+    }
+}
+#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 11021)
+cusparseFormat_t hipFormatToCudaFormat(hipsparseFormat_t format)
+{
+    switch(format)
+    {
+    case HIPSPARSE_FORMAT_CSR:
+        return CUSPARSE_FORMAT_CSR;
+    case HIPSPARSE_FORMAT_COO:
+        return CUSPARSE_FORMAT_COO;
+    case HIPSPARSE_FORMAT_COO_AOS:
+        return CUSPARSE_FORMAT_COO_AOS;
+    default:
+        throw "Non existent hipsparseFormat_t";
+    }
+}
+#endif
 
+#if(CUDART_VERSION >= 12000)
 hipsparseFormat_t CudaFormatToHIPFormat(cusparseFormat_t format)
 {
     switch(format)
     {
     case CUSPARSE_FORMAT_CSR:
         return HIPSPARSE_FORMAT_CSR;
-#if(CUDART_VERSION >= 11021)
     case CUSPARSE_FORMAT_CSC:
         return HIPSPARSE_FORMAT_CSC;
-#endif
     case CUSPARSE_FORMAT_COO:
         return HIPSPARSE_FORMAT_COO;
-#if(CUDART_VERSION < 12000)
-    case CUSPARSE_FORMAT_COO_AOS:
-        return HIPSPARSE_FORMAT_COO_AOS;
-#endif
-#if(CUDART_VERSION >= 11021)
     case CUSPARSE_FORMAT_BLOCKED_ELL:
         return HIPSPARSE_FORMAT_BLOCKED_ELL;
-#endif
+    default:
+        throw "Non existent cusparseFormat_t";
+    }
+}
+#elif(CUDART_VERSION >= 11021 && CUDART_VERSION < 12000)
+hipsparseFormat_t CudaFormatToHIPFormat(cusparseFormat_t format)
+{
+    switch(format)
+    {
+    case CUSPARSE_FORMAT_CSR:
+        return HIPSPARSE_FORMAT_CSR;
+    case CUSPARSE_FORMAT_CSC:
+        return HIPSPARSE_FORMAT_CSC;
+    case CUSPARSE_FORMAT_COO:
+        return HIPSPARSE_FORMAT_COO;
+    case CUSPARSE_FORMAT_COO_AOS:
+        return HIPSPARSE_FORMAT_COO_AOS;
+    case CUSPARSE_FORMAT_BLOCKED_ELL:
+        return HIPSPARSE_FORMAT_BLOCKED_ELL;
+    default:
+        throw "Non existent cusparseFormat_t";
+    }
+}
+#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 11021)
+hipsparseFormat_t CudaFormatToHIPFormat(cusparseFormat_t format)
+{
+    switch(format)
+    {
+    case CUSPARSE_FORMAT_CSR:
+        return HIPSPARSE_FORMAT_CSR;
+    case CUSPARSE_FORMAT_COO:
+        return HIPSPARSE_FORMAT_COO;
+    case CUSPARSE_FORMAT_COO_AOS:
+        return HIPSPARSE_FORMAT_COO_AOS;
     default:
         throw "Non existent cusparseFormat_t";
     }

--- a/library/src/nvcc_detail/hipsparse.cpp
+++ b/library/src/nvcc_detail/hipsparse.cpp
@@ -604,6 +604,10 @@ hipsparseStatus_t hipsparseDestroyBsrilu02Info(bsrilu02Info_t info)
     return hipCUSPARSEStatusToHIPStatus(cusparseDestroyBsrilu02Info((bsrilu02Info_t)info));
 }
 
+
+
+
+#if CUDART_VERSION < 12000
 hipsparseStatus_t hipsparseCreateCsrsv2Info(csrsv2Info_t* info)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseCreateCsrsv2Info((csrsv2Info_t*)info));
@@ -614,16 +618,6 @@ hipsparseStatus_t hipsparseDestroyCsrsv2Info(csrsv2Info_t info)
     return hipCUSPARSEStatusToHIPStatus(cusparseDestroyCsrsv2Info((csrsv2Info_t)info));
 }
 
-hipsparseStatus_t hipsparseCreateColorInfo(hipsparseColorInfo_t* info)
-{
-    return hipCUSPARSEStatusToHIPStatus(cusparseCreateColorInfo((cusparseColorInfo_t*)info));
-}
-
-hipsparseStatus_t hipsparseDestroyColorInfo(hipsparseColorInfo_t info)
-{
-    return hipCUSPARSEStatusToHIPStatus(cusparseDestroyColorInfo((cusparseColorInfo_t)info));
-}
-
 hipsparseStatus_t hipsparseCreateCsrsm2Info(csrsm2Info_t* info)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseCreateCsrsm2Info((csrsm2Info_t*)info));
@@ -632,6 +626,22 @@ hipsparseStatus_t hipsparseCreateCsrsm2Info(csrsm2Info_t* info)
 hipsparseStatus_t hipsparseDestroyCsrsm2Info(csrsm2Info_t info)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseDestroyCsrsm2Info((csrsm2Info_t)info));
+}
+#endif
+
+
+
+
+
+
+hipsparseStatus_t hipsparseCreateColorInfo(hipsparseColorInfo_t* info)
+{
+    return hipCUSPARSEStatusToHIPStatus(cusparseCreateColorInfo((cusparseColorInfo_t*)info));
+}
+
+hipsparseStatus_t hipsparseDestroyColorInfo(hipsparseColorInfo_t info)
+{
+    return hipCUSPARSEStatusToHIPStatus(cusparseDestroyColorInfo((cusparseColorInfo_t)info));
 }
 
 hipsparseStatus_t hipsparseCreateCsrilu02Info(csrilu02Info_t* info)
@@ -1170,13 +1180,16 @@ hipsparseStatus_t hipsparseZcsrmv(hipsparseHandle_t         handle,
 }
 #endif
 
+#if CUDART_VERSION < 12000
 hipsparseStatus_t
     hipsparseXcsrsv2_zeroPivot(hipsparseHandle_t handle, csrsv2Info_t info, int* position)
 {
     return hipCUSPARSEStatusToHIPStatus(
         cusparseXcsrsv2_zeroPivot((cusparseHandle_t)handle, (csrsv2Info_t)info, position));
 }
+#endif
 
+#if CUDART_VERSION < 12000
 hipsparseStatus_t hipsparseScsrsv2_bufferSize(hipsparseHandle_t         handle,
                                               hipsparseOperation_t      transA,
                                               int                       m,
@@ -1272,6 +1285,7 @@ hipsparseStatus_t hipsparseZcsrsv2_bufferSize(hipsparseHandle_t         handle,
                                    (csrsv2Info_t)info,
                                    pBufferSizeInBytes));
 }
+#endif
 
 hipsparseStatus_t hipsparseScsrsv2_bufferSizeExt(hipsparseHandle_t         handle,
                                                  hipsparseOperation_t      transA,
@@ -1329,6 +1343,7 @@ hipsparseStatus_t hipsparseZcsrsv2_bufferSizeExt(hipsparseHandle_t         handl
     return HIPSPARSE_STATUS_INTERNAL_ERROR;
 }
 
+#if CUDART_VERSION < 12000
 hipsparseStatus_t hipsparseScsrsv2_analysis(hipsparseHandle_t         handle,
                                             hipsparseOperation_t      transA,
                                             int                       m,
@@ -1432,7 +1447,9 @@ hipsparseStatus_t hipsparseZcsrsv2_analysis(hipsparseHandle_t         handle,
                                  hipPolicyToCudaPolicy(policy),
                                  pBuffer));
 }
+#endif
 
+#if CUDART_VERSION < 12000
 hipsparseStatus_t hipsparseScsrsv2_solve(hipsparseHandle_t         handle,
                                          hipsparseOperation_t      transA,
                                          int                       m,
@@ -1556,6 +1573,7 @@ hipsparseStatus_t hipsparseZcsrsv2_solve(hipsparseHandle_t         handle,
                                                               hipPolicyToCudaPolicy(policy),
                                                               pBuffer));
 }
+#endif
 
 #if CUDART_VERSION < 11000
 hipsparseStatus_t hipsparseShybmv(hipsparseHandle_t         handle,
@@ -3417,13 +3435,16 @@ hipsparseStatus_t hipsparseZbsrsm2_solve(hipsparseHandle_t         handle,
                                                               pBuffer));
 }
 
+#if CUDART_VERSION < 12000
 hipsparseStatus_t
     hipsparseXcsrsm2_zeroPivot(hipsparseHandle_t handle, csrsm2Info_t info, int* position)
 {
     return hipCUSPARSEStatusToHIPStatus(
         cusparseXcsrsm2_zeroPivot((cusparseHandle_t)handle, (csrsm2Info_t)info, position));
 }
+#endif
 
+#if CUDART_VERSION < 12000
 hipsparseStatus_t hipsparseScsrsm2_bufferSizeExt(hipsparseHandle_t         handle,
                                                  int                       algo,
                                                  hipsparseOperation_t      transA,
@@ -3575,7 +3596,9 @@ hipsparseStatus_t hipsparseZcsrsm2_bufferSizeExt(hipsparseHandle_t         handl
                                       hipPolicyToCudaPolicy(policy),
                                       pBufferSize));
 }
+#endif
 
+#if CUDART_VERSION < 12000
 hipsparseStatus_t hipsparseScsrsm2_analysis(hipsparseHandle_t         handle,
                                             int                       algo,
                                             hipsparseOperation_t      transA,
@@ -3727,7 +3750,9 @@ hipsparseStatus_t hipsparseZcsrsm2_analysis(hipsparseHandle_t         handle,
                                  hipPolicyToCudaPolicy(policy),
                                  pBuffer));
 }
+#endif
 
+#if CUDART_VERSION < 12000
 hipsparseStatus_t hipsparseScsrsm2_solve(hipsparseHandle_t         handle,
                                          int                       algo,
                                          hipsparseOperation_t      transA,
@@ -3875,6 +3900,7 @@ hipsparseStatus_t hipsparseZcsrsm2_solve(hipsparseHandle_t         handle,
                                                               hipPolicyToCudaPolicy(policy),
                                                               pBuffer));
 }
+#endif
 
 #if CUDART_VERSION < 12000
 hipsparseStatus_t hipsparseSgemmi(hipsparseHandle_t handle,
@@ -6741,6 +6767,7 @@ hipsparseStatus_t hipsparseZnnz(hipsparseHandle_t         handle,
                                                      nnzTotalDevHostPtr));
 }
 
+#if CUDART_VERSION < 12000
 hipsparseStatus_t hipsparseSdense2csr(hipsparseHandle_t         handle,
                                       int                       m,
                                       int                       n,
@@ -6832,6 +6859,7 @@ hipsparseStatus_t hipsparseZdense2csr(hipsparseHandle_t         handle,
                                                            csrRowPtr,
                                                            csrColInd));
 }
+#endif
 
 hipsparseStatus_t hipsparseSpruneDense2csr_bufferSize(hipsparseHandle_t         handle,
                                                       int                       m,
@@ -7255,6 +7283,7 @@ hipsparseStatus_t hipsparseDpruneDense2csrByPercentage(hipsparseHandle_t        
                                             buffer));
 }
 
+#if CUDART_VERSION < 12000
 hipsparseStatus_t hipsparseSdense2csc(hipsparseHandle_t         handle,
                                       int                       m,
                                       int                       n,
@@ -7346,7 +7375,9 @@ hipsparseStatus_t hipsparseZdense2csc(hipsparseHandle_t         handle,
                                                            cscRowInd,
                                                            cscColPtr));
 }
+#endif
 
+#if CUDART_VERSION < 12000
 hipsparseStatus_t hipsparseScsr2dense(hipsparseHandle_t         handle,
                                       int                       m,
                                       int                       n,
@@ -7430,7 +7461,9 @@ hipsparseStatus_t hipsparseZcsr2dense(hipsparseHandle_t         handle,
                                                            (cuDoubleComplex*)A,
                                                            ld));
 }
+#endif
 
+#if CUDART_VERSION < 12000
 hipsparseStatus_t hipsparseScsc2dense(hipsparseHandle_t         handle,
                                       int                       m,
                                       int                       n,
@@ -7514,6 +7547,7 @@ hipsparseStatus_t hipsparseZcsc2dense(hipsparseHandle_t         handle,
                                                            (cuDoubleComplex*)A,
                                                            ld));
 }
+#endif
 
 hipsparseStatus_t hipsparseSgebsr2gebsc_bufferSize(hipsparseHandle_t handle,
                                                    int               mb,
@@ -10697,7 +10731,7 @@ hipsparseStatus_t hipsparseCreateCoo(hipsparseSpMatDescr_t* spMatDescr,
 }
 #endif
 
-#if(CUDART_VERSION >= 10010)
+#if(CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
 hipsparseStatus_t hipsparseCreateCooAoS(hipsparseSpMatDescr_t* spMatDescr,
                                         int64_t                rows,
                                         int64_t                cols,
@@ -10845,7 +10879,7 @@ hipsparseStatus_t hipsparseCooGet(const hipsparseSpMatDescr_t spMatDescr,
 }
 #endif
 
-#if(CUDART_VERSION >= 10010)
+#if(CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
 hipsparseStatus_t hipsparseCooAoSGet(const hipsparseSpMatDescr_t spMatDescr,
                                      int64_t*                    rows,
                                      int64_t*                    cols,
@@ -11034,7 +11068,7 @@ hipsparseStatus_t hipsparseSpMatGetStridedBatch(hipsparseSpMatDescr_t spMatDescr
 }
 #endif
 
-#if(CUDART_VERSION >= 10010)
+#if(CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
 hipsparseStatus_t hipsparseSpMatSetStridedBatch(hipsparseSpMatDescr_t spMatDescr, int batchCount)
 {
     return hipCUSPARSEStatusToHIPStatus(

--- a/library/src/nvcc_detail/hipsparse.cpp
+++ b/library/src/nvcc_detail/hipsparse.cpp
@@ -604,9 +604,6 @@ hipsparseStatus_t hipsparseDestroyBsrilu02Info(bsrilu02Info_t info)
     return hipCUSPARSEStatusToHIPStatus(cusparseDestroyBsrilu02Info((bsrilu02Info_t)info));
 }
 
-
-
-
 #if CUDART_VERSION < 12000
 hipsparseStatus_t hipsparseCreateCsrsv2Info(csrsv2Info_t* info)
 {
@@ -628,11 +625,6 @@ hipsparseStatus_t hipsparseDestroyCsrsm2Info(csrsm2Info_t info)
     return hipCUSPARSEStatusToHIPStatus(cusparseDestroyCsrsm2Info((csrsm2Info_t)info));
 }
 #endif
-
-
-
-
-
 
 hipsparseStatus_t hipsparseCreateColorInfo(hipsparseColorInfo_t* info)
 {

--- a/library/src/nvcc_detail/hipsparse.cpp
+++ b/library/src/nvcc_detail/hipsparse.cpp
@@ -8287,7 +8287,21 @@ hipsparseStatus_t hipsparseZcsr2csc(hipsparseHandle_t       handle,
 }
 #endif
 
-#if(CUDART_VERSION >= 10010)
+
+#if(CUDART_VERSION >= 12000)
+cusparseCsr2CscAlg_t hipCsr2CscAlgToCudaCsr2CscAlg(hipsparseCsr2CscAlg_t alg)
+{
+    switch(alg)
+    {
+    case HIPSPARSE_CSR2CSC_ALG1:
+        return CUSPARSE_CSR2CSC_ALG1;
+    case HIPSPARSE_CSR2CSC_ALG_DEFAULT:
+        return CUSPARSE_CSR2CSC_ALG_DEFAULT;
+    default:
+        throw "Non existant hipsparseCsr2CscAlg_t";
+    }
+}
+#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
 cusparseCsr2CscAlg_t hipCsr2CscAlgToCudaCsr2CscAlg(hipsparseCsr2CscAlg_t alg)
 {
     switch(alg)
@@ -8300,6 +8314,7 @@ cusparseCsr2CscAlg_t hipCsr2CscAlgToCudaCsr2CscAlg(hipsparseCsr2CscAlg_t alg)
         throw "Non existant hipsparseCsr2CscAlg_t";
     }
 }
+#endif
 
 hipsparseStatus_t hipsparseCsr2cscEx2_bufferSize(hipsparseHandle_t     handle,
                                                  int                   m,
@@ -10243,8 +10258,10 @@ cusparseFormat_t hipFormatToCudaFormat(hipsparseFormat_t format)
 #endif
     case HIPSPARSE_FORMAT_COO:
         return CUSPARSE_FORMAT_COO;
+#if(CUDART_VERSION < 12000)
     case HIPSPARSE_FORMAT_COO_AOS:
         return CUSPARSE_FORMAT_COO_AOS;
+#endif
 #if(CUDART_VERSION >= 11021)
     case HIPSPARSE_FORMAT_BLOCKED_ELL:
         return CUSPARSE_FORMAT_BLOCKED_ELL;
@@ -10266,8 +10283,10 @@ hipsparseFormat_t CudaFormatToHIPFormat(cusparseFormat_t format)
 #endif
     case CUSPARSE_FORMAT_COO:
         return HIPSPARSE_FORMAT_COO;
+#if(CUDART_VERSION < 12000)
     case CUSPARSE_FORMAT_COO_AOS:
         return HIPSPARSE_FORMAT_COO_AOS;
+#endif
 #if(CUDART_VERSION >= 11021)
     case CUSPARSE_FORMAT_BLOCKED_ELL:
         return HIPSPARSE_FORMAT_BLOCKED_ELL;
@@ -10360,7 +10379,26 @@ hipsparseIndexType_t CudaIndexTypeToHIPIndexType(cusparseIndexType_t type)
 }
 #endif
 
-#if(CUDART_VERSION >= 11021)
+#if(CUDART_VERSION >= 12000)
+cusparseSpMVAlg_t hipSpMVAlgToCudaSpMVAlg(hipsparseSpMVAlg_t alg)
+{
+    switch(alg)
+    {
+    case HIPSPARSE_SPMV_ALG_DEFAULT:
+        return CUSPARSE_SPMV_ALG_DEFAULT;
+    case HIPSPARSE_SPMV_COO_ALG1:
+        return CUSPARSE_SPMV_COO_ALG1;
+    case HIPSPARSE_SPMV_COO_ALG2:
+        return CUSPARSE_SPMV_COO_ALG2;
+    case HIPSPARSE_SPMV_CSR_ALG1:
+        return CUSPARSE_SPMV_CSR_ALG1;
+    case HIPSPARSE_SPMV_CSR_ALG2:
+        return CUSPARSE_SPMV_CSR_ALG2;
+    default:
+        throw "Non existant hipsparseSpMVAlg_t";
+    }
+}
+#elif(CUDART_VERSION >= 11021 && CUDART_VERSION < 12000)
 cusparseSpMVAlg_t hipSpMVAlgToCudaSpMVAlg(hipsparseSpMVAlg_t alg)
 {
     switch(alg)
@@ -10387,7 +10425,7 @@ cusparseSpMVAlg_t hipSpMVAlgToCudaSpMVAlg(hipsparseSpMVAlg_t alg)
         throw "Non existant hipsparseSpMVAlg_t";
     }
 }
-#elif(CUDART_VERSION >= 10010)
+#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 11021)
 cusparseSpMVAlg_t hipSpMVAlgToCudaSpMVAlg(hipsparseSpMVAlg_t alg)
 {
     switch(alg)
@@ -10406,7 +10444,34 @@ cusparseSpMVAlg_t hipSpMVAlgToCudaSpMVAlg(hipsparseSpMVAlg_t alg)
 }
 #endif
 
-#if(CUDART_VERSION >= 11021)
+#if(CUDART_VERSION >= 12000)
+cusparseSpMMAlg_t hipSpMMAlgToCudaSpMMAlg(hipsparseSpMMAlg_t alg)
+{
+    switch(alg)
+    {
+    case HIPSPARSE_SPMM_ALG_DEFAULT:
+        return CUSPARSE_SPMM_ALG_DEFAULT;
+    case HIPSPARSE_SPMM_COO_ALG1:
+        return CUSPARSE_SPMM_COO_ALG1;
+    case HIPSPARSE_SPMM_COO_ALG2:
+        return CUSPARSE_SPMM_COO_ALG2;
+    case HIPSPARSE_SPMM_COO_ALG3:
+        return CUSPARSE_SPMM_COO_ALG3;
+    case HIPSPARSE_SPMM_COO_ALG4:
+        return CUSPARSE_SPMM_COO_ALG4;
+    case HIPSPARSE_SPMM_CSR_ALG1:
+        return CUSPARSE_SPMM_CSR_ALG1;
+    case HIPSPARSE_SPMM_CSR_ALG2:
+        return CUSPARSE_SPMM_CSR_ALG2;
+    case HIPSPARSE_SPMM_CSR_ALG3:
+        return CUSPARSE_SPMM_CSR_ALG3;
+    case HIPSPARSE_SPMM_BLOCKED_ELL_ALG1:
+        return CUSPARSE_SPMM_BLOCKED_ELL_ALG1;
+    default:
+        throw "Non existant hipsparseSpMMAlg_t";
+    }
+}
+#elif(CUDART_VERSION >= 11021 && CUDART_VERSION < 12000)
 cusparseSpMMAlg_t hipSpMMAlgToCudaSpMMAlg(hipsparseSpMMAlg_t alg)
 {
     switch(alg)
@@ -10443,7 +10508,7 @@ cusparseSpMMAlg_t hipSpMMAlgToCudaSpMMAlg(hipsparseSpMMAlg_t alg)
         throw "Non existant hipsparseSpMMAlg_t";
     }
 }
-#elif(CUDART_VERSION >= 11003)
+#elif(CUDART_VERSION >= 11003 && CUDART_VERSION < 11021)
 cusparseSpMMAlg_t hipSpMMAlgToCudaSpMMAlg(hipsparseSpMMAlg_t alg)
 {
     switch(alg)
@@ -10478,7 +10543,7 @@ cusparseSpMMAlg_t hipSpMMAlgToCudaSpMMAlg(hipsparseSpMMAlg_t alg)
         throw "Non existant hipsparseSpMMAlg_t";
     }
 }
-#elif(CUDART_VERSION >= 10010)
+#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 11003)
 cusparseSpMMAlg_t hipSpMMAlgToCudaSpMMAlg(hipsparseSpMMAlg_t alg)
 {
     switch(alg)

--- a/library/src/nvcc_detail/hipsparse.cpp
+++ b/library/src/nvcc_detail/hipsparse.cpp
@@ -8287,7 +8287,6 @@ hipsparseStatus_t hipsparseZcsr2csc(hipsparseHandle_t       handle,
 }
 #endif
 
-
 #if(CUDART_VERSION >= 12000)
 cusparseCsr2CscAlg_t hipCsr2CscAlgToCudaCsr2CscAlg(hipsparseCsr2CscAlg_t alg)
 {

--- a/library/src/nvcc_detail/hipsparse.cpp
+++ b/library/src/nvcc_detail/hipsparse.cpp
@@ -8315,6 +8315,7 @@ cusparseCsr2CscAlg_t hipCsr2CscAlgToCudaCsr2CscAlg(hipsparseCsr2CscAlg_t alg)
 }
 #endif
 
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 10010)
 hipsparseStatus_t hipsparseCsr2cscEx2_bufferSize(hipsparseHandle_t     handle,
                                                  int                   m,
                                                  int                   n,


### PR DESCRIPTION
Gets hipsparse compiling with cuda 12 by removing cusparse deprecated functions