### PR TITLE
Fix SpGEMM_reuse (SWDEV-455606)

### DIFF
--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -38,8 +38,6 @@
 #ifndef HIPSPARSE_H
 #define HIPSPARSE_H
 
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-
 #include "hipsparse-export.h"
 #include "hipsparse-version.h"
 

--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -38,6 +38,8 @@
 #ifndef HIPSPARSE_H
 #define HIPSPARSE_H
 
+#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
+
 #include "hipsparse-export.h"
 #include "hipsparse-version.h"
 

--- a/library/src/amd_detail/hipsparse.cpp
+++ b/library/src/amd_detail/hipsparse.cpp
@@ -14745,7 +14745,7 @@ hipsparseStatus_t hipsparseSpGEMM_compute(hipsparseHandle_t          handle,
 
         // Need to store temporary space for host/device 1 value used in hipsparseSpGEMM_copy Axpby
         *bufferSize2 += ((computeTypeSize - 1) / 256 + 1) * 256;
-    
+
         spgemmDescr->bufferSize2 = bufferSize2;
     }
     else
@@ -15276,9 +15276,6 @@ hipsparseStatus_t hipsparseSpGEMMreuse_compute(hipsparseHandle_t          handle
     }
     std::cout << "" << std::endl;
 
-
-
-
     int64_t              C_num_rows2, C_num_cols2, C_nnz2;
     hipsparseIndexBase_t indexBaseC;
     hipsparseIndexType_t rowIndexTypeC;
@@ -15329,9 +15326,6 @@ hipsparseStatus_t hipsparseSpGEMMreuse_compute(hipsparseHandle_t          handle
         std::cout << hcsrValuesC[i] << " ";
     }
     std::cout << "" << std::endl;
-
-
-
 
     return hipsparse::rocSPARSEStatusToHIPStatus(
         rocsparse_spgemm((rocsparse_handle)handle,

--- a/library/src/amd_detail/hipsparse.cpp
+++ b/library/src/amd_detail/hipsparse.cpp
@@ -30,7 +30,6 @@
 #include <stdlib.h>
 
 #include <iostream>
-#include <vector>
 
 #define TO_STR2(x) #x
 #define TO_STR(x) TO_STR2(x)

--- a/library/src/amd_detail/hipsparse.cpp
+++ b/library/src/amd_detail/hipsparse.cpp
@@ -15008,8 +15008,10 @@ hipsparseStatus_t hipsparseSpGEMMreuse_nnz(hipsparseHandle_t          handle,
     }
 
     // If any external buffer is nullptr, they must all be nullptr.
-    bool allBuffersNull = (externalBuffer2 == nullptr) & (externalBuffer3 == nullptr) & (externalBuffer4 == nullptr);
-    bool anyBuffersNull = (externalBuffer2 == nullptr) | (externalBuffer3 == nullptr) | (externalBuffer4 == nullptr);
+    bool allBuffersNull = (externalBuffer2 == nullptr) & (externalBuffer3 == nullptr)
+                          & (externalBuffer4 == nullptr);
+    bool anyBuffersNull = (externalBuffer2 == nullptr) | (externalBuffer3 == nullptr)
+                          | (externalBuffer4 == nullptr);
     if(anyBuffersNull && !allBuffersNull)
     {
         return HIPSPARSE_STATUS_INVALID_VALUE;
@@ -15066,13 +15068,15 @@ hipsparseStatus_t hipsparseSpGEMMreuse_nnz(hipsparseHandle_t          handle,
     }
     else
     {
-        std::cout << "bufferSize3: " << *bufferSize3 << " bufferSize4: " << *bufferSize4 << std::endl;
+        std::cout << "bufferSize3: " << *bufferSize3 << " bufferSize4: " << *bufferSize4
+                  << std::endl;
         hipStream_t stream;
         RETURN_IF_HIPSPARSE_ERROR(hipsparseGetStream(handle, &stream));
 
         spgemmDescr->externalBuffer2 = externalBuffer2;
         spgemmDescr->externalBuffer3 = externalBuffer3; // stores C column indices and values
-        spgemmDescr->externalBuffer4 = externalBuffer4; // stores C row pointers array + rocsparse_spgemm buffer
+        spgemmDescr->externalBuffer4
+            = externalBuffer4; // stores C row pointers array + rocsparse_spgemm buffer
 
         size_t byteOffset3 = ((csrColIndTypeSizeC * nnzC - 1) / 256 + 1) * 256;
         size_t byteOffset4 = ((csrRowOffsetsTypeSizeC * (rowsC + 1) - 1) / 256 + 1) * 256;
@@ -15093,20 +15097,21 @@ hipsparseStatus_t hipsparseSpGEMMreuse_nnz(hipsparseHandle_t          handle,
             static_cast<char*>(spgemmDescr->externalBuffer3) + byteOffset3));
 
         size_t bufferSize = (spgemmDescr->bufferSize4 - byteOffset4);
-        RETURN_IF_ROCSPARSE_ERROR(rocsparse_spgemm((rocsparse_handle)handle,
-                                                   hipsparse::hipOperationToHCCOperation(opA),
-                                                   hipsparse::hipOperationToHCCOperation(opB),
-                                                   alpha,
-                                                   (rocsparse_const_spmat_descr)matA,
-                                                   (rocsparse_const_spmat_descr)matB,
-                                                   nullptr,
-                                                   (rocsparse_const_spmat_descr)matC,
-                                                   (rocsparse_spmat_descr)matC,
-                                                   hipsparse::hipDataTypeToHCCDataType(computeType),
-                                                   hipsparse::hipSpGEMMAlgToHCCSpGEMMAlg(alg),
-                                                   rocsparse_spgemm_stage_symbolic,
-                                                   &bufferSize,
-                                                   static_cast<char*>(spgemmDescr->externalBuffer4) + byteOffset4));
+        RETURN_IF_ROCSPARSE_ERROR(
+            rocsparse_spgemm((rocsparse_handle)handle,
+                             hipsparse::hipOperationToHCCOperation(opA),
+                             hipsparse::hipOperationToHCCOperation(opB),
+                             alpha,
+                             (rocsparse_const_spmat_descr)matA,
+                             (rocsparse_const_spmat_descr)matB,
+                             nullptr,
+                             (rocsparse_const_spmat_descr)matC,
+                             (rocsparse_spmat_descr)matC,
+                             hipsparse::hipDataTypeToHCCDataType(computeType),
+                             hipsparse::hipSpGEMMAlgToHCCSpGEMMAlg(alg),
+                             rocsparse_spgemm_stage_symbolic,
+                             &bufferSize,
+                             static_cast<char*>(spgemmDescr->externalBuffer4) + byteOffset4));
     }
 
     return HIPSPARSE_STATUS_SUCCESS;
@@ -15285,7 +15290,6 @@ hipsparseStatus_t hipsparseSpGEMMreuse_compute(hipsparseHandle_t          handle
     // }
     // std::cout << "" << std::endl;
 
-
     size_t csrRowOffsetsTypeSizeC;
     size_t csrColIndTypeSizeC;
     size_t csrValueTypeSizeC;
@@ -15304,26 +15308,27 @@ hipsparseStatus_t hipsparseSpGEMMreuse_compute(hipsparseHandle_t          handle
 
     void* device_one = (static_cast<char*>(spgemmDescr->externalBuffer5) + byteOffset5);
 
-    // Use external buffer for values array as the original values array may have data in it 
+    // Use external buffer for values array as the original values array may have data in it
     // that must be accounted for when multiplying by beta. See below.
     RETURN_IF_HIPSPARSE_ERROR(
         hipsparseCsrSetPointers(matC, csrRowOffsetsC, csrColIndC, csrValuesCFromBuffer5));
 
     size_t bufferSize = (spgemmDescr->bufferSize4 - byteOffset4);
-    RETURN_IF_ROCSPARSE_ERROR(rocsparse_spgemm((rocsparse_handle)handle,
-                            hipsparse::hipOperationToHCCOperation(opA),
-                            hipsparse::hipOperationToHCCOperation(opB),
-                            alpha,
-                            (rocsparse_const_spmat_descr)matA,
-                            (rocsparse_const_spmat_descr)matB,
-                            nullptr,
-                            (rocsparse_const_spmat_descr)matC,
-                            (rocsparse_spmat_descr)matC,
-                            hipsparse::hipDataTypeToHCCDataType(computeType),
-                            hipsparse::hipSpGEMMAlgToHCCSpGEMMAlg(alg),
-                            rocsparse_spgemm_stage_numeric,
-                            &bufferSize,
-                            static_cast<char*>(spgemmDescr->externalBuffer4) + byteOffset4));
+    RETURN_IF_ROCSPARSE_ERROR(
+        rocsparse_spgemm((rocsparse_handle)handle,
+                         hipsparse::hipOperationToHCCOperation(opA),
+                         hipsparse::hipOperationToHCCOperation(opB),
+                         alpha,
+                         (rocsparse_const_spmat_descr)matA,
+                         (rocsparse_const_spmat_descr)matB,
+                         nullptr,
+                         (rocsparse_const_spmat_descr)matC,
+                         (rocsparse_spmat_descr)matC,
+                         hipsparse::hipDataTypeToHCCDataType(computeType),
+                         hipsparse::hipSpGEMMAlgToHCCSpGEMMAlg(alg),
+                         rocsparse_spgemm_stage_numeric,
+                         &bufferSize,
+                         static_cast<char*>(spgemmDescr->externalBuffer4) + byteOffset4));
 
     // Get pointer mode
     hipsparsePointerMode_t pointer_mode;

--- a/library/src/amd_detail/hipsparse.cpp
+++ b/library/src/amd_detail/hipsparse.cpp
@@ -15103,108 +15103,6 @@ hipsparseStatus_t hipsparseSpGEMMreuse_compute(hipsparseHandle_t          handle
         return HIPSPARSE_STATUS_INVALID_VALUE;
     }
 
-    // int64_t              A_num_rows2, A_num_cols2, A_nnz2;
-    // hipsparseIndexBase_t indexBaseA;
-    // hipsparseIndexType_t rowIndexTypeA;
-    // hipsparseIndexType_t columnIndexTypeA;
-    // hipDataType          valueTypeA;
-    // int*                 csrRowOffsetsA = nullptr;
-    // int*                 csrColIndA     = nullptr;
-    // float*               csrValuesA     = nullptr;
-    // RETURN_IF_HIPSPARSE_ERROR(hipsparseConstCsrGet(matA,
-    //                                                &A_num_rows2,
-    //                                                &A_num_cols2,
-    //                                                &A_nnz2,
-    //                                                (const void**)&csrRowOffsetsA,
-    //                                                (const void**)&csrColIndA,
-    //                                                (const void**)&csrValuesA,
-    //                                                &rowIndexTypeA,
-    //                                                &columnIndexTypeA,
-    //                                                &indexBaseA,
-    //                                                &valueTypeA));
-
-    // std::vector<int>   hcsrRowOffsetsA(A_num_rows2 + 1, 0);
-    // std::vector<int>   hcsrColIndA(A_nnz2, 0);
-    // std::vector<float> hcsrValuesA(A_nnz2, 0.0f);
-    // hipMemcpy(hcsrRowOffsetsA.data(),
-    //           csrRowOffsetsA,
-    //           sizeof(int) * (A_num_rows2 + 1),
-    //           hipMemcpyDeviceToHost);
-    // hipMemcpy(hcsrColIndA.data(), csrColIndA, sizeof(int) * A_nnz2, hipMemcpyDeviceToHost);
-    // hipMemcpy(hcsrValuesA.data(), csrValuesA, sizeof(float) * A_nnz2, hipMemcpyDeviceToHost);
-
-    // std::cout << "hcsrRowOffsetsA" << std::endl;
-    // for(size_t i = 0; i < hcsrRowOffsetsA.size(); i++)
-    // {
-    //     std::cout << hcsrRowOffsetsA[i] << " ";
-    // }
-    // std::cout << "" << std::endl;
-
-    // std::cout << "hcsrColIndA" << std::endl;
-    // for(size_t i = 0; i < hcsrColIndA.size(); i++)
-    // {
-    //     std::cout << hcsrColIndA[i] << " ";
-    // }
-    // std::cout << "" << std::endl;
-
-    // std::cout << "hcsrValuesA" << std::endl;
-    // for(size_t i = 0; i < hcsrValuesA.size(); i++)
-    // {
-    //     std::cout << hcsrValuesA[i] << " ";
-    // }
-    // std::cout << "" << std::endl;
-
-    // int64_t              B_num_rows2, B_num_cols2, B_nnz2;
-    // hipsparseIndexBase_t indexBaseB;
-    // hipsparseIndexType_t rowIndexTypeB;
-    // hipsparseIndexType_t columnIndexTypeB;
-    // hipDataType          valueTypeB;
-    // int*                 csrRowOffsetsB = nullptr;
-    // int*                 csrColIndB     = nullptr;
-    // float*               csrValuesB     = nullptr;
-    // RETURN_IF_HIPSPARSE_ERROR(hipsparseConstCsrGet(matB,
-    //                                                &B_num_rows2,
-    //                                                &B_num_cols2,
-    //                                                &B_nnz2,
-    //                                                (const void**)&csrRowOffsetsB,
-    //                                                (const void**)&csrColIndB,
-    //                                                (const void**)&csrValuesB,
-    //                                                &rowIndexTypeB,
-    //                                                &columnIndexTypeB,
-    //                                                &indexBaseB,
-    //                                                &valueTypeB));
-
-    // std::vector<int>   hcsrRowOffsetsB(B_num_rows2 + 1, 0);
-    // std::vector<int>   hcsrColIndB(B_nnz2, 0);
-    // std::vector<float> hcsrValuesB(B_nnz2, 0.0f);
-    // hipMemcpy(hcsrRowOffsetsB.data(),
-    //           csrRowOffsetsB,
-    //           sizeof(int) * (B_num_rows2 + 1),
-    //           hipMemcpyDeviceToHost);
-    // hipMemcpy(hcsrColIndB.data(), csrColIndB, sizeof(int) * B_nnz2, hipMemcpyDeviceToHost);
-    // hipMemcpy(hcsrValuesB.data(), csrValuesB, sizeof(float) * B_nnz2, hipMemcpyDeviceToHost);
-
-    // std::cout << "hcsrRowOffsetsB" << std::endl;
-    // for(size_t i = 0; i < hcsrRowOffsetsB.size(); i++)
-    // {
-    //     std::cout << hcsrRowOffsetsB[i] << " ";
-    // }
-    // std::cout << "" << std::endl;
-
-    // std::cout << "hcsrColIndB" << std::endl;
-    // for(size_t i = 0; i < hcsrColIndB.size(); i++)
-    // {
-    //     std::cout << hcsrColIndB[i] << " ";
-    // }
-    // std::cout << "" << std::endl;
-
-    // std::cout << "hcsrValuesB" << std::endl;
-    // for(size_t i = 0; i < hcsrValuesB.size(); i++)
-    // {
-    //     std::cout << hcsrValuesB[i] << " ";
-    // }
-    // std::cout << "" << std::endl;
-
     // Get data stored in C matrix
     int64_t              rowsC, colsC, nnzC;
     void*                csrRowOffsetsC;
@@ -15225,37 +15123,6 @@ hipsparseStatus_t hipsparseSpGEMMreuse_compute(hipsparseHandle_t          handle
                                               &csrColIndTypeC,
                                               &idxBaseC,
                                               &csrValueTypeC));
-
-    // std::vector<int>   hcsrRowOffsetsC(rowsC + 1, 0);
-    // std::vector<int>   hcsrColIndC(nnzC, 0);
-    // std::vector<float> hcsrValuesC(nnzC, 0.0f);
-    // hipMemcpy(hcsrRowOffsetsC.data(),
-    //           csrRowOffsetsC,
-    //           sizeof(int) * (rowsC + 1),
-    //           hipMemcpyDeviceToHost);
-    // hipMemcpy(hcsrColIndC.data(), csrColIndC, sizeof(int) * nnzC, hipMemcpyDeviceToHost);
-    // hipMemcpy(hcsrValuesC.data(), csrValuesC, sizeof(float) * nnzC, hipMemcpyDeviceToHost);
-
-    // std::cout << "hcsrRowOffsetsC" << std::endl;
-    // for(size_t i = 0; i < hcsrRowOffsetsC.size(); i++)
-    // {
-    //     std::cout << hcsrRowOffsetsC[i] << " ";
-    // }
-    // std::cout << "" << std::endl;
-
-    // std::cout << "hcsrColIndC" << std::endl;
-    // for(size_t i = 0; i < hcsrColIndC.size(); i++)
-    // {
-    //     std::cout << hcsrColIndC[i] << " ";
-    // }
-    // std::cout << "" << std::endl;
-
-    // std::cout << "hcsrValuesC" << std::endl;
-    // for(size_t i = 0; i < hcsrValuesC.size(); i++)
-    // {
-    //     std::cout << hcsrValuesC[i] << " ";
-    // }
-    // std::cout << "" << std::endl;
 
     size_t csrRowOffsetsTypeSizeC;
     size_t csrColIndTypeSizeC;
@@ -15463,25 +15330,6 @@ hipsparseStatus_t hipsparseSpGEMMreuse_copy(hipsparseHandle_t          handle,
 
         hipStream_t stream;
         RETURN_IF_HIPSPARSE_ERROR(hipsparseGetStream(handle, &stream));
-
-        // std::vector<int> hcsr_row_ptr(rowsC + 1, 0);
-        // std::vector<int> hcsr_col_ind(nnzC, 0);
-        // RETURN_IF_HIP_ERROR(hipMemcpy(hcsr_row_ptr.data(), spgemmDescr->externalBuffer4, sizeof(int) * (rowsC + 1), hipMemcpyDeviceToHost));
-        // RETURN_IF_HIP_ERROR(hipMemcpy(hcsr_col_ind.data(), spgemmDescr->externalBuffer3, sizeof(int) * nnzC, hipMemcpyDeviceToHost));
-
-        // std::cout << "hipsparseSpGEMMreuse_copy hcsr_row_ptr" << std::endl;
-        // for(size_t i = 0; i < hcsr_row_ptr.size(); i++)
-        // {
-        //     std::cout << hcsr_row_ptr[i] << " ";
-        // }
-        // std::cout << "" << std::endl;
-
-        // std::cout << "hipsparseSpGEMMreuse_copy hcsr_col_ind" << std::endl;
-        // for(size_t i = 0; i < hcsr_col_ind.size(); i++)
-        // {
-        //     std::cout << hcsr_col_ind[i] << " ";
-        // }
-        // std::cout << "" << std::endl;
 
         RETURN_IF_HIP_ERROR(hipMemcpyAsync(csrRowOffsetsC,
                                            spgemmDescr->externalBuffer4,

--- a/library/src/amd_detail/hipsparse.cpp
+++ b/library/src/amd_detail/hipsparse.cpp
@@ -14561,7 +14561,8 @@ hipsparseStatus_t hipsparseSpGEMM_workEstimation(hipsparseHandle_t          hand
                                               &csrValueTypeC));
 
     size_t csrRowOffsetsTypeSizeC;
-    RETURN_IF_HIPSPARSE_ERROR(hipsparse::getIndexTypeSize(csrRowOffsetsTypeC, csrRowOffsetsTypeSizeC));
+    RETURN_IF_HIPSPARSE_ERROR(
+        hipsparse::getIndexTypeSize(csrRowOffsetsTypeC, csrRowOffsetsTypeSizeC));
 
     if(externalBuffer1 == nullptr)
     {
@@ -14663,7 +14664,8 @@ hipsparseStatus_t hipsparseSpGEMM_compute(hipsparseHandle_t          handle,
     size_t csrRowOffsetsTypeSizeC;
     size_t csrColIndTypeSizeC;
     size_t csrValueTypeSizeC;
-    RETURN_IF_HIPSPARSE_ERROR(hipsparse::getIndexTypeSize(csrRowOffsetsTypeC, csrRowOffsetsTypeSizeC));
+    RETURN_IF_HIPSPARSE_ERROR(
+        hipsparse::getIndexTypeSize(csrRowOffsetsTypeC, csrRowOffsetsTypeSizeC));
     RETURN_IF_HIPSPARSE_ERROR(hipsparse::getIndexTypeSize(csrColIndTypeC, csrColIndTypeSizeC));
     RETURN_IF_HIPSPARSE_ERROR(hipsparse::getDataTypeSize(csrValueTypeC, csrValueTypeSizeC));
 
@@ -14770,7 +14772,8 @@ hipsparseStatus_t hipsparseSpGEMM_copy(hipsparseHandle_t          handle,
     size_t csrRowOffsetsTypeSizeC;
     size_t csrColIndTypeSizeC;
     size_t csrValueTypeSizeC;
-    RETURN_IF_HIPSPARSE_ERROR(hipsparse::getIndexTypeSize(csrRowOffsetsTypeC, csrRowOffsetsTypeSizeC));
+    RETURN_IF_HIPSPARSE_ERROR(
+        hipsparse::getIndexTypeSize(csrRowOffsetsTypeC, csrRowOffsetsTypeSizeC));
     RETURN_IF_HIPSPARSE_ERROR(hipsparse::getIndexTypeSize(csrColIndTypeC, csrColIndTypeSizeC));
     RETURN_IF_HIPSPARSE_ERROR(hipsparse::getDataTypeSize(csrValueTypeC, csrValueTypeSizeC));
 
@@ -15016,7 +15019,8 @@ hipsparseStatus_t hipsparseSpGEMMreuse_nnz(hipsparseHandle_t          handle,
     size_t csrRowOffsetsTypeSizeC;
     size_t csrColIndTypeSizeC;
     size_t csrValueTypeSizeC;
-    RETURN_IF_HIPSPARSE_ERROR(hipsparse::getIndexTypeSize(csrRowOffsetsTypeC, csrRowOffsetsTypeSizeC));
+    RETURN_IF_HIPSPARSE_ERROR(
+        hipsparse::getIndexTypeSize(csrRowOffsetsTypeC, csrRowOffsetsTypeSizeC));
     RETURN_IF_HIPSPARSE_ERROR(hipsparse::getIndexTypeSize(csrColIndTypeC, csrColIndTypeSizeC));
     RETURN_IF_HIPSPARSE_ERROR(hipsparse::getDataTypeSize(csrValueTypeC, csrValueTypeSizeC));
 
@@ -15040,7 +15044,8 @@ hipsparseStatus_t hipsparseSpGEMMreuse_nnz(hipsparseHandle_t          handle,
 
         spgemmDescr->externalBuffer2 = externalBuffer2;
         spgemmDescr->externalBuffer3 = externalBuffer3; // stores C column indices and values
-        spgemmDescr->externalBuffer4 = externalBuffer4; // stores C row pointers array + spgemm buffer
+        spgemmDescr->externalBuffer4
+            = externalBuffer4; // stores C row pointers array + spgemm buffer
 
         size_t byteOffset3 = ((csrColIndTypeSizeC * nnzC - 1) / 256 + 1) * 256;
         size_t byteOffset4 = ((csrRowOffsetsTypeSizeC * (rowsC + 1) - 1) / 256 + 1) * 256;
@@ -15255,7 +15260,8 @@ hipsparseStatus_t hipsparseSpGEMMreuse_compute(hipsparseHandle_t          handle
     size_t csrRowOffsetsTypeSizeC;
     size_t csrColIndTypeSizeC;
     size_t csrValueTypeSizeC;
-    RETURN_IF_HIPSPARSE_ERROR(hipsparse::getIndexTypeSize(csrRowOffsetsTypeC, csrRowOffsetsTypeSizeC));
+    RETURN_IF_HIPSPARSE_ERROR(
+        hipsparse::getIndexTypeSize(csrRowOffsetsTypeC, csrRowOffsetsTypeSizeC));
     RETURN_IF_HIPSPARSE_ERROR(hipsparse::getIndexTypeSize(csrColIndTypeC, csrColIndTypeSizeC));
     RETURN_IF_HIPSPARSE_ERROR(hipsparse::getDataTypeSize(csrValueTypeC, csrValueTypeSizeC));
 
@@ -15431,7 +15437,8 @@ hipsparseStatus_t hipsparseSpGEMMreuse_copy(hipsparseHandle_t          handle,
     size_t csrRowOffsetsTypeSizeC;
     size_t csrColIndTypeSizeC;
     size_t csrValueTypeSizeC;
-    RETURN_IF_HIPSPARSE_ERROR(hipsparse::getIndexTypeSize(csrRowOffsetsTypeC, csrRowOffsetsTypeSizeC));
+    RETURN_IF_HIPSPARSE_ERROR(
+        hipsparse::getIndexTypeSize(csrRowOffsetsTypeC, csrRowOffsetsTypeSizeC));
     RETURN_IF_HIPSPARSE_ERROR(hipsparse::getIndexTypeSize(csrColIndTypeC, csrColIndTypeSizeC));
     RETURN_IF_HIPSPARSE_ERROR(hipsparse::getDataTypeSize(csrValueTypeC, csrValueTypeSizeC));
 


### PR DESCRIPTION
Fixes SpGEMM_reuse in hipsparse. See SWDEV-455606. In this JIRA issue I have attached a hipsparse example code (spgemm_reuse.cpp) that demonstrates the failure. The fix is similar to what was done to fix SpGEMM in this PR: https://github.com/ROCm/hipSPARSE/pull/449. 