### PR TITLE
SWDEV-359377

### DIFF
--- a/clients/include/testing_bsrsm2.hpp
+++ b/clients/include/testing_bsrsm2.hpp
@@ -526,7 +526,7 @@ hipsparseStatus_t testing_bsrsm2(void)
     // Get current executables absolute path
 
     // Matrices are stored at the same path in matrices directory
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // hipSPARSE handle and opaque structs
     std::unique_ptr<handle_struct> test_handle(new handle_struct);

--- a/clients/include/testing_csrcolor.hpp
+++ b/clients/include/testing_csrcolor.hpp
@@ -235,7 +235,7 @@ hipsparseStatus_t testing_csrcolor()
 {
     // Determine absolute path of test matrix
     // Matrices are stored at the same path in matrices directory
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // hipSPARSE handle
     std::unique_ptr<handle_struct> test_handle(new handle_struct);

--- a/clients/include/testing_sddmm_coo.hpp
+++ b/clients/include/testing_sddmm_coo.hpp
@@ -202,7 +202,7 @@ hipsparseStatus_t testing_sddmm_coo()
     hipsparseSDDMMAlg_t  alg      = HIPSPARSE_SDDMM_ALG_DEFAULT;
 
     // Matrices are stored at the same path in matrices directory
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_sddmm_coo_aos.hpp
+++ b/clients/include/testing_sddmm_coo_aos.hpp
@@ -200,7 +200,7 @@ hipsparseStatus_t testing_sddmm_coo_aos()
     hipsparseSDDMMAlg_t  alg      = HIPSPARSE_SDDMM_ALG_DEFAULT;
 
     // Matrices are stored at the same path in matrices directory
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_sddmm_csc.hpp
+++ b/clients/include/testing_sddmm_csc.hpp
@@ -204,7 +204,7 @@ hipsparseStatus_t testing_sddmm_csc()
     hipsparseSDDMMAlg_t  alg      = HIPSPARSE_SDDMM_ALG_DEFAULT;
 
     // Matrices are stored at the same path in matrices directory
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_sddmm_csr.hpp
+++ b/clients/include/testing_sddmm_csr.hpp
@@ -203,7 +203,7 @@ hipsparseStatus_t testing_sddmm_csr()
     hipsparseSDDMMAlg_t  alg      = HIPSPARSE_SDDMM_ALG_DEFAULT;
 
     // Matrices are stored at the same path in matrices directory
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_sparse_to_dense_coo.hpp
+++ b/clients/include/testing_sparse_to_dense_coo.hpp
@@ -132,7 +132,7 @@ hipsparseStatus_t testing_sparse_to_dense_coo(void)
     hipsparseOrder_t            order    = HIPSPARSE_ORDER_COL;
 
     // Matrices are stored at the same path in matrices directory
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_sparse_to_dense_csc.hpp
+++ b/clients/include/testing_sparse_to_dense_csc.hpp
@@ -138,7 +138,7 @@ hipsparseStatus_t testing_sparse_to_dense_csc(void)
     hipsparseOrder_t            order    = HIPSPARSE_ORDER_COL;
 
     // Matrices are stored at the same path in matrices directory
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_sparse_to_dense_csr.hpp
+++ b/clients/include/testing_sparse_to_dense_csr.hpp
@@ -138,7 +138,7 @@ hipsparseStatus_t testing_sparse_to_dense_csr(void)
     hipsparseOrder_t            order    = HIPSPARSE_ORDER_COL;
 
     // Matrices are stored at the same path in matrices directory
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_spgemm_csr.hpp
+++ b/clients/include/testing_spgemm_csr.hpp
@@ -354,7 +354,7 @@ hipsparseStatus_t testing_spgemm_csr(void)
     hipsparseSpGEMMAlg_t alg      = HIPSPARSE_SPGEMM_DEFAULT;
 
     // Matrices are stored at the same path in matrices directory
-    std::string filename = hipsparse_exepath() + "../matrices/nos6.bin";
+    std::string filename = get_filename("nos6.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_spgemmreuse_csr.hpp
+++ b/clients/include/testing_spgemmreuse_csr.hpp
@@ -228,7 +228,7 @@ hipsparseStatus_t testing_spgemmreuse_csr(void)
     hipsparseSpGEMMAlg_t alg      = HIPSPARSE_SPGEMM_DEFAULT;
 
     // Matrices are stored at the same path in matrices directory
-    std::string filename = hipsparse_exepath() + "../matrices/nos6.bin";
+    std::string filename = get_filename("nos6.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_spmm_batched_coo.hpp
+++ b/clients/include/testing_spmm_batched_coo.hpp
@@ -198,7 +198,7 @@ hipsparseStatus_t testing_spmm_batched_coo()
 #endif
 
     // Matrices are stored at the same path in matrices directory
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_spmm_batched_csc.hpp
+++ b/clients/include/testing_spmm_batched_csc.hpp
@@ -209,7 +209,7 @@ hipsparseStatus_t testing_spmm_batched_csc()
 #endif
 
     // Matrices are stored at the same path in matrices directory
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_spmm_batched_csr.hpp
+++ b/clients/include/testing_spmm_batched_csr.hpp
@@ -209,7 +209,7 @@ hipsparseStatus_t testing_spmm_batched_csr()
 #endif
 
     // Matrices are stored at the same path in matrices directory
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_spmm_coo.hpp
+++ b/clients/include/testing_spmm_coo.hpp
@@ -213,7 +213,7 @@ hipsparseStatus_t testing_spmm_coo()
 #endif
 
     // Matrices are stored at the same path in matrices directory
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_spmm_csc.hpp
+++ b/clients/include/testing_spmm_csc.hpp
@@ -215,7 +215,7 @@ hipsparseStatus_t testing_spmm_csc()
 #endif
 
     // Matrices are stored at the same path in matrices directory
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_spmm_csr.hpp
+++ b/clients/include/testing_spmm_csr.hpp
@@ -215,7 +215,7 @@ hipsparseStatus_t testing_spmm_csr()
 #endif
 
     // Matrices are stored at the same path in matrices directory
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_spmv_coo.hpp
+++ b/clients/include/testing_spmv_coo.hpp
@@ -150,7 +150,7 @@ hipsparseStatus_t testing_spmv_coo(void)
     hipsparseSpMVAlg_t   alg      = HIPSPARSE_COOMV_ALG;
 
     // Matrices are stored at the same path in matrices directory
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_spmv_coo_aos.hpp
+++ b/clients/include/testing_spmv_coo_aos.hpp
@@ -148,7 +148,7 @@ hipsparseStatus_t testing_spmv_coo_aos(void)
     hipsparseSpMVAlg_t   alg      = HIPSPARSE_COOMV_ALG;
 
     // Matrices are stored at the same path in matrices directory
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_spmv_csr.hpp
+++ b/clients/include/testing_spmv_csr.hpp
@@ -174,7 +174,7 @@ hipsparseStatus_t testing_spmv_csr(void)
     hipsparseSpMVAlg_t   alg      = HIPSPARSE_CSRMV_ALG2;
 
     // Matrices are stored at the same path in matrices directory
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_spsm_coo.hpp
+++ b/clients/include/testing_spsm_coo.hpp
@@ -191,7 +191,7 @@ hipsparseStatus_t testing_spsm_coo(void)
     hipsparseOrder_t     order    = HIPSPARSE_ORDER_COL;
     hipsparseSpSMAlg_t   alg      = HIPSPARSE_SPSM_ALG_DEFAULT;
 
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_spsm_csr.hpp
+++ b/clients/include/testing_spsm_csr.hpp
@@ -192,7 +192,7 @@ hipsparseStatus_t testing_spsm_csr(void)
     hipsparseOrder_t     order    = HIPSPARSE_ORDER_COL;
     hipsparseSpSMAlg_t   alg      = HIPSPARSE_SPSM_ALG_DEFAULT;
 
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_spsv_coo.hpp
+++ b/clients/include/testing_spsv_coo.hpp
@@ -176,7 +176,7 @@ hipsparseStatus_t testing_spsv_coo(void)
     hipsparseFillMode_t  uplo     = HIPSPARSE_FILL_MODE_LOWER;
     hipsparseSpSVAlg_t   alg      = HIPSPARSE_SPSV_ALG_DEFAULT;
 
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/testing_spsv_csr.hpp
+++ b/clients/include/testing_spsv_csr.hpp
@@ -177,7 +177,7 @@ hipsparseStatus_t testing_spsv_csr(void)
     hipsparseFillMode_t  uplo     = HIPSPARSE_FILL_MODE_LOWER;
     hipsparseSpSVAlg_t   alg      = HIPSPARSE_SPSV_ALG_DEFAULT;
 
-    std::string filename = hipsparse_exepath() + "../matrices/nos3.bin";
+    std::string filename = get_filename("nos3.bin");
 
     // Index and data type
     hipsparseIndexType_t typeI

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -6043,4 +6043,24 @@ public:
     }
 };
 
+const char* get_hipsparse_clients_matrices_dir();
+
+inline std::string get_filename(const std::string& bin_file)
+{
+    const char* matrices_dir = get_hipsparse_clients_matrices_dir();
+    if(matrices_dir == nullptr)
+    {
+        matrices_dir = getenv("HIPSPARSE_CLIENTS_MATRICES_DIR");
+    }
+
+    if(matrices_dir != nullptr)
+    {
+        return matrices_dir + bin_file;
+    }
+    else
+    {
+        return hipsparse_exepath() + "../matrices/" + bin_file;
+    }
+}
+
 #endif // TESTING_UTILITY_HPP

--- a/clients/tests/CMakeLists.txt
+++ b/clients/tests/CMakeLists.txt
@@ -23,116 +23,40 @@
 
 find_package(GTest REQUIRED)
 
-# Download some test matrices
-set(TEST_MATRICES
-  SNAP/amazon0312
-  Muite/Chebyshev4
-  FEMLAB/sme3Dc
-  Williams/webbase-1M
-  Bova/rma10
-  JGD_BIBD/bibd_22_8
-  Williams/mac_econ_fwd500
-  Williams/mc2depi
-  Hamm/scircuit
-  Sandia/ASIC_320k
-  GHS_psdef/bmwcra_1
-  HB/nos1
-  HB/nos2
-  HB/nos3
-  HB/nos4
-  HB/nos5
-  HB/nos6
-  HB/nos7
-  DNVS/shipsec1
-)
 
-set(TEST_MD5HASH
-  f567e5f5029d052e3004bc69bb3f13f5
-  e39879103dafab21f4cf942e0fe42a85
-  a95eee14d980a9cfbbaf5df4a3c64713
-  2d4c239daad6f12d66a1e6a2af44cbdb
-  a899a0c48b9a58d081c52ffd88a84955
-  455d5b699ea10232bbab5bc002219ae6
-  f1b0e56fbb75d1d6862874e3d7d33060
-  8c8633eada6455c1784269b213c85ea6
-  3e62f7ea83914f7e20019aefb2a5176f
-  fcfaf8a25c8f49b8d29f138f3c65c08f
-  8a3cf5448a4fe73dcbdb5a16b326715f
-  b203f7605cb1f20f83280061068f7ec7
-  b0f812ffcc9469f0bf9be701205522c4
-  f185514062a0eeabe86d2909275fe1dc
-  04b781415202db404733ca0c159acbef
-  c98e35f1cfd1ee8177f37bdae155a6e7
-  c39375226aa5c495293003a5f637598f
-  9a6481268847e6cf0d70671f2ff1ddcd
-  73372e7d6a0848f8b19d64a924fab73e
-)
+#
+# Client matrices.
+#
+if(NOT EXISTS "${CMAKE_MATRICES_DIR}")
+  #
+  # Download.
+  #
+  set(CMAKE_MATRICES_DIR ${PROJECT_BINARY_DIR}/matrices CACHE STRING "Matrices directory.")
+  file(MAKE_DIRECTORY ${CMAKE_MATRICES_DIR})
 
-if(NOT TARGET hipsparse)
-  set(CONVERT_SOURCE ${CMAKE_SOURCE_DIR}/../deps/convert.cpp)
-else()
-  set(CONVERT_SOURCE ${CMAKE_SOURCE_DIR}/deps/convert.cpp)
-endif()
-
-if(BUILD_ADDRESS_SANITIZER)
-  execute_process(COMMAND ${CMAKE_CXX_COMPILER} ${CONVERT_SOURCE} -O3 -fsanitize=address -shared-libasan -o ${PROJECT_BINARY_DIR}/mtx2csr.exe)
-else()
-  execute_process(COMMAND ${CMAKE_CXX_COMPILER} ${CONVERT_SOURCE} -O3 -o ${PROJECT_BINARY_DIR}/mtx2csr.exe)
-endif()
-
-list(LENGTH TEST_MATRICES len)
-math(EXPR len1 "${len} - 1")
-
-foreach(i RANGE 0 ${len1})
-  list(GET TEST_MATRICES ${i} m)
-  list(GET TEST_MD5HASH ${i} md5)
-
-  string(REPLACE "/" ";" sep_m ${m})
-  list(GET sep_m 0 dir)
-  list(GET sep_m 1 mat)
-
-  # Download test matrices if not already downloaded
-  set(CMAKE_MATRICES_DIR ${PROJECT_BINARY_DIR}/matrices)
-  if(NOT EXISTS "${CMAKE_MATRICES_DIR}/${mat}.bin")
-    message("-- Downloading and extracting test matrix ${m}.tar.gz")
-    file(DOWNLOAD https://sparse.tamu.edu/MM/${m}.tar.gz ${CMAKE_MATRICES_DIR}/${mat}.tar.gz
-        INACTIVITY_TIMEOUT 3
-        STATUS DL)
-
-    list(GET DL 0 stat)
-    list(GET DL 1 msg)
-
-    if(NOT stat EQUAL 0)
-      message("-- Timeout has been reached, trying mirror ...")
-      # Try again using ufl links
-      file(DOWNLOAD https://www.cise.ufl.edu/research/sparse/MM/${m}.tar.gz ${CMAKE_MATRICES_DIR}/${mat}.tar.gz
-          INACTIVITY_TIMEOUT 3
-          STATUS DL)
-
-      list(GET DL 0 stat)
-      list(GET DL 1 msg)
-
-      if(NOT stat EQUAL 0)
-        message(FATAL_ERROR "${msg}")
-      endif()
-    endif()
-
-    # Check MD5 hash before continuing
-    file(MD5 ${CMAKE_MATRICES_DIR}/${mat}.tar.gz hash)
-
-    # Compare hash
-    if(NOT hash STREQUAL md5)
-      message(FATAL_ERROR "${mat}.tar.gz is corrupted")
-    endif()
-    execute_process(COMMAND tar xf ${mat}.tar.gz WORKING_DIRECTORY ${CMAKE_MATRICES_DIR})
-    
-    file(RENAME ${CMAKE_MATRICES_DIR}/${mat}/${mat}.mtx ${CMAKE_MATRICES_DIR}/${mat}.mtx)
-    execute_process(COMMAND ${PROJECT_BINARY_DIR}/mtx2csr.exe ${mat}.mtx ${mat}.bin WORKING_DIRECTORY ${CMAKE_MATRICES_DIR})
-    # TODO: add 'COMMAND_ERROR_IS_FATAL ANY' once cmake supported version is 3.19
-    file(REMOVE_RECURSE ${CMAKE_MATRICES_DIR}/${mat}.tar.gz ${CMAKE_MATRICES_DIR}/${mat} ${CMAKE_MATRICES_DIR}/${mat}.mtx)
-	
+  if(NOT TARGET hipsparse)
+    set(CONVERT_SOURCE ${CMAKE_SOURCE_DIR}/../deps/convert.cpp CACHE STRING "Convert tool mtx2csr.")
+    include(${CMAKE_SOURCE_DIR}/../cmake/ClientMatrices.cmake)
+  else()
+   set(CONVERT_SOURCE ${CMAKE_SOURCE_DIR}/deps/convert.cpp CACHE STRING "Convert tool mtx2csr.")
+    include(${CMAKE_SOURCE_DIR}/cmake/ClientMatrices.cmake)
   endif()
-endforeach()
+
+else()
+  #
+  # Copy.
+  #
+  if(NOT CMAKE_MATRICES_DIR STREQUAL "${PROJECT_BINARY_DIR}/matrices")
+    message("Copy matrix files from ${CMAKE_MATRICES_DIR} to ${PROJECT_BINARY_DIR}/matrices")
+
+    execute_process(COMMAND cp -r ${CMAKE_MATRICES_DIR} ${PROJECT_BINARY_DIR}/matrices RESULT_VARIABLE STATUS WORKING_DIRECTORY ${CMAKE_MATRICES_DIR})
+
+    if(STATUS AND NOT STATUS EQUAL 0)
+      message(FATAL_ERROR "Failed to copy matrix .bin files, aborting.")
+    endif()
+  endif()
+
+endif()
 
 set(HIPSPARSE_TEST_SOURCES
   hipsparse_gtest_main.cpp

--- a/clients/tests/hipsparse_gtest_main.cpp
+++ b/clients/tests/hipsparse_gtest_main.cpp
@@ -150,6 +150,12 @@ public:
       Main function:
 =================================================================== */
 
+static const char* s_hipsparse_clients_matrices_dir = nullptr;
+const char*        get_hipsparse_clients_matrices_dir()
+{
+    return s_hipsparse_clients_matrices_dir;
+}
+
 int main(int argc, char** argv)
 {
     // Print version
@@ -166,10 +172,34 @@ int main(int argc, char** argv)
             device_id = atoi(argv[i + 1]);
         }
 
+        if(strcmp(argv[i], "--matrices-dir") == 0)
+        {
+            if(argc > i + 1)
+            {
+                s_hipsparse_clients_matrices_dir = argv[i + 1];
+            }
+            else
+            {
+                fprintf(stderr, "missing argument from option --matrices-dir");
+                return -1;
+            }
+        }
+
         if(strcmp(argv[i], "--version") == 0)
         {
             printf("hipSPARSE version: %s\n", version);
-
+            return 0;
+        }
+        if(strcmp(argv[i], "--help") == 0)
+        {
+            fprintf(stderr,
+                    "Usage: %s [--matrices-dir <matrix directory path>] [--device <device id>]\n",
+                    argv[0]);
+            fprintf(stderr,
+                    "To specify the directory of matrix input files the user can export the "
+                    "environment variable HIPSPARSE_CLIENTS_MATRICES_DIR or uses the command line "
+                    "option '--matrices-dir'. If the command line option '--matrices-dir' is used "
+                    "then the environment variable HIPSPARSE_CLIENTS_MATRICES_DIR is ignored.\n");
             return 0;
         }
     }

--- a/clients/tests/test_bsr2csr.cpp
+++ b/clients/tests/test_bsr2csr.cpp
@@ -104,7 +104,7 @@ Arguments setup_bsr2csr_arguments(bsr2csr_bin_tuple tup)
     std::string bin_file = std::get<4>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_bsric02.cpp
+++ b/clients/tests/test_bsric02.cpp
@@ -85,7 +85,7 @@ Arguments setup_bsric02_arguments(bsric02_bin_tuple tup)
     // Get current executables absolute path
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_bsrilu02.cpp
+++ b/clients/tests/test_bsrilu02.cpp
@@ -96,7 +96,7 @@ Arguments setup_bsrilu02_arguments(bsrilu02_bin_tuple tup)
     std::string bin_file = std::get<7>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_bsrmm.cpp
+++ b/clients/tests/test_bsrmm.cpp
@@ -115,7 +115,7 @@ Arguments setup_bsrmm_arguments(bsrmm_bin_tuple tup)
     std::string bin_file = std::get<8>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_bsrmv.cpp
+++ b/clients/tests/test_bsrmv.cpp
@@ -94,7 +94,7 @@ Arguments setup_bsrmv_arguments(bsrmv_bin_tuple tup)
     std::string bin_file = std::get<5>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_bsrsv2.cpp
+++ b/clients/tests/test_bsrsv2.cpp
@@ -100,7 +100,7 @@ Arguments setup_bsrsv2_arguments(bsrsv2_bin_tuple tup)
     std::string bin_file = std::get<7>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_coo2csr.cpp
+++ b/clients/tests/test_coo2csr.cpp
@@ -94,7 +94,7 @@ Arguments setup_coo2csr_arguments(coo2csr_bin_tuple tup)
     arg.timing           = 0;
     std::string bin_file = std::get<1>(tup);
 
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_coosort.cpp
+++ b/clients/tests/test_coosort.cpp
@@ -100,7 +100,7 @@ Arguments setup_coosort_arguments(coosort_bin_tuple tup)
     std::string bin_file = std::get<3>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_cscsort.cpp
+++ b/clients/tests/test_cscsort.cpp
@@ -98,7 +98,7 @@ Arguments setup_cscsort_arguments(cscsort_bin_tuple tup)
     std::string bin_file = std::get<2>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_csr2bsr.cpp
+++ b/clients/tests/test_csr2bsr.cpp
@@ -111,7 +111,7 @@ Arguments setup_csr2bsr_arguments(csr2bsr_bin_tuple tup)
     std::string bin_file = std::get<4>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_csr2coo.cpp
+++ b/clients/tests/test_csr2coo.cpp
@@ -97,7 +97,7 @@ Arguments setup_csr2coo_arguments(csr2coo_bin_tuple tup)
     std::string bin_file = std::get<1>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_csr2csc.cpp
+++ b/clients/tests/test_csr2csc.cpp
@@ -94,7 +94,7 @@ Arguments setup_csr2csc_arguments(csr2csc_bin_tuple tup)
     std::string bin_file = std::get<2>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_csr2csc_ex2.cpp
+++ b/clients/tests/test_csr2csc_ex2.cpp
@@ -95,7 +95,7 @@ Arguments setup_csr2csc_ex2_arguments(csr2csc_ex2_bin_tuple tup)
     std::string bin_file = std::get<2>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_csr2csr_compress.cpp
+++ b/clients/tests/test_csr2csr_compress.cpp
@@ -83,7 +83,7 @@ Arguments setup_csr2csr_compress_arguments(csr2csr_compress_bin_tuple tup)
     std::string bin_file = std::get<2>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_csr2gebsr.cpp
+++ b/clients/tests/test_csr2gebsr.cpp
@@ -118,7 +118,7 @@ Arguments setup_csr2gebsr_arguments(csr2gebsr_bin_tuple tup)
     std::string bin_file = std::get<5>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_csr2hyb.cpp
+++ b/clients/tests/test_csr2hyb.cpp
@@ -90,7 +90,7 @@ Arguments setup_csr2hyb_arguments(csr2hyb_bin_tuple tup)
     std::string bin_file = std::get<3>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_csrgeam.cpp
+++ b/clients/tests/test_csrgeam.cpp
@@ -116,7 +116,7 @@ Arguments setup_csrgeam_arguments(csrgeam_bin_tuple tup)
     std::string bin_file = std::get<5>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_csrgeam2.cpp
+++ b/clients/tests/test_csrgeam2.cpp
@@ -93,7 +93,7 @@ Arguments setup_csrgeam2_arguments(csrgeam2_bin_tuple tup)
     std::string bin_file = std::get<5>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_csrgemm.cpp
+++ b/clients/tests/test_csrgemm.cpp
@@ -107,7 +107,7 @@ Arguments setup_csrgemm_arguments(csrgemm_bin_tuple tup)
     std::string bin_file = std::get<5>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_csrgemm2_a.cpp
+++ b/clients/tests/test_csrgemm2_a.cpp
@@ -93,7 +93,7 @@ Arguments setup_csrgemm2_a_arguments(csrgemm2_a_bin_tuple tup)
     std::string bin_file = std::get<4>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_csrgemm2_b.cpp
+++ b/clients/tests/test_csrgemm2_b.cpp
@@ -87,7 +87,7 @@ Arguments setup_csrgemm2_b_arguments(csrgemm2_b_bin_tuple tup)
     std::string bin_file = std::get<3>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_csric02.cpp
+++ b/clients/tests/test_csric02.cpp
@@ -78,7 +78,7 @@ Arguments setup_csric02_arguments(csric02_bin_tuple tup)
     // Get current executables absolute path
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_csrilu02.cpp
+++ b/clients/tests/test_csrilu02.cpp
@@ -98,7 +98,7 @@ Arguments setup_csrilu02_arguments(csrilu02_bin_tuple tup)
     std::string bin_file = std::get<5>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_csrilusv.cpp
+++ b/clients/tests/test_csrilusv.cpp
@@ -62,7 +62,7 @@ Arguments setup_csrilusv_arguments(csrilusv_bin_tuple tup)
     std::string bin_file = std::get<1>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_csrmm.cpp
+++ b/clients/tests/test_csrmm.cpp
@@ -41,11 +41,11 @@ double csrmm_beta_range[]  = {0.5};
 
 base  csrmm_idxbase_range[] = {HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE};
 trans csrmm_transA_range[]  = {HIPSPARSE_OPERATION_NON_TRANSPOSE,
-                               HIPSPARSE_OPERATION_TRANSPOSE,
-                               HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE};
+                              HIPSPARSE_OPERATION_TRANSPOSE,
+                              HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE};
 trans csrmm_transB_range[]  = {HIPSPARSE_OPERATION_NON_TRANSPOSE,
-                               HIPSPARSE_OPERATION_TRANSPOSE,
-                               HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE};
+                              HIPSPARSE_OPERATION_TRANSPOSE,
+                              HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE};
 
 std::string csrmm_bin[] = {"rma10.bin", "nos1.bin", "nos3.bin", "nos5.bin", "nos7.bin"};
 

--- a/clients/tests/test_csrmm.cpp
+++ b/clients/tests/test_csrmm.cpp
@@ -41,11 +41,11 @@ double csrmm_beta_range[]  = {0.5};
 
 base  csrmm_idxbase_range[] = {HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE};
 trans csrmm_transA_range[]  = {HIPSPARSE_OPERATION_NON_TRANSPOSE,
-                              HIPSPARSE_OPERATION_TRANSPOSE,
-                              HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE};
+                               HIPSPARSE_OPERATION_TRANSPOSE,
+                               HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE};
 trans csrmm_transB_range[]  = {HIPSPARSE_OPERATION_NON_TRANSPOSE,
-                              HIPSPARSE_OPERATION_TRANSPOSE,
-                              HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE};
+                               HIPSPARSE_OPERATION_TRANSPOSE,
+                               HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE};
 
 std::string csrmm_bin[] = {"rma10.bin", "nos1.bin", "nos3.bin", "nos5.bin", "nos7.bin"};
 
@@ -99,7 +99,7 @@ Arguments setup_csrmm_arguments(csrmm_bin_tuple tup)
     std::string bin_file = std::get<6>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_csrmv.cpp
+++ b/clients/tests/test_csrmv.cpp
@@ -40,8 +40,8 @@ std::vector<double> csr_alpha_range = {3.0};
 std::vector<double> csr_beta_range  = {1.0};
 
 trans csr_trans_range[]   = {HIPSPARSE_OPERATION_NON_TRANSPOSE,
-                           HIPSPARSE_OPERATION_TRANSPOSE,
-                           HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE};
+                             HIPSPARSE_OPERATION_TRANSPOSE,
+                             HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE};
 base  csr_idxbase_range[] = {HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE};
 
 std::string csr_bin[] = {"nos1.bin",
@@ -100,7 +100,7 @@ Arguments setup_csrmv_arguments(csrmv_bin_tuple tup)
     std::string bin_file = std::get<4>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_csrmv.cpp
+++ b/clients/tests/test_csrmv.cpp
@@ -40,8 +40,8 @@ std::vector<double> csr_alpha_range = {3.0};
 std::vector<double> csr_beta_range  = {1.0};
 
 trans csr_trans_range[]   = {HIPSPARSE_OPERATION_NON_TRANSPOSE,
-                             HIPSPARSE_OPERATION_TRANSPOSE,
-                             HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE};
+                           HIPSPARSE_OPERATION_TRANSPOSE,
+                           HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE};
 base  csr_idxbase_range[] = {HIPSPARSE_INDEX_BASE_ZERO, HIPSPARSE_INDEX_BASE_ONE};
 
 std::string csr_bin[] = {"nos1.bin",

--- a/clients/tests/test_csrsm2.cpp
+++ b/clients/tests/test_csrsm2.cpp
@@ -99,7 +99,7 @@ Arguments setup_csrsm2_arguments(csrsm2_bin_tuple tup)
     std::string bin_file = std::get<7>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_csrsort.cpp
+++ b/clients/tests/test_csrsort.cpp
@@ -105,7 +105,7 @@ Arguments setup_csrsort_arguments(csrsort_bin_tuple tup)
     std::string bin_file = std::get<2>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_csrsv2.cpp
+++ b/clients/tests/test_csrsv2.cpp
@@ -101,7 +101,7 @@ Arguments setup_csrsv2_arguments(csrsv2_bin_tuple tup)
     std::string bin_file = std::get<5>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_gebsr2csr.cpp
+++ b/clients/tests/test_gebsr2csr.cpp
@@ -109,7 +109,7 @@ Arguments setup_gebsr2csr_arguments(gebsr2csr_bin_tuple tup)
     std::string bin_file = std::get<5>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_gebsr2gebsc.cpp
+++ b/clients/tests/test_gebsr2gebsc.cpp
@@ -99,7 +99,7 @@ Arguments setup_gebsr2gebsc_arguments(gebsr2gebsc_bin_tuple tup)
     std::string bin_file = std::get<4>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_gebsr2gebsr.cpp
+++ b/clients/tests/test_gebsr2gebsr.cpp
@@ -128,7 +128,7 @@ Arguments setup_gebsr2gebsr_arguments(gebsr2gebsr_bin_tuple tup)
     std::string bin_file = std::get<7>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_gemmi.cpp
+++ b/clients/tests/test_gemmi.cpp
@@ -83,7 +83,7 @@ Arguments setup_gemmi_arguments(gemmi_bin_tuple tup)
     std::string bin_file = std::get<3>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_hyb2csr.cpp
+++ b/clients/tests/test_hyb2csr.cpp
@@ -88,7 +88,7 @@ Arguments setup_hyb2csr_arguments(hyb2csr_bin_tuple tup)
     std::string bin_file = std::get<1>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_hybmv.cpp
+++ b/clients/tests/test_hybmv.cpp
@@ -97,7 +97,7 @@ Arguments setup_hybmv_arguments(hybmv_bin_tuple tup)
     std::string bin_file = std::get<5>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_prune_csr2csr.cpp
+++ b/clients/tests/test_prune_csr2csr.cpp
@@ -90,7 +90,7 @@ Arguments setup_prune_csr2csr_arguments(prune_csr2csr_bin_tuple tup)
     std::string bin_file = std::get<3>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/clients/tests/test_prune_csr2csr_by_percentage.cpp
+++ b/clients/tests/test_prune_csr2csr_by_percentage.cpp
@@ -102,7 +102,7 @@ Arguments setup_prune_csr2csr_by_percentage_arguments(prune_csr2csr_by_percentag
     std::string bin_file = std::get<3>(tup);
 
     // Matrices are stored at the same path in matrices directory
-    arg.filename = hipsparse_exepath() + "../matrices/" + bin_file;
+    arg.filename = get_filename(bin_file);
 
     return arg;
 }

--- a/cmake/ClientMatrices.cmake
+++ b/cmake/ClientMatrices.cmake
@@ -1,0 +1,179 @@
+# ########################################################################
+# Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ########################################################################
+
+set(TEST_MATRICES
+  SNAP/amazon0312
+  Muite/Chebyshev4
+  FEMLAB/sme3Dc
+  Williams/webbase-1M
+  Bova/rma10
+  JGD_BIBD/bibd_22_8
+  Williams/mac_econ_fwd500
+  Williams/mc2depi
+  Hamm/scircuit
+  Sandia/ASIC_320k
+  GHS_psdef/bmwcra_1
+  HB/nos1
+  HB/nos2
+  HB/nos3
+  HB/nos4
+  HB/nos5
+  HB/nos6
+  HB/nos7
+  DNVS/shipsec1
+)
+
+set(TEST_MD5HASH
+  f567e5f5029d052e3004bc69bb3f13f5
+  e39879103dafab21f4cf942e0fe42a85
+  a95eee14d980a9cfbbaf5df4a3c64713
+  2d4c239daad6f12d66a1e6a2af44cbdb
+  a899a0c48b9a58d081c52ffd88a84955
+  455d5b699ea10232bbab5bc002219ae6
+  f1b0e56fbb75d1d6862874e3d7d33060
+  8c8633eada6455c1784269b213c85ea6
+  3e62f7ea83914f7e20019aefb2a5176f
+  fcfaf8a25c8f49b8d29f138f3c65c08f
+  8a3cf5448a4fe73dcbdb5a16b326715f
+  b203f7605cb1f20f83280061068f7ec7
+  b0f812ffcc9469f0bf9be701205522c4
+  f185514062a0eeabe86d2909275fe1dc
+  04b781415202db404733ca0c159acbef
+  c98e35f1cfd1ee8177f37bdae155a6e7
+  c39375226aa5c495293003a5f637598f
+  9a6481268847e6cf0d70671f2ff1ddcd
+  73372e7d6a0848f8b19d64a924fab73e
+)
+
+if(NOT CMAKE_MATRICES_DIR)
+  message(FATAL_ERROR "Unspecified CMAKE_MATRICES_DIR")
+endif()
+
+if(NOT CONVERT_SOURCE)
+  set(CONVERT_SOURCE ${CMAKE_SOURCE_DIR}/deps/convert.cpp)
+endif()
+
+# convert relative path to absolute
+get_filename_component(PROJECT_BINARY_DIR "${PROJECT_BINARY_DIR}"
+                       ABSOLUTE BASE_DIR "${CMAKE_SOURCE_DIR}")
+get_filename_component(CMAKE_MATRICES_DIR "${CMAKE_MATRICES_DIR}"
+                       ABSOLUTE BASE_DIR "${CMAKE_SOURCE_DIR}")
+
+file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR})
+
+if(BUILD_ADDRESS_SANITIZER)
+  execute_process(COMMAND ${CMAKE_CXX_COMPILER} ${CONVERT_SOURCE} -O3 -fsanitize=address -shared-libasan -o ${PROJECT_BINARY_DIR}/mtx2csr.exe
+    RESULT_VARIABLE STATUS)
+else()
+  execute_process(COMMAND ${CMAKE_CXX_COMPILER} ${CONVERT_SOURCE} -O3 -o ${PROJECT_BINARY_DIR}/mtx2csr.exe
+    RESULT_VARIABLE STATUS)
+endif()
+
+if(STATUS AND NOT STATUS EQUAL 0)
+  message(FATAL_ERROR "mtx2csr.exe failed to build, aborting.")
+endif()
+
+list(LENGTH TEST_MATRICES len)
+math(EXPR len1 "${len} - 1")
+
+foreach(i RANGE 0 ${len1})
+  list(GET TEST_MATRICES ${i} m)
+  list(GET TEST_MD5HASH ${i} md5)
+
+  string(REPLACE "/" ";" sep_m ${m})
+  list(GET sep_m 0 dir)
+  list(GET sep_m 1 mat)
+
+  # Download test matrices if not already downloaded
+  if(NOT EXISTS "${CMAKE_MATRICES_DIR}/${mat}.bin")
+    if(NOT ROCSPARSE_MTX_DIR)
+      # First try user specified mirror, if available
+      if(DEFINED ENV{ROCSPARSE_TEST_MIRROR} AND NOT $ENV{ROCSPARSE_TEST_MIRROR} STREQUAL "")
+        message("-- Downloading and extracting test matrix ${m}.tar.gz from user specified test mirror: $ENV{ROCSPARSE_TEST_MIRROR}")
+        file(DOWNLOAD $ENV{ROCSPARSE_TEST_MIRROR}/${mat}.tar.gz ${CMAKE_MATRICES_DIR}/${mat}.tar.gz
+             INACTIVITY_TIMEOUT 3
+             STATUS DL)
+
+        list(GET DL 0 stat)
+        list(GET DL 1 msg)
+
+        if(NOT stat EQUAL 0)
+          message(FATAL_ERROR "-- Timeout has been reached, specified test mirror is not reachable: ${msg}")
+        endif()
+      else()
+        message("-- Downloading and extracting test matrix ${m}.tar.gz")
+        file(DOWNLOAD https://sparse.tamu.edu/MM/${m}.tar.gz ${CMAKE_MATRICES_DIR}/${mat}.tar.gz
+             INACTIVITY_TIMEOUT 3
+             STATUS DL)
+
+        list(GET DL 0 stat)
+        list(GET DL 1 msg)
+
+        if(NOT stat EQUAL 0)
+          message("-- Timeout has been reached, trying mirror ...")
+          # Try again using ufl links
+          file(DOWNLOAD https://www.cise.ufl.edu/research/sparse/MM/${m}.tar.gz ${CMAKE_MATRICES_DIR}/${mat}.tar.gz
+               INACTIVITY_TIMEOUT 3
+               STATUS DL)
+
+          list(GET DL 0 stat)
+          list(GET DL 1 msg)
+
+          if(NOT stat EQUAL 0)
+            message(FATAL_ERROR "${msg}")
+          endif()
+        endif()
+      endif()
+
+      # Check MD5 hash before continuing
+      file(MD5 ${CMAKE_MATRICES_DIR}/${mat}.tar.gz hash)
+
+      # Compare hash
+      if(NOT hash STREQUAL md5)
+        message(FATAL_ERROR "${mat}.tar.gz is corrupted")
+      endif()
+
+      execute_process(COMMAND tar xf ${mat}.tar.gz
+        RESULT_VARIABLE STATUS
+        WORKING_DIRECTORY ${CMAKE_MATRICES_DIR})
+      if(STATUS AND NOT STATUS EQUAL 0)
+        message(FATAL_ERROR "uncompressing failed, aborting.")
+      endif()
+
+      file(RENAME ${CMAKE_MATRICES_DIR}/${mat}/${mat}.mtx ${CMAKE_MATRICES_DIR}/${mat}.mtx)
+    else()
+      file(RENAME ${ROCSPARSE_MTX_DIR}/${mat}/${mat}.mtx ${CMAKE_MATRICES_DIR}/${mat}.mtx)
+    endif()
+    execute_process(COMMAND ${PROJECT_BINARY_DIR}/mtx2csr.exe ${mat}.mtx ${mat}.bin
+      RESULT_VARIABLE STATUS
+      WORKING_DIRECTORY ${CMAKE_MATRICES_DIR})
+    if(STATUS AND NOT STATUS EQUAL 0)
+      message(FATAL_ERROR "mtx2csr.exe failed, aborting.")
+    else()
+      message(STATUS "${mat} success.")
+    endif()
+    # TODO: add 'COMMAND_ERROR_IS_FATAL ANY' once cmake supported version is 3.19
+    file(REMOVE_RECURSE ${CMAKE_MATRICES_DIR}/${mat}.tar.gz ${CMAKE_MATRICES_DIR}/${mat} ${CMAKE_MATRICES_DIR}/${mat}.mtx)
+
+  endif()
+endforeach()


### PR DESCRIPTION
[SWDEV-359377](https://ontrack-internal.amd.com/browse/SWDEV-359377)

The proposed refactoring allows the user to specify the path of the directory of the matrix files.
This can be done either with the environment variable HIPSPARSE_CLIENTS_MATRICES_DIR:

> export HIPSPARSE_CLIENTS_MATRICES_DIR=\<path\>
> hipsparse-test 

or from the command line (in that case the environment variable is ignored):
> hipsparse-test --matrices-dir \<path\>


