### PR TITLE
Fix reserved identifiers in include guards

### DIFF
--- a/library/include/hipsparse-version.h.in
+++ b/library/include/hipsparse-version.h.in
@@ -25,9 +25,8 @@
  * \brief hipsparse-version.h provides the configured version and settings
  */
 
-#pragma once
-#ifndef _HIPSPARSE_VERSION_H_
-#define _HIPSPARSE_VERSION_H_
+#ifndef HIPSPARSE_VERSION_H
+#define HIPSPARSE_VERSION_H
 
 // clang-format off
 #define hipsparseVersionMajor    @hipsparse_VERSION_MAJOR@
@@ -36,4 +35,4 @@
 #define hipsparseVersionTweak    @hipsparse_VERSION_TWEAK@
 // clang-format on
 
-#endif // _HIPSPARSE_VERSION_H_
+#endif /* HIPSPARSE_VERSION_H */

--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -35,9 +35,8 @@
 // This is the master include file for hipSPARSE, wrapping around rocSPARSE and
 // cuSPARSE "version 2".
 
-#pragma once
-#ifndef _HIPSPARSE_H_
-#define _HIPSPARSE_H_
+#ifndef HIPSPARSE_H
+#define HIPSPARSE_H
 
 #include "hipsparse-export.h"
 #include "hipsparse-version.h"
@@ -10497,4 +10496,4 @@ hipsparseStatus_t hipsparseSpSM_solve(hipsparseHandle_t           handle,
 }
 #endif
 
-#endif // _HIPSPARSE_H_
+#endif // HIPSPARSE_H


### PR DESCRIPTION
The include guards have been changed to the filename in uppercase letters with all non-alphanumeric symbols replaced by underscore. This include guard pattern matches the guard that is used for the generated file rocsparse-export.h.

The C and C++ standards reserve all identifiers that begin with an underscore followed by a capital letter [C99 §7.1.3] [C++11 §17.6.4.3.2].

There's also no reason to use #pragma once and include guards together in the same file. To quote [Microsoft's documentation on #pragma once in VS2015](https://learn.microsoft.com/en-us/cpp/preprocessor/once?redirectedfrom=MSDN&view=msvc-170):

> There is no advantage to use of both the #include guard idiom and
> #pragma once in the same file. The compiler recognizes the #include
> guard idiom and implements the multiple include optimization the
> same way as the #pragma once directive if no non-comment code or
> preprocessor directive comes before or after the standard form of
> the idiom