### PR TITLE
replace build.image with build.os in the .readthedocs.yaml config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,10 @@ sphinx:
 formats: [htmlzip]
 
 python:
-   version: "3.8"
    install:
    - requirements: docs/.sphinx/requirements.txt
+
+build:
+   os: ubuntu-20.04
+   tools:
+      python: "3.8"


### PR DESCRIPTION
https://docs.readthedocs.io/en/stable/config-file/v2.html

build.image (which is implicitly used if neither is specified) will be deprecated in October 2023