### PR TITLE
Update BSR conversion routines for blockDim zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log for hipSPARSE
 
-## hipSPARSE 2.3.5
+## hipSPARSE 2.3.6
+### Added
+- Added SpGEMM algorithms
+### Changed
+- For hipsparseXbsr2csr and hipsparseXcsr2bsr, blockDim == 0 now returns HIPSPARSE_STATUS_INVALID_SIZE
+
+## hipSPARSE 2.3.5 for ROCm 5.5.0
 ### Improved
 - Fixed an issue, where the rocm folder was not removed on upgrade of meta packages
 - Fixed a compilation issue with cusparse backend

--- a/clients/include/testing_bsr2csr.hpp
+++ b/clients/include/testing_bsr2csr.hpp
@@ -372,14 +372,14 @@ hipsparseStatus_t testing_bsr2csr(Arguments argus)
                                    dcsr_row_ptr,
                                    dcsr_col_ind);
 
-        if(mb < 0 || nb < 0 || block_dim < 0)
+        if(mb < 0 || nb < 0 || block_dim <= 0)
         {
             verify_hipsparse_status_invalid_size(status,
-                                                 "Error: mb < 0 || nb < 0 || block_dim < 0");
+                                                 "Error: mb < 0 || nb < 0 || block_dim <= 0");
         }
         else
         {
-            verify_hipsparse_status_success(status, "mb >= 0 && nb >= 0 && block_dim >= 0");
+            verify_hipsparse_status_success(status, "mb >= 0 && nb >= 0 && block_dim > 0");
         }
 
         return HIPSPARSE_STATUS_SUCCESS;

--- a/clients/include/testing_csr2bsr.hpp
+++ b/clients/include/testing_csr2bsr.hpp
@@ -492,13 +492,13 @@ hipsparseStatus_t testing_csr2bsr(Arguments argus)
                                       dbsr_row_ptr,
                                       &bsr_nnzb);
 
-        if(m < 0 || n < 0 || block_dim < 0)
+        if(m < 0 || n < 0 || block_dim <= 0)
         {
-            verify_hipsparse_status_invalid_size(status, "Error: m < 0 || n < 0 || block_dim < 0");
+            verify_hipsparse_status_invalid_size(status, "Error: m < 0 || n < 0 || block_dim <= 0");
         }
         else
         {
-            verify_hipsparse_status_success(status, "m >= 0 && n >= 0 && block_dim >= 0");
+            verify_hipsparse_status_success(status, "m >= 0 && n >= 0 && block_dim > 0");
         }
 
         status = hipsparseXcsr2bsr(handle,
@@ -515,13 +515,13 @@ hipsparseStatus_t testing_csr2bsr(Arguments argus)
                                    dbsr_row_ptr,
                                    dbsr_col_ind);
 
-        if(m < 0 || n < 0 || block_dim < 0)
+        if(m < 0 || n < 0 || block_dim <= 0)
         {
-            verify_hipsparse_status_invalid_size(status, "Error: m < 0 || n < 0 || block_dim < 0");
+            verify_hipsparse_status_invalid_size(status, "Error: m < 0 || n < 0 || block_dim <= 0");
         }
         else
         {
-            verify_hipsparse_status_success(status, "m >= 0 && n >= 0 && block_dim >= 0");
+            verify_hipsparse_status_success(status, "m >= 0 && n >= 0 && block_dim > 0");
         }
 
         return HIPSPARSE_STATUS_SUCCESS;

--- a/clients/tests/test_bsr2csr.cpp
+++ b/clients/tests/test_bsr2csr.cpp
@@ -35,9 +35,9 @@ typedef std::
         bsr2csr_bin_tuple;
 
 // Random matrices
-int bsr2csr_M_range[]         = {-1, 0, 872, 13095, 21453};
-int bsr2csr_N_range[]         = {-3, 0, 623, 12766, 29285};
-int bsr2csr_block_dim_range[] = {-1, 0, 1, 2, 4, 7, 16};
+int bsr2csr_M_range[]         = {0, 872, 13095, 21453};
+int bsr2csr_N_range[]         = {0, 623, 12766, 29285};
+int bsr2csr_block_dim_range[] = {1, 2, 4, 7, 16};
 
 hipsparseIndexBase_t bsr2csr_csr_base_range[] = {HIPSPARSE_INDEX_BASE_ZERO};
 

--- a/clients/tests/test_csr2bsr.cpp
+++ b/clients/tests/test_csr2bsr.cpp
@@ -35,9 +35,9 @@ typedef std::
         csr2bsr_bin_tuple;
 
 // Random matrices
-int csr2bsr_M_range[]         = {-1, 0, 872, 13095, 21453};
-int csr2bsr_N_range[]         = {-3, 0, 623, 12766, 29285};
-int csr2bsr_block_dim_range[] = {-1, 0, 1, 2, 4, 7, 16};
+int csr2bsr_M_range[]         = {0, 872, 13095, 21453};
+int csr2bsr_N_range[]         = {0, 623, 12766, 29285};
+int csr2bsr_block_dim_range[] = {1, 2, 4, 7, 16};
 
 hipsparseIndexBase_t csr2bsr_csr_base_range[] = {HIPSPARSE_INDEX_BASE_ZERO};
 


### PR DESCRIPTION
- The conversion routines hipsparseXbsr2csr and hipsparseXcsr2bsr now return invalid size status when passed blockDim 0.
- With this change and the corresponding rocsparse PR: https://github.com/ROCmSoftwarePlatform/rocSPARSE-internal/pull/501 hipsparse should now be passing all HSA_XNACK=1 tests.