### PR TITLE
Add hipsparseBlockedEllGet routine implementation when using cuda backend

### DIFF
--- a/clients/include/testing_spmat_descr.hpp
+++ b/clients/include/testing_spmat_descr.hpp
@@ -500,7 +500,7 @@ void testing_spmat_descr_bad_arg(void)
                                             "Error: dataType is nullptr");
 #endif
 
-#if(!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11070)
     verify_hipsparse_status_invalid_pointer(hipsparseBlockedEllGet(nullptr,
                                                                    &rows,
                                                                    &cols,

--- a/library/src/nvcc_detail/hipsparse.cpp
+++ b/library/src/nvcc_detail/hipsparse.cpp
@@ -11077,29 +11077,31 @@ hipsparseStatus_t hipsparseBlockedEllGet(const hipsparseSpMatDescr_t spMatDescr,
 {
     // As of cusparse 11.4.1, this routine does not actually exist as a symbol in the cusparse
     // library (the documentation indicates that it should exist starting at cusparse 11.2.1).
-    // Uncomment once it has been added
-    // cusparseIndexType_t cuda_index_type;
-    // cusparseIndexBase_t cuda_index_base;
-    // cudaDataType        cuda_data_type;
+#if(CUDART_VERSION >= 11070)
+    cusparseIndexType_t cuda_index_type;
+    cusparseIndexBase_t cuda_index_base;
+    cudaDataType        cuda_data_type;
 
-    // RETURN_IF_CUSPARSE_ERROR(
-    //     cusparseBlockedEllGet((cusparseSpMatDescr_t)spMatDescr,
-    //                           rows,
-    //                           cols,
-    //                           ellBlockSize,
-    //                           ellCols,
-    //                           ellColInd,
-    //                           ellValue,
-    //                           ellIdxType != nullptr ? &cuda_index_type : nullptr,
-    //                           idxBase != nullptr ? &cuda_index_base : nullptr,
-    //                           valueType != nullptr ? &cuda_data_type : nullptr));
+    RETURN_IF_CUSPARSE_ERROR(
+        cusparseBlockedEllGet((cusparseSpMatDescr_t)spMatDescr,
+                              rows,
+                              cols,
+                              ellBlockSize,
+                              ellCols,
+                              ellColInd,
+                              ellValue,
+                              ellIdxType != nullptr ? &cuda_index_type : nullptr,
+                              idxBase != nullptr ? &cuda_index_base : nullptr,
+                              valueType != nullptr ? &cuda_data_type : nullptr));
 
-    // *ellIdxType = CudaIndexTypeToHIPIndexType(cuda_index_type);
-    // *idxBase    = CudaIndexBaseToHIPIndexBase(cuda_index_base);
-    // *valueType  = CudaDataTypeToHIPDataType(cuda_data_type);
+    *ellIdxType = CudaIndexTypeToHIPIndexType(cuda_index_type);
+    *idxBase    = CudaIndexBaseToHIPIndexBase(cuda_index_base);
+    *valueType  = CudaDataTypeToHIPDataType(cuda_data_type);
 
-    // return HIPSPARSE_STATUS_SUCCESS;
+    return HIPSPARSE_STATUS_SUCCESS;
+#else
     return HIPSPARSE_STATUS_NOT_SUPPORTED;
+#endif
 }
 #endif
 


### PR DESCRIPTION
Resolves SWDEV-378262

Proposed changes:
 - Add hipsparseBlockedEllGet implementation for cuda version 11.7.0 or greater
 - Test hipsparseBlockedEllGet for cuda version 11.7.0 or greater