### PR TITLE
Add codeowners for documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,7 @@
 * @ntrost57 @YvanMokwinski @jsandham
+# Documentation files
+docs/* @ROCm/rocm-documentation
+*.md @ROCm/rocm-documentation
+*.rst @ROCm/rocm-documentation
+# Header directory for Doxygen documentation
+library/include/* @ROCm/rocm-documentation


### PR DESCRIPTION
Relates to https://github.com/ROCm/ROCm/issues/2832
Adding documentation team as codeowners for documentation.
Goal is to make this group of code owners reviewers when merging documentation changes. The header directory is related to documentation and thus changes to that are also flagged for documentation review.

**Please note that this requires the team to be added as a role with Write permissions.**