### PR TITLE
Remove auto stage form hipSPARSE

### DIFF
--- a/clients/include/testing_bsrmv.hpp
+++ b/clients/include/testing_bsrmv.hpp
@@ -445,6 +445,7 @@ hipsparseStatus_t testing_bsrmv(Arguments argus)
     CHECK_HIP_ERROR(hipMemcpy(d_alpha, &h_alpha, sizeof(T), hipMemcpyHostToDevice));
     CHECK_HIP_ERROR(hipMemcpy(d_beta, &h_beta, sizeof(T), hipMemcpyHostToDevice));
 
+    std::cout << "AAAA" << std::endl;
     // Convert to BSR
     int nnzb;
     CHECK_HIPSPARSE_ERROR(hipsparseXcsr2bsrNnz(handle,
@@ -467,6 +468,7 @@ hipsparseStatus_t testing_bsrmv(Arguments argus)
     int* dbsr_col_ind = (int*)dbsr_col_ind_managed.get();
     T*   dbsr_val     = (T*)dbsr_val_managed.get();
 
+    std::cout << "BBBB nnzb: " << nnzb << std::endl;
     CHECK_HIPSPARSE_ERROR(hipsparseXcsr2bsr(handle,
                                             dir,
                                             m,
@@ -480,6 +482,8 @@ hipsparseStatus_t testing_bsrmv(Arguments argus)
                                             dbsr_val,
                                             dbsr_row_ptr,
                                             dbsr_col_ind));
+
+    std::cout << "CCCC" << std::endl;
 
     if(argus.unit_check)
     {
@@ -503,6 +507,8 @@ hipsparseStatus_t testing_bsrmv(Arguments argus)
                                               &h_beta,
                                               dy_1));
 
+        std::cout << "DDDD" << std::endl;
+
         // ROCSPARSE pointer mode device
         CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_DEVICE));
         CHECK_HIPSPARSE_ERROR(hipsparseXbsrmv(handle,
@@ -520,6 +526,8 @@ hipsparseStatus_t testing_bsrmv(Arguments argus)
                                               dx,
                                               d_beta,
                                               dy_2));
+
+        std::cout << "EEEE" << std::endl;
 
         // copy output from device to CPU
         CHECK_HIP_ERROR(hipMemcpy(hy_1.data(), dy_1, sizeof(T) * m, hipMemcpyDeviceToHost));

--- a/clients/include/testing_bsrmv.hpp
+++ b/clients/include/testing_bsrmv.hpp
@@ -358,20 +358,20 @@ hipsparseStatus_t testing_bsrmv(Arguments argus)
 
         CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_HOST));
         hipsparseStatus_t status = hipsparseXbsrmv(handle,
-                                 dir,
-                                 transA,
-                                 mb,
-                                 nb,
-                                 safe_size,
-                                 &h_alpha,
-                                 descr,
-                                 dval,
-                                 dptr,
-                                 dcol,
-                                 block_dim,
-                                 dx,
-                                 &h_beta,
-                                 dy);
+                                                   dir,
+                                                   transA,
+                                                   mb,
+                                                   nb,
+                                                   safe_size,
+                                                   &h_alpha,
+                                                   descr,
+                                                   dval,
+                                                   dptr,
+                                                   dcol,
+                                                   block_dim,
+                                                   dx,
+                                                   &h_beta,
+                                                   dy);
 
         verify_hipsparse_status_success(status, "mb >= 0 && nb >= 0");
 

--- a/clients/tests/test_bsrmm.cpp
+++ b/clients/tests/test_bsrmm.cpp
@@ -34,9 +34,9 @@ typedef std::tuple<int, int, int, int, double, double, direction, base, trans, t
 typedef std::tuple<int, int, double, double, direction, base, trans, trans, std::string>
     bsrmm_bin_tuple;
 
-int bsrmm_M_range[]         = {-1, 42, 2059};
-int bsrmm_N_range[]         = {-1, 7, 78};
-int bsrmm_K_range[]         = {-1, 50, 173, 1375};
+int bsrmm_M_range[]         = {42, 2059};
+int bsrmm_N_range[]         = {7, 78};
+int bsrmm_K_range[]         = {50, 173, 1375};
 int bsrmm_block_dim_range[] = {4, 7, 16};
 
 double bsrmm_alpha_range[] = {-0.5};

--- a/clients/tests/test_bsrmv.cpp
+++ b/clients/tests/test_bsrmv.cpp
@@ -37,7 +37,6 @@ int bsr_M_range[]   = {0, 500, 7111};
 int bsr_N_range[]   = {0, 842, 4441};
 int bsr_dim_range[] = {1, 3, 5, 9};
 
-
 std::vector<double> bsr_alpha_range = {3.0};
 std::vector<double> bsr_beta_range  = {1.0};
 

--- a/clients/tests/test_bsrmv.cpp
+++ b/clients/tests/test_bsrmv.cpp
@@ -33,9 +33,10 @@ typedef hipsparseDirection_t                                    dir;
 typedef std::tuple<int, int, double, double, int, dir, base>    bsrmv_tuple;
 typedef std::tuple<double, double, int, dir, base, std::string> bsrmv_bin_tuple;
 
-int bsr_M_range[]   = {-1, 0, 500, 7111};
-int bsr_N_range[]   = {-3, 0, 842, 4441};
-int bsr_dim_range[] = {-1, 0, 1, 3, 5, 9};
+int bsr_M_range[]   = {0, 500, 7111};
+int bsr_N_range[]   = {0, 842, 4441};
+int bsr_dim_range[] = {1, 3, 5, 9};
+
 
 std::vector<double> bsr_alpha_range = {3.0};
 std::vector<double> bsr_beta_range  = {1.0};

--- a/library/src/amd_detail/hipsparse.cpp
+++ b/library/src/amd_detail/hipsparse.cpp
@@ -14208,58 +14208,58 @@ hipsparseStatus_t hipsparseSpGEMM_compute(hipsparseHandle_t          handle,
 
     // get matrix C non-zero entries C_nnz1
     int64_t C_num_rows1, C_num_cols1, C_nnz1;
-    RETURN_IF_HIPSPARSE_ERROR(hipsparseSpMatGetSize(matC, &C_num_rows1, &C_num_cols1, &C_nnz1) )
+    RETURN_IF_HIPSPARSE_ERROR(hipsparseSpMatGetSize(matC, &C_num_rows1, &C_num_cols1, &C_nnz1))
 
     if(externalBuffer2 == nullptr)
     {
         return rocSPARSEStatusToHIPStatus(rocsparse_spgemm((rocsparse_handle)handle,
-                                                       hipOperationToHCCOperation(opA),
-                                                       hipOperationToHCCOperation(opB),
-                                                       alpha_ptr,
-                                                       (rocsparse_const_spmat_descr)matA,
-                                                       (rocsparse_const_spmat_descr)matB,
-                                                       beta_ptr,
-                                                       (rocsparse_spmat_descr)matC,
-                                                       (rocsparse_spmat_descr)matC,
-                                                       hipDataTypeToHCCDataType(computeType),
-                                                       hipSpGEMMAlgToHCCSpGEMMAlg(alg),
-                                                       rocsparse_spgemm_stage_buffer_size,
-                                                       bufferSize2,
-                                                       externalBuffer2));
+                                                           hipOperationToHCCOperation(opA),
+                                                           hipOperationToHCCOperation(opB),
+                                                           alpha_ptr,
+                                                           (rocsparse_const_spmat_descr)matA,
+                                                           (rocsparse_const_spmat_descr)matB,
+                                                           beta_ptr,
+                                                           (rocsparse_spmat_descr)matC,
+                                                           (rocsparse_spmat_descr)matC,
+                                                           hipDataTypeToHCCDataType(computeType),
+                                                           hipSpGEMMAlgToHCCSpGEMMAlg(alg),
+                                                           rocsparse_spgemm_stage_buffer_size,
+                                                           bufferSize2,
+                                                           externalBuffer2));
     }
     else if(C_nnz1 == 0)
     {
         return rocSPARSEStatusToHIPStatus(rocsparse_spgemm((rocsparse_handle)handle,
-                                                       hipOperationToHCCOperation(opA),
-                                                       hipOperationToHCCOperation(opB),
-                                                       alpha_ptr,
-                                                       (rocsparse_const_spmat_descr)matA,
-                                                       (rocsparse_const_spmat_descr)matB,
-                                                       beta_ptr,
-                                                       (rocsparse_spmat_descr)matC,
-                                                       (rocsparse_spmat_descr)matC,
-                                                       hipDataTypeToHCCDataType(computeType),
-                                                       hipSpGEMMAlgToHCCSpGEMMAlg(alg),
-                                                       rocsparse_spgemm_stage_nnz,
-                                                       bufferSize2,
-                                                       externalBuffer2));
+                                                           hipOperationToHCCOperation(opA),
+                                                           hipOperationToHCCOperation(opB),
+                                                           alpha_ptr,
+                                                           (rocsparse_const_spmat_descr)matA,
+                                                           (rocsparse_const_spmat_descr)matB,
+                                                           beta_ptr,
+                                                           (rocsparse_spmat_descr)matC,
+                                                           (rocsparse_spmat_descr)matC,
+                                                           hipDataTypeToHCCDataType(computeType),
+                                                           hipSpGEMMAlgToHCCSpGEMMAlg(alg),
+                                                           rocsparse_spgemm_stage_nnz,
+                                                           bufferSize2,
+                                                           externalBuffer2));
     }
     else
     {
         return rocSPARSEStatusToHIPStatus(rocsparse_spgemm((rocsparse_handle)handle,
-                                                       hipOperationToHCCOperation(opA),
-                                                       hipOperationToHCCOperation(opB),
-                                                       alpha_ptr,
-                                                       (rocsparse_const_spmat_descr)matA,
-                                                       (rocsparse_const_spmat_descr)matB,
-                                                       beta_ptr,
-                                                       (rocsparse_spmat_descr)matC,
-                                                       (rocsparse_spmat_descr)matC,
-                                                       hipDataTypeToHCCDataType(computeType),
-                                                       hipSpGEMMAlgToHCCSpGEMMAlg(alg),
-                                                       rocsparse_spgemm_stage_compute,
-                                                       bufferSize2,
-                                                       externalBuffer2));
+                                                           hipOperationToHCCOperation(opA),
+                                                           hipOperationToHCCOperation(opB),
+                                                           alpha_ptr,
+                                                           (rocsparse_const_spmat_descr)matA,
+                                                           (rocsparse_const_spmat_descr)matB,
+                                                           beta_ptr,
+                                                           (rocsparse_spmat_descr)matC,
+                                                           (rocsparse_spmat_descr)matC,
+                                                           hipDataTypeToHCCDataType(computeType),
+                                                           hipSpGEMMAlgToHCCSpGEMMAlg(alg),
+                                                           rocsparse_spgemm_stage_compute,
+                                                           bufferSize2,
+                                                           externalBuffer2));
     }
 }
 

--- a/library/src/amd_detail/hipsparse.cpp
+++ b/library/src/amd_detail/hipsparse.cpp
@@ -8705,6 +8705,27 @@ hipsparseStatus_t hipsparseCsr2cscEx2(hipsparseHandle_t     handle,
                                buffer));
     case HIP_R_16F:
     case HIP_C_16F:
+    case HIP_C_8I:
+    case HIP_R_8U:
+    case HIP_C_8U:
+    case HIP_R_32I:
+    case HIP_C_32I:
+    case HIP_R_32U:
+    case HIP_C_32U:
+    case HIP_R_16BF:
+    case HIP_C_16BF:
+    case HIP_R_4I:
+    case HIP_C_4I:
+    case HIP_R_4U:
+    case HIP_C_4U:
+    case HIP_R_16I:
+    case HIP_C_16I:
+    case HIP_R_16U:
+    case HIP_C_16U:
+    case HIP_R_64I:
+    case HIP_C_64I:
+    case HIP_R_64U:
+    case HIP_C_64U:
         return HIPSPARSE_STATUS_NOT_SUPPORTED;
     }
 


### PR DESCRIPTION
Removes auto stage from hipSPARSE as it has been removed from rocSPARSE.
Also fixes failures in bsrmv and bsrmm related to changes made in the rocsparse PR: https://github.com/ROCmSoftwarePlatform/rocSPARSE-internal/commit/ddb9a9f89dd1b84b2f52937174b27a2d5c81afb9