### PR TITLE
Add hipsparseGetErrorName and hipsparseGetErrorString

### DIFF
--- a/clients/include/testing_axpby.hpp
+++ b/clients/include/testing_axpby.hpp
@@ -89,32 +89,55 @@ void testing_axpby_bad_arg(void)
     verify_hipsparse_status_success(hipsparseDestroyDnVec(y), "Success");
 #endif
 
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_SUCCESS): "
+              << hipsparseGetErrorName(HIPSPARSE_STATUS_SUCCESS) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_NOT_INITIALIZED): "
+              << hipsparseGetErrorName(HIPSPARSE_STATUS_NOT_INITIALIZED) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_ALLOC_FAILED): "
+              << hipsparseGetErrorName(HIPSPARSE_STATUS_ALLOC_FAILED) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_INVALID_VALUE): "
+              << hipsparseGetErrorName(HIPSPARSE_STATUS_INVALID_VALUE) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_ARCH_MISMATCH): "
+              << hipsparseGetErrorName(HIPSPARSE_STATUS_ARCH_MISMATCH) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_MAPPING_ERROR): "
+              << hipsparseGetErrorName(HIPSPARSE_STATUS_MAPPING_ERROR) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_EXECUTION_FAILED): "
+              << hipsparseGetErrorName(HIPSPARSE_STATUS_EXECUTION_FAILED) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_INTERNAL_ERROR): "
+              << hipsparseGetErrorName(HIPSPARSE_STATUS_INTERNAL_ERROR) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED): "
+              << hipsparseGetErrorName(HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_ZERO_PIVOT): "
+              << hipsparseGetErrorName(HIPSPARSE_STATUS_ZERO_PIVOT) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_NOT_SUPPORTED): "
+              << hipsparseGetErrorName(HIPSPARSE_STATUS_NOT_SUPPORTED) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES): "
+              << hipsparseGetErrorName(HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES) << std::endl;
 
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_SUCCESS): " << hipsparseGetErrorName(HIPSPARSE_STATUS_SUCCESS) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_NOT_INITIALIZED): " << hipsparseGetErrorName(HIPSPARSE_STATUS_NOT_INITIALIZED) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_ALLOC_FAILED): " << hipsparseGetErrorName(HIPSPARSE_STATUS_ALLOC_FAILED) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_INVALID_VALUE): " << hipsparseGetErrorName(HIPSPARSE_STATUS_INVALID_VALUE) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_ARCH_MISMATCH): " << hipsparseGetErrorName(HIPSPARSE_STATUS_ARCH_MISMATCH) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_MAPPING_ERROR): " << hipsparseGetErrorName(HIPSPARSE_STATUS_MAPPING_ERROR) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_EXECUTION_FAILED): " << hipsparseGetErrorName(HIPSPARSE_STATUS_EXECUTION_FAILED) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_INTERNAL_ERROR): " << hipsparseGetErrorName(HIPSPARSE_STATUS_INTERNAL_ERROR) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED): " << hipsparseGetErrorName(HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_ZERO_PIVOT): " << hipsparseGetErrorName(HIPSPARSE_STATUS_ZERO_PIVOT) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_NOT_SUPPORTED): " << hipsparseGetErrorName(HIPSPARSE_STATUS_NOT_SUPPORTED) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES): " << hipsparseGetErrorName(HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES) << std::endl;
-
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_SUCCESS): " << hipsparseGetErrorString(HIPSPARSE_STATUS_SUCCESS) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_NOT_INITIALIZED): " << hipsparseGetErrorString(HIPSPARSE_STATUS_NOT_INITIALIZED) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_ALLOC_FAILED): " << hipsparseGetErrorString(HIPSPARSE_STATUS_ALLOC_FAILED) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_INVALID_VALUE): " << hipsparseGetErrorString(HIPSPARSE_STATUS_INVALID_VALUE) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_ARCH_MISMATCH): " << hipsparseGetErrorString(HIPSPARSE_STATUS_ARCH_MISMATCH) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_MAPPING_ERROR): " << hipsparseGetErrorString(HIPSPARSE_STATUS_MAPPING_ERROR) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_EXECUTION_FAILED): " << hipsparseGetErrorString(HIPSPARSE_STATUS_EXECUTION_FAILED) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_INTERNAL_ERROR): " << hipsparseGetErrorString(HIPSPARSE_STATUS_INTERNAL_ERROR) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED): " << hipsparseGetErrorString(HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_ZERO_PIVOT): " << hipsparseGetErrorString(HIPSPARSE_STATUS_ZERO_PIVOT) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_NOT_SUPPORTED): " << hipsparseGetErrorString(HIPSPARSE_STATUS_NOT_SUPPORTED) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES): " << hipsparseGetErrorString(HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_SUCCESS): "
+              << hipsparseGetErrorString(HIPSPARSE_STATUS_SUCCESS) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_NOT_INITIALIZED): "
+              << hipsparseGetErrorString(HIPSPARSE_STATUS_NOT_INITIALIZED) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_ALLOC_FAILED): "
+              << hipsparseGetErrorString(HIPSPARSE_STATUS_ALLOC_FAILED) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_INVALID_VALUE): "
+              << hipsparseGetErrorString(HIPSPARSE_STATUS_INVALID_VALUE) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_ARCH_MISMATCH): "
+              << hipsparseGetErrorString(HIPSPARSE_STATUS_ARCH_MISMATCH) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_MAPPING_ERROR): "
+              << hipsparseGetErrorString(HIPSPARSE_STATUS_MAPPING_ERROR) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_EXECUTION_FAILED): "
+              << hipsparseGetErrorString(HIPSPARSE_STATUS_EXECUTION_FAILED) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_INTERNAL_ERROR): "
+              << hipsparseGetErrorString(HIPSPARSE_STATUS_INTERNAL_ERROR) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED): "
+              << hipsparseGetErrorString(HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_ZERO_PIVOT): "
+              << hipsparseGetErrorString(HIPSPARSE_STATUS_ZERO_PIVOT) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_NOT_SUPPORTED): "
+              << hipsparseGetErrorString(HIPSPARSE_STATUS_NOT_SUPPORTED) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES): "
+              << hipsparseGetErrorString(HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES) << std::endl;
 }
 
 template <typename I, typename T>

--- a/clients/include/testing_axpby.hpp
+++ b/clients/include/testing_axpby.hpp
@@ -88,6 +88,33 @@ void testing_axpby_bad_arg(void)
     verify_hipsparse_status_success(hipsparseDestroySpVec(x), "Success");
     verify_hipsparse_status_success(hipsparseDestroyDnVec(y), "Success");
 #endif
+
+
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_SUCCESS): " << hipsparseGetErrorName(HIPSPARSE_STATUS_SUCCESS) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_NOT_INITIALIZED): " << hipsparseGetErrorName(HIPSPARSE_STATUS_NOT_INITIALIZED) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_ALLOC_FAILED): " << hipsparseGetErrorName(HIPSPARSE_STATUS_ALLOC_FAILED) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_INVALID_VALUE): " << hipsparseGetErrorName(HIPSPARSE_STATUS_INVALID_VALUE) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_ARCH_MISMATCH): " << hipsparseGetErrorName(HIPSPARSE_STATUS_ARCH_MISMATCH) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_MAPPING_ERROR): " << hipsparseGetErrorName(HIPSPARSE_STATUS_MAPPING_ERROR) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_EXECUTION_FAILED): " << hipsparseGetErrorName(HIPSPARSE_STATUS_EXECUTION_FAILED) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_INTERNAL_ERROR): " << hipsparseGetErrorName(HIPSPARSE_STATUS_INTERNAL_ERROR) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED): " << hipsparseGetErrorName(HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_ZERO_PIVOT): " << hipsparseGetErrorName(HIPSPARSE_STATUS_ZERO_PIVOT) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_NOT_SUPPORTED): " << hipsparseGetErrorName(HIPSPARSE_STATUS_NOT_SUPPORTED) << std::endl;
+    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES): " << hipsparseGetErrorName(HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES) << std::endl;
+
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_SUCCESS): " << hipsparseGetErrorString(HIPSPARSE_STATUS_SUCCESS) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_NOT_INITIALIZED): " << hipsparseGetErrorString(HIPSPARSE_STATUS_NOT_INITIALIZED) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_ALLOC_FAILED): " << hipsparseGetErrorString(HIPSPARSE_STATUS_ALLOC_FAILED) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_INVALID_VALUE): " << hipsparseGetErrorString(HIPSPARSE_STATUS_INVALID_VALUE) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_ARCH_MISMATCH): " << hipsparseGetErrorString(HIPSPARSE_STATUS_ARCH_MISMATCH) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_MAPPING_ERROR): " << hipsparseGetErrorString(HIPSPARSE_STATUS_MAPPING_ERROR) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_EXECUTION_FAILED): " << hipsparseGetErrorString(HIPSPARSE_STATUS_EXECUTION_FAILED) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_INTERNAL_ERROR): " << hipsparseGetErrorString(HIPSPARSE_STATUS_INTERNAL_ERROR) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED): " << hipsparseGetErrorString(HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_ZERO_PIVOT): " << hipsparseGetErrorString(HIPSPARSE_STATUS_ZERO_PIVOT) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_NOT_SUPPORTED): " << hipsparseGetErrorString(HIPSPARSE_STATUS_NOT_SUPPORTED) << std::endl;
+    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES): " << hipsparseGetErrorString(HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES) << std::endl;
 }
 
 template <typename I, typename T>

--- a/clients/include/testing_axpby.hpp
+++ b/clients/include/testing_axpby.hpp
@@ -88,56 +88,6 @@ void testing_axpby_bad_arg(void)
     verify_hipsparse_status_success(hipsparseDestroySpVec(x), "Success");
     verify_hipsparse_status_success(hipsparseDestroyDnVec(y), "Success");
 #endif
-
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_SUCCESS): "
-              << hipsparseGetErrorName(HIPSPARSE_STATUS_SUCCESS) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_NOT_INITIALIZED): "
-              << hipsparseGetErrorName(HIPSPARSE_STATUS_NOT_INITIALIZED) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_ALLOC_FAILED): "
-              << hipsparseGetErrorName(HIPSPARSE_STATUS_ALLOC_FAILED) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_INVALID_VALUE): "
-              << hipsparseGetErrorName(HIPSPARSE_STATUS_INVALID_VALUE) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_ARCH_MISMATCH): "
-              << hipsparseGetErrorName(HIPSPARSE_STATUS_ARCH_MISMATCH) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_MAPPING_ERROR): "
-              << hipsparseGetErrorName(HIPSPARSE_STATUS_MAPPING_ERROR) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_EXECUTION_FAILED): "
-              << hipsparseGetErrorName(HIPSPARSE_STATUS_EXECUTION_FAILED) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_INTERNAL_ERROR): "
-              << hipsparseGetErrorName(HIPSPARSE_STATUS_INTERNAL_ERROR) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED): "
-              << hipsparseGetErrorName(HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_ZERO_PIVOT): "
-              << hipsparseGetErrorName(HIPSPARSE_STATUS_ZERO_PIVOT) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_NOT_SUPPORTED): "
-              << hipsparseGetErrorName(HIPSPARSE_STATUS_NOT_SUPPORTED) << std::endl;
-    std::cout << "hipsparseGetErrorName(HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES): "
-              << hipsparseGetErrorName(HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES) << std::endl;
-
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_SUCCESS): "
-              << hipsparseGetErrorString(HIPSPARSE_STATUS_SUCCESS) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_NOT_INITIALIZED): "
-              << hipsparseGetErrorString(HIPSPARSE_STATUS_NOT_INITIALIZED) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_ALLOC_FAILED): "
-              << hipsparseGetErrorString(HIPSPARSE_STATUS_ALLOC_FAILED) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_INVALID_VALUE): "
-              << hipsparseGetErrorString(HIPSPARSE_STATUS_INVALID_VALUE) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_ARCH_MISMATCH): "
-              << hipsparseGetErrorString(HIPSPARSE_STATUS_ARCH_MISMATCH) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_MAPPING_ERROR): "
-              << hipsparseGetErrorString(HIPSPARSE_STATUS_MAPPING_ERROR) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_EXECUTION_FAILED): "
-              << hipsparseGetErrorString(HIPSPARSE_STATUS_EXECUTION_FAILED) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_INTERNAL_ERROR): "
-              << hipsparseGetErrorString(HIPSPARSE_STATUS_INTERNAL_ERROR) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED): "
-              << hipsparseGetErrorString(HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_ZERO_PIVOT): "
-              << hipsparseGetErrorString(HIPSPARSE_STATUS_ZERO_PIVOT) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_NOT_SUPPORTED): "
-              << hipsparseGetErrorString(HIPSPARSE_STATUS_NOT_SUPPORTED) << std::endl;
-    std::cout << "hipsparseGetErrorString(HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES): "
-              << hipsparseGetErrorString(HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES) << std::endl;
 }
 
 template <typename I, typename T>

--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -44,6 +44,8 @@
 #include <hip/hip_complex.h>
 #include <hip/hip_runtime.h>
 
+#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
+
 /// \cond DO_NOT_DOCUMENT
 #define DEPRECATED_CUDA_12000(warning)
 #define DEPRECATED_CUDA_11000(warning)
@@ -506,20 +508,26 @@ hipsparseStatus_t hipsparseDestroy(hipsparseHandle_t handle);
 
 #if(!defined(CUDART_VERSION) || CUDART_VERSION > 10000)
 /*! \ingroup aux_module
- *  \brief Return the string representation of a hipSPARSE status code enum name
+ *  \brief Return the string representation of a hipSPARSE status's matching backend status enum name
  *
  *  \details
- *  \p hipsparseGetErrorName takes a hipSPARSE status as input and returns the string representation of this status.
- *  If the status is not recognized, the function returns "Unrecognized status code".
+ *  \p hipsparseGetErrorName takes a hipSPARSE status as input and first converts it to the matching backend 
+ *  status (either rocsparse_status or cusparseStatus_t). It then returns the string representation of this status 
+ *  enum name. If the status is not recognized, the function returns "Unrecognized status code".
+ *
+ *  For example, hipsparseGetErrorName(HIPSPARSE_STATUS_SUCCESS) on a system with a rocSPARSE backend will 
+ *  return "rocsparse_status_success". On a system with a cuSPARSE backend this function would return 
+ *  "CUSPARSE_STATUS_SUCCESS".
  */
 HIPSPARSE_EXPORT
 const char* hipsparseGetErrorName(hipsparseStatus_t status);
 
 /*! \ingroup aux_module
- *  \brief Return the hipSPARSE status code description as a string
+ *  \brief Return the hipSPARSE status's matching backend status description as a string
  *
  *  \details
- *  \p hipsparseGetErrorString takes a hipSPARSE status as input and returns the string representation of this status.
+ *  \p hipsparseGetErrorString takes a hipSPARSE status as input and first converts it to the matching backend 
+ *  status (either rocsparse_status or cusparseStatus_t). It then returns the string description of this status.
  *  If the status is not recognized, the function returns "Unrecognized status code".
  */
 HIPSPARSE_EXPORT

--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -44,8 +44,6 @@
 #include <hip/hip_complex.h>
 #include <hip/hip_runtime.h>
 
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-
 /// \cond DO_NOT_DOCUMENT
 #define DEPRECATED_CUDA_12000(warning)
 #define DEPRECATED_CUDA_11000(warning)

--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -409,6 +409,28 @@ hipsparseStatus_t hipsparseCreate(hipsparseHandle_t* handle);
 HIPSPARSE_EXPORT
 hipsparseStatus_t hipsparseDestroy(hipsparseHandle_t handle);
 
+#if(!defined(CUDART_VERSION) || CUDART_VERSION > 10000)
+/*! \ingroup aux_module
+ *  \brief Return the string representation of a hipSPARSE status code enum name
+ *
+ *  \details
+ *  \p hipsparseGetErrorName takes a hipSPARSE status as input and returns the string representation of this status.
+ *  If the status is not recognized, the function returns "Unrecognized status code".
+ */
+HIPSPARSE_EXPORT
+const char* hipsparseGetErrorName(hipsparseStatus_t status);
+
+/*! \ingroup aux_module
+ *  \brief Return the hipSPARSE status code description as a string
+ *
+ *  \details
+ *  \p hipsparseGetErrorString takes a hipSPARSE status as input and returns the string representation of this status.
+ *  If the status is not recognized, the function returns "Unrecognized status code".
+ */
+HIPSPARSE_EXPORT
+const char* hipsparseGetErrorString(hipsparseStatus_t status);
+#endif
+
 /*! \ingroup aux_module
  *  \brief Get hipSPARSE version
  *

--- a/library/src/amd_detail/hipsparse.cpp
+++ b/library/src/amd_detail/hipsparse.cpp
@@ -656,6 +656,16 @@ hipsparseStatus_t hipsparseDestroy(hipsparseHandle_t handle)
     return rocSPARSEStatusToHIPStatus(rocsparse_destroy_handle((rocsparse_handle)handle));
 }
 
+const char* hipsparseGetErrorName(hipsparseStatus_t status);
+{
+    return rocsparseGetStatusName(status);
+}
+
+const char* hipsparseGetErrorString(hipsparseStatus_t status)
+{
+    return rocsparseGetStatusString(status);
+}
+
 hipsparseStatus_t hipsparseGetVersion(hipsparseHandle_t handle, int* version)
 {
     if(handle == nullptr)

--- a/library/src/amd_detail/hipsparse.cpp
+++ b/library/src/amd_detail/hipsparse.cpp
@@ -120,8 +120,46 @@ hipsparseStatus_t rocSPARSEStatusToHIPStatus(rocsparse_status_ status)
         return HIPSPARSE_STATUS_ARCH_MISMATCH;
     case rocsparse_status_zero_pivot:
         return HIPSPARSE_STATUS_ZERO_PIVOT;
+    case rocsparse_status_not_initialized:
+        return HIPSPARSE_STATUS_NOT_INITIALIZED;
+    case rocsparse_status_type_mismatch:
+    case rocsparse_status_requires_sorted_storage:
+    case rocsparse_status_thrown_exception:
+        return HIPSPARSE_STATUS_INTERNAL_ERROR;
+    case rocsparse_status_continue:
+        return HIPSPARSE_STATUS_SUCCESS;
     default:
         throw "Non existent rocsparse_status";
+    }
+}
+
+rocsparse_status_ hipSPARSEStatusToRocSPARSEStatus(hipsparseStatus_t status)
+{
+    switch(status)
+    {
+    case HIPSPARSE_STATUS_SUCCESS:
+        return rocsparse_status_success;
+    case HIPSPARSE_STATUS_NOT_INITIALIZED:
+        return rocsparse_status_not_initialized;
+    case HIPSPARSE_STATUS_ALLOC_FAILED:
+        return rocsparse_status_memory_error;
+    case HIPSPARSE_STATUS_INVALID_VALUE:
+        return rocsparse_status_invalid_value;
+    case HIPSPARSE_STATUS_ARCH_MISMATCH:
+        return rocsparse_status_arch_mismatch;
+    case HIPSPARSE_STATUS_MAPPING_ERROR:
+    case HIPSPARSE_STATUS_EXECUTION_FAILED:
+    case HIPSPARSE_STATUS_INTERNAL_ERROR:
+    case HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED:
+        return rocsparse_status_internal_error;
+    case HIPSPARSE_STATUS_ZERO_PIVOT:
+        return rocsparse_status_zero_pivot;
+    case HIPSPARSE_STATUS_NOT_SUPPORTED:
+        return rocsparse_status_not_implemented;
+    case HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES:
+        return rocsparse_status_internal_error;
+    default:
+        throw "Non existent hipsparseStatus_t";
     }
 }
 
@@ -656,14 +694,14 @@ hipsparseStatus_t hipsparseDestroy(hipsparseHandle_t handle)
     return rocSPARSEStatusToHIPStatus(rocsparse_destroy_handle((rocsparse_handle)handle));
 }
 
-const char* hipsparseGetErrorName(hipsparseStatus_t status);
+const char* hipsparseGetErrorName(hipsparseStatus_t status)
 {
-    return rocsparse_get_status_name(status);
+    return rocsparse_get_status_name(hipSPARSEStatusToRocSPARSEStatus(status));
 }
 
 const char* hipsparseGetErrorString(hipsparseStatus_t status)
 {
-    return rocsparse_get_status_description(status);
+    return rocsparse_get_status_description(hipSPARSEStatusToRocSPARSEStatus(status));
 }
 
 hipsparseStatus_t hipsparseGetVersion(hipsparseHandle_t handle, int* version)

--- a/library/src/amd_detail/hipsparse.cpp
+++ b/library/src/amd_detail/hipsparse.cpp
@@ -658,12 +658,12 @@ hipsparseStatus_t hipsparseDestroy(hipsparseHandle_t handle)
 
 const char* hipsparseGetErrorName(hipsparseStatus_t status);
 {
-    return rocsparseGetStatusName(status);
+    return rocsparse_get_status_name(status);
 }
 
 const char* hipsparseGetErrorString(hipsparseStatus_t status)
 {
-    return rocsparseGetStatusString(status);
+    return rocsparse_get_status_description(status);
 }
 
 hipsparseStatus_t hipsparseGetVersion(hipsparseHandle_t handle, int* version)

--- a/library/src/nvidia_detail/hipsparse.cpp
+++ b/library/src/nvidia_detail/hipsparse.cpp
@@ -45,7 +45,6 @@ extern "C" {
 
 hipsparseStatus_t hipCUSPARSEStatusToHIPStatus(cusparseStatus_t cuStatus)
 {
-
 #if(CUDART_VERSION >= 11003)
     switch(cuStatus)
     {
@@ -111,7 +110,6 @@ hipsparseStatus_t hipCUSPARSEStatusToHIPStatus(cusparseStatus_t cuStatus)
 
 cusparseStatus_t hipSPARSEStatusToCUSPARSEStatus(hipsparseStatus_t hipStatus)
 {
-
 #if(CUDART_VERSION >= 11003)
     switch(hipStatus)
     {

--- a/library/src/nvidia_detail/hipsparse.cpp
+++ b/library/src/nvidia_detail/hipsparse.cpp
@@ -109,6 +109,72 @@ hipsparseStatus_t hipCUSPARSEStatusToHIPStatus(cusparseStatus_t cuStatus)
 #endif
 }
 
+cusparseStatus_t hipSPARSEStatusToCUSPARSEStatus(hipsparseStatus_t hipStatus)
+{
+
+#if(CUDART_VERSION >= 11003)
+    switch(hipStatus)
+    {
+    case HIPSPARSE_STATUS_SUCCESS:
+        return CUSPARSE_STATUS_SUCCESS;
+    case HIPSPARSE_STATUS_NOT_INITIALIZED:
+        return CUSPARSE_STATUS_NOT_INITIALIZED;
+    case HIPSPARSE_STATUS_ALLOC_FAILED:
+        return CUSPARSE_STATUS_ALLOC_FAILED;
+    case HIPSPARSE_STATUS_INVALID_VALUE:
+        return CUSPARSE_STATUS_INVALID_VALUE;
+    case HIPSPARSE_STATUS_ARCH_MISMATCH:
+        return CUSPARSE_STATUS_ARCH_MISMATCH;
+    case HIPSPARSE_STATUS_MAPPING_ERROR:
+        return CUSPARSE_STATUS_MAPPING_ERROR;
+    case HIPSPARSE_STATUS_EXECUTION_FAILED:
+        return CUSPARSE_STATUS_EXECUTION_FAILED;
+    case HIPSPARSE_STATUS_INTERNAL_ERROR:
+        return CUSPARSE_STATUS_INTERNAL_ERROR;
+    case HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED:
+        return CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED;
+    case HIPSPARSE_STATUS_ZERO_PIVOT:
+        return CUSPARSE_STATUS_ZERO_PIVOT;
+    case HIPSPARSE_STATUS_NOT_SUPPORTED:
+        return CUSPARSE_STATUS_NOT_SUPPORTED;
+    case HIPSPARSE_STATUS_INSUFFICIENT_RESOURCES:
+        return CUSPARSE_STATUS_INSUFFICIENT_RESOURCES;
+    default:
+        throw "Non existent hipsparseStatus_t";
+    }
+#elif(CUDART_VERSION >= 10010)
+    switch(hipStatus)
+    {
+    case HIPSPARSE_STATUS_SUCCESS:
+        return CUSPARSE_STATUS_SUCCESS;
+    case HIPSPARSE_STATUS_NOT_INITIALIZED:
+        return CUSPARSE_STATUS_NOT_INITIALIZED;
+    case HIPSPARSE_STATUS_ALLOC_FAILED:
+        return CUSPARSE_STATUS_ALLOC_FAILED;
+    case HIPSPARSE_STATUS_INVALID_VALUE:
+        return CUSPARSE_STATUS_INVALID_VALUE;
+    case HIPSPARSE_STATUS_ARCH_MISMATCH:
+        return CUSPARSE_STATUS_ARCH_MISMATCH;
+    case HIPSPARSE_STATUS_MAPPING_ERROR:
+        return CUSPARSE_STATUS_MAPPING_ERROR;
+    case HIPSPARSE_STATUS_EXECUTION_FAILED:
+        return CUSPARSE_STATUS_EXECUTION_FAILED;
+    case HIPSPARSE_STATUS_INTERNAL_ERROR:
+        return CUSPARSE_STATUS_INTERNAL_ERROR;
+    case HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED:
+        return CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED;
+    case HIPSPARSE_STATUS_ZERO_PIVOT:
+        return CUSPARSE_STATUS_ZERO_PIVOT;
+    case HIPSPARSE_STATUS_NOT_SUPPORTED:
+        return CUSPARSE_STATUS_NOT_SUPPORTED;
+    default:
+        throw "Non existent hipsparseStatus_t";
+    }
+#else
+#error "CUDART_VERSION is not supported"
+#endif
+}
+
 cusparsePointerMode_t hipPointerModeToCudaPointerMode(hipsparsePointerMode_t mode)
 {
     switch(mode)
@@ -436,12 +502,12 @@ hipsparseStatus_t hipsparseDestroy(hipsparseHandle_t handle)
 #if CUDART_VERSION > 10000
 const char* hipsparseGetErrorName(hipsparseStatus_t status);
 {
-    return cusparseGetStatusName(status);
+    return cusparseGetErrorName(hipSPARSEStatusToCUSPARSEStatus(status));
 }
 
 const char* hipsparseGetErrorString(hipsparseStatus_t status)
 {
-    return cusparseGetStatusString(status);
+    return cusparseGetErrorString(hipSPARSEStatusToCUSPARSEStatus(status));
 }
 #endif
 

--- a/library/src/nvidia_detail/hipsparse.cpp
+++ b/library/src/nvidia_detail/hipsparse.cpp
@@ -433,6 +433,18 @@ hipsparseStatus_t hipsparseDestroy(hipsparseHandle_t handle)
     return hipCUSPARSEStatusToHIPStatus(cusparseDestroy((cusparseHandle_t)handle));
 }
 
+#if CUDART_VERSION > 10000
+const char* hipsparseGetErrorName(hipsparseStatus_t status);
+{
+    return cusparseGetStatusName(status);
+}
+
+const char* hipsparseGetErrorString(hipsparseStatus_t status)
+{
+    return cusparseGetStatusString(status);
+}
+#endif
+
 hipsparseStatus_t hipsparseGetVersion(hipsparseHandle_t handle, int* version)
 {
     if(handle == nullptr)

--- a/library/src/nvidia_detail/hipsparse.cpp
+++ b/library/src/nvidia_detail/hipsparse.cpp
@@ -498,7 +498,7 @@ hipsparseStatus_t hipsparseDestroy(hipsparseHandle_t handle)
 }
 
 #if CUDART_VERSION > 10000
-const char* hipsparseGetErrorName(hipsparseStatus_t status);
+const char* hipsparseGetErrorName(hipsparseStatus_t status)
 {
     return cusparseGetErrorName(hipSPARSEStatusToCUSPARSEStatus(status));
 }


### PR DESCRIPTION
Adds missing routines hipsparseGetErrorName and hipsparseGetErrorString to hipsparse.