### PR TITLE
366827 - Disable file reorg backward compatibility support by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ endif()
 include(cmake/Dependencies.cmake)
 
 # FOR HANDLING ENABLE/DISABLE OPTIONAL BACKWARD COMPATIBILITY for FILE/FOLDER REORG
-option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY "Build with file/folder reorg with backward compatibility enabled" ON)
+option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY "Build with file/folder reorg with backward compatibility enabled" OFF)
 if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
   rocm_wrap_header_dir(
     ${CMAKE_SOURCE_DIR}/library/include

--- a/install.sh
+++ b/install.sh
@@ -268,7 +268,7 @@ install_prefix=hipsparse-install
 rocm_path=/opt/rocm
 build_relocatable=false
 build_address_sanitizer=false
-build_freorg_bkwdcomp=true
+build_freorg_bkwdcomp=false
 compiler=${CXX}
 
 # #################################################


### PR DESCRIPTION
Change proposed:
- File Reorg backward compatibility option set to OFF
- Backward Compatibility flag in install script set to false by default.