### PR TITLE
Re-enable static library CI

### DIFF
--- a/.jenkins/precheckin.groovy
+++ b/.jenkins/precheckin.groovy
@@ -93,4 +93,3 @@ ci: {
         runCI([ubuntu18:['gfx906']], urlJobName)       
     }
 }
-

--- a/.jenkins/static.groovy
+++ b/.jenkins/static.groovy
@@ -16,8 +16,8 @@ def runCI =
     def prj = new rocProject('hipSPARSE', 'static')
 
     prj.paths.build_command = './install.sh -c --static'
-    prj.compiler.compiler_name = 'c++'
-    prj.compiler.compiler_path = 'c++'
+    prj.compiler.compiler_name = 'hipcc'
+    prj.compiler.compiler_path = '/opt/rocm/bin/hipcc'
     prj.libraryDependencies = ['rocBLAS', 'rocSPARSE', 'rocPRIM']
     prj.defaults.ccache = false
 

--- a/.jenkins/static.groovy
+++ b/.jenkins/static.groovy
@@ -13,11 +13,11 @@ def runCI =
 {
     nodeDetails, jobName->
 
-    def prj = new rocProject('hipSPARSE', 'Static Library PreCheckin')
+    def prj = new rocProject('hipSPARSE', 'static')
 
     prj.paths.build_command = './install.sh -c --static'
-    prj.compiler.compiler_name = 'hipcc'
-    prj.compiler.compiler_path = '/opt/rocm/bin/hipcc'
+    prj.compiler.compiler_name = 'c++'
+    prj.compiler.compiler_path = 'c++'
     prj.libraryDependencies = ['rocBLAS', 'rocSPARSE', 'rocPRIM']
     prj.defaults.ccache = false
 
@@ -33,7 +33,7 @@ def runCI =
         platform, project->
 
         commonGroovy = load "${project.paths.project_src_prefix}/.jenkins/common.groovy"
-        commonGroovy.runCompileCommand(platform, project,true)
+        commonGroovy.runCompileCommand(platform, project, true)
     }
 
     def testCommand =
@@ -93,4 +93,3 @@ ci: {
         runCI([ubuntu18:['gfx906']], urlJobName)       
     }
 }
-

--- a/.jenkins/static.groovy
+++ b/.jenkins/static.groovy
@@ -16,8 +16,8 @@ def runCI =
     def prj = new rocProject('hipSPARSE', 'static')
 
     prj.paths.build_command = './install.sh -c --static'
-    prj.compiler.compiler_name = 'hipcc'
-    prj.compiler.compiler_path = '/opt/rocm/bin/hipcc'
+    prj.compiler.compiler_name = 'amdclang++'
+    prj.compiler.compiler_path = '/opt/rocm/bin/amdclang++'
     prj.libraryDependencies = ['rocBLAS', 'rocSPARSE', 'rocPRIM']
     prj.defaults.ccache = false
 


### PR DESCRIPTION
requires static lib jobs for deps to pass: 'rocBLAS', 'rocSPARSE', 'rocPRIM'