### PR TITLE
cmake: add rocsparse as package dep if building static lib

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -172,6 +172,7 @@ endif()
 if(NOT USE_CUDA)
   rocm_export_targets(TARGETS roc::hipsparse
                       DEPENDS PACKAGE hip
+                      STATIC_DEPENDS PACKAGE rocsparse
                       NAMESPACE roc::)
 else()
   rocm_export_targets(TARGETS roc::hipsparse


### PR DESCRIPTION
When a static library is built, no linking is done.  (Basically static libraries are just archives of object files.)

So if `libfoo.a` depends on `libbar.a`, CMake just has to remember that when you link `libfoo.a`, it also needs to pull in `libbar.a`.  The problem is that CMake only knows about `libbar.a` if a `find_package(bar)` is done.  This PR fixes our generated `foo-config.cmake` file to find this dependency, when we're building a static library.