### PR TITLE
Fix failures in descr bad args checks

### DIFF
--- a/clients/include/testing_const_dnmat_descr.hpp
+++ b/clients/include/testing_const_dnmat_descr.hpp
@@ -76,7 +76,6 @@ void testing_const_dnmat_descr_bad_arg(void)
 
     // hipsparseDestroyDnVec
     verify_hipsparse_status_invalid_pointer(hipsparseDestroyDnMat(nullptr), "Error: x is nullptr");
-    verify_hipsparse_status_success(hipsparseDestroyDnMat(nullptr), "Success");
 
     // Create valid descriptor
     verify_hipsparse_status_success(

--- a/clients/include/testing_const_dnvec_descr.hpp
+++ b/clients/include/testing_const_dnvec_descr.hpp
@@ -63,7 +63,6 @@ void testing_const_dnvec_descr_bad_arg(void)
 
     // hipsparseDestroyDnVec
     verify_hipsparse_status_invalid_pointer(hipsparseDestroyDnVec(nullptr), "Error: x is nullptr");
-    verify_hipsparse_status_success(hipsparseDestroyDnVec(nullptr), "Success");
 
     // Create valid descriptor
     verify_hipsparse_status_success(hipsparseCreateConstDnVec(&x, size, val_data, dataType),

--- a/clients/include/testing_const_spmat_descr.hpp
+++ b/clients/include/testing_const_spmat_descr.hpp
@@ -219,7 +219,6 @@ void testing_const_spmat_descr_bad_arg(void)
 
     // hipsparseDestroySpMat
     verify_hipsparse_status_invalid_pointer(hipsparseDestroySpMat(nullptr), "Error: A is nullptr");
-    verify_hipsparse_status_success(hipsparseDestroySpMat(nullptr), "Success");
 
     // Create valid descriptors
     hipsparseConstSpMatDescr_t coo;

--- a/clients/include/testing_const_spvec_descr.hpp
+++ b/clients/include/testing_const_spvec_descr.hpp
@@ -78,7 +78,6 @@ void testing_const_spvec_descr_bad_arg(void)
 
     // hipsparseDestroySpVec
     verify_hipsparse_status_invalid_pointer(hipsparseDestroySpVec(nullptr), "Error: x is nullptr");
-    verify_hipsparse_status_success(hipsparseDestroySpVec(nullptr), "Success");
 
     // Create valid descriptor
     verify_hipsparse_status_success(

--- a/clients/include/testing_dnmat_descr.hpp
+++ b/clients/include/testing_dnmat_descr.hpp
@@ -73,7 +73,6 @@ void testing_dnmat_descr_bad_arg(void)
 
     // hipsparseDestroyDnVec
     verify_hipsparse_status_invalid_pointer(hipsparseDestroyDnMat(nullptr), "Error: x is nullptr");
-    verify_hipsparse_status_success(hipsparseDestroyDnMat(nullptr), "Success");
 
     // Create valid descriptor
     verify_hipsparse_status_success(

--- a/clients/include/testing_dnvec_descr.hpp
+++ b/clients/include/testing_dnvec_descr.hpp
@@ -63,7 +63,6 @@ void testing_dnvec_descr_bad_arg(void)
 
     // hipsparseDestroyDnVec
     verify_hipsparse_status_invalid_pointer(hipsparseDestroyDnVec(nullptr), "Error: x is nullptr");
-    verify_hipsparse_status_success(hipsparseDestroyDnVec(nullptr), "Success");
 
     // Create valid descriptor
     verify_hipsparse_status_success(hipsparseCreateDnVec(&x, size, val_data, dataType), "Success");

--- a/clients/include/testing_spmat_descr.hpp
+++ b/clients/include/testing_spmat_descr.hpp
@@ -204,8 +204,7 @@ void testing_spmat_descr_bad_arg(void)
 
     // hipsparseDestroySpMat
     verify_hipsparse_status_invalid_pointer(hipsparseDestroySpMat(nullptr), "Error: A is nullptr");
-    verify_hipsparse_status_success(hipsparseDestroySpMat(nullptr), "Success");
-
+    
     // Create valid descriptors
     hipsparseSpMatDescr_t coo;
     hipsparseSpMatDescr_t coo_aos;

--- a/clients/include/testing_spmat_descr.hpp
+++ b/clients/include/testing_spmat_descr.hpp
@@ -204,7 +204,7 @@ void testing_spmat_descr_bad_arg(void)
 
     // hipsparseDestroySpMat
     verify_hipsparse_status_invalid_pointer(hipsparseDestroySpMat(nullptr), "Error: A is nullptr");
-    
+
     // Create valid descriptors
     hipsparseSpMatDescr_t coo;
     hipsparseSpMatDescr_t coo_aos;

--- a/clients/include/testing_spvec_descr.hpp
+++ b/clients/include/testing_spvec_descr.hpp
@@ -77,7 +77,6 @@ void testing_spvec_descr_bad_arg(void)
 
     // hipsparseDestroySpVec
     verify_hipsparse_status_invalid_pointer(hipsparseDestroySpVec(nullptr), "Error: x is nullptr");
-    verify_hipsparse_status_success(hipsparseDestroySpVec(nullptr), "Success");
 
     // Create valid descriptor
     verify_hipsparse_status_success(


### PR DESCRIPTION
Fix failures to descr bad args checks when running with rocsparse backend accidentally introduced after 4d19a656835bb04decccfb0f26a5e937488a5210