### PR TITLE
Updates tests with zero buffer size

### DIFF
--- a/clients/include/testing_coosort.hpp
+++ b/clients/include/testing_coosort.hpp
@@ -264,9 +264,9 @@ hipsparseStatus_t testing_coosort(Arguments argus)
         {
             verify_hipsparse_status_success(status, "m >= 0 && n >= 0 && nnz >= 0");
 
-            // Buffer size should be 4
-            size_t four = 4;
-            unit_check_general(1, 1, 1, &four, &buffer_size);
+            // Buffer size should be 0
+            size_t zero = 0;
+            unit_check_general(1, 1, 1, &zero, &buffer_size);
         }
 
         if(by_row)

--- a/clients/include/testing_cscsort.hpp
+++ b/clients/include/testing_cscsort.hpp
@@ -243,9 +243,9 @@ hipsparseStatus_t testing_cscsort(Arguments argus)
         {
             verify_hipsparse_status_success(status, "m >= 0 && n >= 0 && nnz >= 0");
 
-            // Buffer size should be 4
-            size_t four = 4;
-            unit_check_general(1, 1, 1, &four, &buffer_size);
+            // Buffer size should be 0
+            size_t zero = 0;
+            unit_check_general(1, 1, 1, &zero, &buffer_size);
         }
 
         status

--- a/clients/include/testing_csr2gebsr.hpp
+++ b/clients/include/testing_csr2gebsr.hpp
@@ -295,13 +295,6 @@ void testing_csr2gebsr_bad_arg(void)
         verify_hipsparse_status_invalid_pointer(status, "Error: bsr_nnz_devhost is nullptr");
     }
 
-    {
-        ARGSET;
-        arg_p_buffer = nullptr;
-        status       = CALL_NNZ;
-        verify_hipsparse_status_invalid_pointer(status, "Error: p_buffer is nullptr");
-    }
-
 #undef CALL_NNZ
 #undef CALL_ARG_NNZ
 
@@ -417,13 +410,6 @@ void testing_csr2gebsr_bad_arg(void)
         arg_col_block_dim = -1;
         status            = CALL_FUNC;
         verify_hipsparse_status_invalid_size(status, "Error: col_block_dim is invalid");
-    }
-
-    {
-        ARGSET;
-        arg_p_buffer = nullptr;
-        status       = CALL_FUNC;
-        verify_hipsparse_status_invalid_pointer(status, "Error: p_buffer is nullptr");
     }
 
 #undef CALL_FUNC

--- a/clients/include/testing_csrgemm2_b.hpp
+++ b/clients/include/testing_csrgemm2_b.hpp
@@ -464,31 +464,6 @@ void testing_csrgemm2_b_bad_arg(void)
                                        dbuffer);
         verify_hipsparse_status_invalid_pointer(status, "Error: info is nullptr");
     }
-    // testing for(nullptr == dbuffer)
-    {
-        status = hipsparseXcsrgemm2Nnz(handle,
-                                       M,
-                                       N,
-                                       0,
-                                       nullptr,
-                                       0,
-                                       nullptr,
-                                       nullptr,
-                                       nullptr,
-                                       0,
-                                       nullptr,
-                                       nullptr,
-                                       descr_D,
-                                       nnz_D,
-                                       dDptr,
-                                       dDcol,
-                                       descr_C,
-                                       dCptr,
-                                       &nnz_C,
-                                       info,
-                                       nullptr);
-        verify_hipsparse_status_invalid_pointer(status, "Error: dbuffer is nullptr");
-    }
 
     // testing hipsparseXcsrgemm2
 
@@ -833,37 +808,6 @@ void testing_csrgemm2_b_bad_arg(void)
                                     dbuffer);
         verify_hipsparse_status_invalid_pointer(status, "Error: info is nullptr");
     }
-    // testing for(nullptr == dbuffer)
-    {
-        status = hipsparseXcsrgemm2(handle,
-                                    M,
-                                    N,
-                                    0,
-                                    (T*)nullptr,
-                                    nullptr,
-                                    0,
-                                    (T*)nullptr,
-                                    nullptr,
-                                    nullptr,
-                                    nullptr,
-                                    0,
-                                    (T*)nullptr,
-                                    nullptr,
-                                    nullptr,
-                                    &beta,
-                                    descr_D,
-                                    nnz_D,
-                                    dDval,
-                                    dDptr,
-                                    dDcol,
-                                    descr_C,
-                                    dCval,
-                                    dCptr,
-                                    dCcol,
-                                    info,
-                                    nullptr);
-        verify_hipsparse_status_invalid_pointer(status, "Error: dbuffer is nullptr");
-    }
 }
 
 template <typename T>
@@ -1197,12 +1141,6 @@ hipsparseStatus_t testing_csrgemm2_b(Arguments argus)
     auto dbuffer_managed = hipsparse_unique_ptr{device_malloc(sizeof(char) * size), device_free};
 
     void* dbuffer = (void*)dbuffer_managed.get();
-
-    if(!dbuffer)
-    {
-        verify_hipsparse_status_success(HIPSPARSE_STATUS_ALLOC_FAILED, "!dbuffer");
-        return HIPSPARSE_STATUS_ALLOC_FAILED;
-    }
 
     // csrgemm2 nnz
 

--- a/clients/include/testing_csrsort.hpp
+++ b/clients/include/testing_csrsort.hpp
@@ -243,9 +243,9 @@ hipsparseStatus_t testing_csrsort(Arguments argus)
         {
             verify_hipsparse_status_success(status, "m >= 0 && n >= 0 && nnz >= 0");
 
-            // Buffer size should be 4
-            size_t four = 4;
-            unit_check_general(1, 1, 1, &four, &buffer_size);
+            // Buffer size should be 0
+            size_t zero = 0;
+            unit_check_general(1, 1, 1, &zero, &buffer_size);
         }
 
         status

--- a/clients/include/testing_gebsr2gebsr.hpp
+++ b/clients/include/testing_gebsr2gebsr.hpp
@@ -440,24 +440,6 @@ void testing_gebsr2gebsr_bad_arg(void)
                                       temp_buffer);
     verify_hipsparse_status_invalid_pointer(status, "Error: nnz_total_dev_host_ptr is nullptr");
 
-    status = hipsparseXgebsr2gebsrNnz(handle,
-                                      dir,
-                                      mb,
-                                      nb,
-                                      nnzb,
-                                      descr_A,
-                                      bsr_row_ptr_A,
-                                      bsr_col_ind_A,
-                                      row_block_dim_A,
-                                      col_block_dim_A,
-                                      descr_C,
-                                      bsr_row_ptr_C,
-                                      row_block_dim_C,
-                                      col_block_dim_C,
-                                      &nnz_total_dev_host_ptr,
-                                      nullptr);
-    verify_hipsparse_status_invalid_pointer(status, "Error: buffer is nullptr");
-
     // Test invalid sizes
     status = hipsparseXgebsr2gebsrNnz(handle,
                                       dir,
@@ -768,26 +750,6 @@ void testing_gebsr2gebsr_bad_arg(void)
                                    col_block_dim_C,
                                    temp_buffer);
     verify_hipsparse_status_invalid_pointer(status, "Error: bsr_col_ind_C is nullptr");
-
-    status = hipsparseXgebsr2gebsr(handle,
-                                   dir,
-                                   mb,
-                                   nb,
-                                   nnzb,
-                                   descr_A,
-                                   bsr_val_A,
-                                   bsr_row_ptr_A,
-                                   bsr_col_ind_A,
-                                   row_block_dim_A,
-                                   col_block_dim_A,
-                                   descr_C,
-                                   bsr_val_C,
-                                   bsr_row_ptr_C,
-                                   bsr_col_ind_C,
-                                   row_block_dim_C,
-                                   col_block_dim_C,
-                                   nullptr);
-    verify_hipsparse_status_invalid_pointer(status, "Error: temp_buffer is nullptr");
 
     // Test invalid sizes
     status = hipsparseXgebsr2gebsr(handle,
@@ -1143,12 +1105,6 @@ hipsparseStatus_t testing_gebsr2gebsr(Arguments argus)
         = hipsparse_unique_ptr{device_malloc(buffer_size_conversion), device_free};
     void* dbuffer_conversion = dbuffer_conversion_managed.get();
 
-    if(!dbuffer_conversion)
-    {
-        verify_hipsparse_status_success(HIPSPARSE_STATUS_ALLOC_FAILED, "!dbuffer_conversion");
-        return HIPSPARSE_STATUS_ALLOC_FAILED;
-    }
-
     // Obtain BSR nnzb first on the host and then using the device and ensure they give the same results
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_HOST));
 
@@ -1237,12 +1193,6 @@ hipsparseStatus_t testing_gebsr2gebsr(Arguments argus)
         = hipsparse_unique_ptr{device_malloc(sizeof(char) * buffer_size), device_free};
 
     void* dbuffer = (void*)dbuffer_managed.get();
-
-    if(!dbuffer)
-    {
-        verify_hipsparse_status_success(HIPSPARSE_STATUS_ALLOC_FAILED, "!dbuffer");
-        return HIPSPARSE_STATUS_ALLOC_FAILED;
-    }
 
     if(argus.unit_check)
     {

--- a/clients/include/testing_gemvi.hpp
+++ b/clients/include/testing_gemvi.hpp
@@ -116,10 +116,6 @@ void testing_gemvi_bad_arg(void)
         hipsparseSgemvi(
             handle, opType, m, n, &alpha, A, lda, nnz, x, xInd, &beta, nullptr, idxBase, buffer),
         "Error: y is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseSgemvi(
-            handle, opType, m, n, &alpha, A, lda, nnz, x, xInd, &beta, y, idxBase, nullptr),
-        "Error: buffer is nullptr");
 
     verify_hipsparse_status_invalid_size(
         hipsparseSgemvi(

--- a/clients/include/testing_gtsv2_nopivot.hpp
+++ b/clients/include/testing_gtsv2_nopivot.hpp
@@ -108,9 +108,6 @@ void testing_gtsv2_nopivot_bad_arg(void)
     verify_hipsparse_status_invalid_pointer(
         hipsparseXgtsv2_nopivot(handle, m, n, ddl, dd, ddu, (T*)nullptr, ldb, dbuf),
         "Error: dB is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgtsv2_nopivot(handle, m, n, ddl, dd, ddu, dB, ldb, nullptr),
-        "Error: bsize is nullptr");
 #endif
 }
 

--- a/clients/include/testing_gtsv2_strided_batch.hpp
+++ b/clients/include/testing_gtsv2_strided_batch.hpp
@@ -118,10 +118,6 @@ void testing_gtsv2_strided_batch_bad_arg(void)
         hipsparseXgtsv2StridedBatch(
             handle, m, ddl, dd, ddu, (T*)nullptr, batch_count, batch_stride, dbuf),
         "Error: dx is nullptr");
-    verify_hipsparse_status_invalid_pointer(
-        hipsparseXgtsv2StridedBatch(
-            handle, m, ddl, dd, ddu, dx, batch_count, batch_stride, nullptr),
-        "Error: bsize is nullptr");
 #endif
 }
 

--- a/clients/include/testing_prune_csr2csr.hpp
+++ b/clients/include/testing_prune_csr2csr.hpp
@@ -305,21 +305,6 @@ void testing_prune_csr2csr_bad_arg(void)
                                        temp_buffer);
     verify_hipsparse_status_invalid_pointer(status, "Error: nnz_total_dev_host_ptr is nullptr");
 
-    status = hipsparseXpruneCsr2csrNnz(handle,
-                                       M,
-                                       N,
-                                       nnz_A,
-                                       descr_A,
-                                       csr_val_A,
-                                       csr_row_ptr_A,
-                                       csr_col_ind_A,
-                                       &threshold,
-                                       descr_C,
-                                       csr_row_ptr_C,
-                                       &nnz_total_dev_host_ptr,
-                                       nullptr);
-    verify_hipsparse_status_invalid_pointer(status, "Error: buffer is nullptr");
-
     // Test hipsparseXpruneCsr2csr
     status = hipsparseXpruneCsr2csr(nullptr,
                                     M,
@@ -528,22 +513,6 @@ void testing_prune_csr2csr_bad_arg(void)
                                     nullptr,
                                     temp_buffer);
     verify_hipsparse_status_invalid_pointer(status, "Error: csr_col_ind_C is nullptr");
-
-    status = hipsparseXpruneCsr2csr(handle,
-                                    M,
-                                    N,
-                                    nnz_A,
-                                    descr_A,
-                                    csr_val_A,
-                                    csr_row_ptr_A,
-                                    csr_col_ind_A,
-                                    &threshold,
-                                    descr_C,
-                                    csr_val_C,
-                                    csr_row_ptr_C,
-                                    csr_col_ind_C,
-                                    nullptr);
-    verify_hipsparse_status_invalid_pointer(status, "Error: buffer is nullptr");
 #endif
 }
 
@@ -775,12 +744,6 @@ hipsparseStatus_t testing_prune_csr2csr(Arguments argus)
     auto d_temp_buffer_managed = hipsparse_unique_ptr{device_malloc(buffer_size), device_free};
 
     T* d_temp_buffer = (T*)d_temp_buffer_managed.get();
-
-    if(!d_temp_buffer)
-    {
-        verify_hipsparse_status_success(HIPSPARSE_STATUS_ALLOC_FAILED, "!d_temp_buffer");
-        return HIPSPARSE_STATUS_ALLOC_FAILED;
-    }
 
     auto d_threshold_managed = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
 

--- a/clients/include/testing_prune_dense2csr.hpp
+++ b/clients/include/testing_prune_dense2csr.hpp
@@ -173,10 +173,6 @@ void testing_prune_dense2csr_bad_arg(void)
         handle, M, N, A, LDA, &threshold, descr, csr_row_ptr, nullptr, temp_buffer);
     verify_hipsparse_status_invalid_pointer(status, "Error: nnz_total_dev_host_ptr is nullptr");
 
-    status = hipsparseXpruneDense2csrNnz(
-        handle, M, N, A, LDA, &threshold, descr, csr_row_ptr, &nnz_total_dev_host_ptr, nullptr);
-    verify_hipsparse_status_invalid_pointer(status, "Error: buffer size is nullptr");
-
     // Test hipsparseXpruneDense2csr
     status = hipsparseXpruneDense2csr(
         nullptr, M, N, A, LDA, &threshold, descr, csr_val, csr_row_ptr, csr_col_ind, temp_buffer);
@@ -244,10 +240,6 @@ void testing_prune_dense2csr_bad_arg(void)
     status = hipsparseXpruneDense2csr(
         handle, M, N, A, LDA, &threshold, descr, csr_val, csr_row_ptr, nullptr, temp_buffer);
     verify_hipsparse_status_invalid_pointer(status, "Error: csr_col_ind is nullptr");
-
-    status = hipsparseXpruneDense2csr(
-        handle, M, N, A, LDA, &threshold, descr, csr_val, csr_row_ptr, csr_col_ind, nullptr);
-    verify_hipsparse_status_invalid_pointer(status, "Error: buffer is nullptr");
 #endif
 }
 
@@ -375,12 +367,6 @@ hipsparseStatus_t testing_prune_dense2csr(Arguments argus)
     auto d_temp_buffer_managed = hipsparse_unique_ptr{device_malloc(buffer_size), device_free};
 
     T* d_temp_buffer = (T*)d_temp_buffer_managed.get();
-
-    if(!d_temp_buffer)
-    {
-        verify_hipsparse_status_success(HIPSPARSE_STATUS_ALLOC_FAILED, "!d_temp_buffer");
-        return HIPSPARSE_STATUS_ALLOC_FAILED;
-    }
 
     auto d_threshold_managed = hipsparse_unique_ptr{device_malloc(sizeof(T)), device_free};
 


### PR DESCRIPTION
Update tests accordingly to match rocsparse PR https://github.com/ROCmSoftwarePlatform/rocSPARSE-internal/pull/525
 - Allow buffer size to be zero and buffer to be nullptr.