### PR TITLE
Fixing SWDEV-386030, hipsparseSpSV_solve API must match cusparse.

### DIFF
--- a/clients/include/testing_spsv_coo.hpp
+++ b/clients/include/testing_spsv_coo.hpp
@@ -138,25 +138,20 @@ void testing_spsv_coo_bad_arg(void)
 
     // SpSV solve
     verify_hipsparse_status_invalid_handle(
-        hipsparseSpSV_solve(nullptr, transA, &alpha, A, x, y, dataType, alg, descr, dbuf));
+        hipsparseSpSV_solve(nullptr, transA, &alpha, A, x, y, dataType, alg, descr));
     verify_hipsparse_status_invalid_pointer(
-        hipsparseSpSV_solve(handle, transA, nullptr, A, x, y, dataType, alg, descr, dbuf),
+        hipsparseSpSV_solve(handle, transA, nullptr, A, x, y, dataType, alg, descr),
         "Error: alpha is nullptr");
     verify_hipsparse_status_invalid_pointer(
-        hipsparseSpSV_solve(handle, transA, &alpha, nullptr, x, y, dataType, alg, descr, dbuf),
+        hipsparseSpSV_solve(handle, transA, &alpha, nullptr, x, y, dataType, alg, descr),
         "Error: A is nullptr");
     verify_hipsparse_status_invalid_pointer(
-        hipsparseSpSV_solve(handle, transA, &alpha, A, nullptr, y, dataType, alg, descr, dbuf),
+        hipsparseSpSV_solve(handle, transA, &alpha, A, nullptr, y, dataType, alg, descr),
         "Error: x is nullptr");
     verify_hipsparse_status_invalid_pointer(
-        hipsparseSpSV_solve(handle, transA, &alpha, A, x, nullptr, dataType, alg, descr, dbuf),
+        hipsparseSpSV_solve(handle, transA, &alpha, A, x, nullptr, dataType, alg, descr),
         "Error: y is nullptr");
-#if(!defined(CUDART_VERSION))
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseSpSV_solve(handle, transA, &alpha, A, x, y, dataType, alg, descr, nullptr),
-        "Error: dbuf is nullptr");
-#endif
-
+    
     // Destruct
     verify_hipsparse_status_success(hipsparseSpSV_destroyDescr(descr), "success");
     verify_hipsparse_status_success(hipsparseDestroySpMat(A), "success");
@@ -307,12 +302,12 @@ hipsparseStatus_t testing_spsv_coo(void)
     // HIPSPARSE pointer mode host
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_HOST));
     CHECK_HIPSPARSE_ERROR(
-        hipsparseSpSV_solve(handle, transA, &h_alpha, A, x, y1, typeT, alg, descr, buffer));
+        hipsparseSpSV_solve(handle, transA, &h_alpha, A, x, y1, typeT, alg, descr));
 
     // HIPSPARSE pointer mode device
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_DEVICE));
     CHECK_HIPSPARSE_ERROR(
-        hipsparseSpSV_solve(handle, transA, d_alpha, A, x, y2, typeT, alg, descr, buffer));
+        hipsparseSpSV_solve(handle, transA, d_alpha, A, x, y2, typeT, alg, descr));
 
     // copy output from device to CPU
     CHECK_HIP_ERROR(hipMemcpy(hy_1.data(), dy_1, sizeof(T) * m, hipMemcpyDeviceToHost));

--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -10394,8 +10394,7 @@ hipsparseStatus_t hipsparseSpSV_solve(hipsparseHandle_t           handle,
                                       const hipsparseDnVecDescr_t y,
                                       hipDataType                 computeType,
                                       hipsparseSpSVAlg_t          alg,
-                                      hipsparseSpSVDescr_t        spsvDescr,
-                                      void*                       externalBuffer);
+                                      hipsparseSpSVDescr_t        spsvDescr);
 #endif
 
 /*! \ingroup generic_module

--- a/library/src/nvcc_detail/hipsparse.cpp
+++ b/library/src/nvcc_detail/hipsparse.cpp
@@ -12102,8 +12102,7 @@ hipsparseStatus_t hipsparseSpSV_solve(hipsparseHandle_t           handle,
                                       const hipsparseDnVecDescr_t y,
                                       hipDataType                 computeType,
                                       hipsparseSpSVAlg_t          alg,
-                                      hipsparseSpSVDescr_t        spsvDescr,
-                                      void*                       externalBuffer)
+                                      hipsparseSpSVDescr_t        spsvDescr)
 {
     return hipCUSPARSEStatusToHIPStatus(cusparseSpSV_solve((cusparseHandle_t)handle,
                                                            hipOperationToCudaOperation(opA),


### PR DESCRIPTION
**Description**

hipsparseSpSV API must match cusparse, the external buffer is not part of the _solve API even though the buffer is a 

"Pointer to a workspace buffer of at least bufferSize bytes. It is used by cusparseSpSV_analysis and cusparseSpSV_solve()"

**Solution**

In the HIP implementation, grab the buffer from the analysis phase in the routine descriptor.
