### PR TITLE
Fix SpSM testing where we missed passing K parameter

### DIFF
--- a/clients/include/testing_spsm_coo.hpp
+++ b/clients/include/testing_spsm_coo.hpp
@@ -203,7 +203,10 @@ hipsparseStatus_t testing_spsm_coo(Arguments argus)
 
     std::string filename = argus.filename;
 
-    std::cout << "m: " << m << " n: " << n << " k: " << k << " transA: " << transA << " transB: " << transB << " orderB: " << orderB << " orderC: " << orderC << " idx_base: " << idx_base << " diag: " << diag << " uplo: " << uplo << " alg: " << alg << " filename: " << filename << std::endl;
+    std::cout << "m: " << m << " n: " << n << " k: " << k << " transA: " << transA
+              << " transB: " << transB << " orderB: " << orderB << " orderC: " << orderC
+              << " idx_base: " << idx_base << " diag: " << diag << " uplo: " << uplo
+              << " alg: " << alg << " filename: " << filename << std::endl;
 
 #if(defined(CUDART_VERSION))
     if(orderB != orderC)

--- a/clients/include/testing_spsm_coo.hpp
+++ b/clients/include/testing_spsm_coo.hpp
@@ -203,6 +203,8 @@ hipsparseStatus_t testing_spsm_coo(Arguments argus)
 
     std::string filename = argus.filename;
 
+    std::cout << "m: " << m << " n: " << n << " k: " << k << " transA: " << transA << " transB: " << transB << " orderB: " << orderB << " orderC: " << orderC << " idx_base: " << idx_base << " diag: " << diag << " uplo: " << uplo << " alg: " << alg << " filename: " << filename << std::endl;
+
 #if(defined(CUDART_VERSION))
     if(orderB != orderC)
     {
@@ -231,6 +233,12 @@ hipsparseStatus_t testing_spsm_coo(Arguments argus)
     {
         fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
         return HIPSPARSE_STATUS_INTERNAL_ERROR;
+    }
+
+    if(m != n)
+    {
+        // Skip non-square matrices
+        return HIPSPARSE_STATUS_SUCCESS;
     }
 
     std::vector<I> hrow_ind(nnz);

--- a/clients/include/testing_spsm_coo.hpp
+++ b/clients/include/testing_spsm_coo.hpp
@@ -203,11 +203,6 @@ hipsparseStatus_t testing_spsm_coo(Arguments argus)
 
     std::string filename = argus.filename;
 
-    std::cout << "m: " << m << " n: " << n << " k: " << k << " transA: " << transA
-              << " transB: " << transB << " orderB: " << orderB << " orderC: " << orderC
-              << " idx_base: " << idx_base << " diag: " << diag << " uplo: " << uplo
-              << " alg: " << alg << " filename: " << filename << std::endl;
-
 #if(defined(CUDART_VERSION))
     if(orderB != orderC)
     {

--- a/clients/include/testing_spsm_csr.hpp
+++ b/clients/include/testing_spsm_csr.hpp
@@ -204,7 +204,10 @@ hipsparseStatus_t testing_spsm_csr(Arguments argus)
 
     std::string filename = argus.filename;
 
-    std::cout << "m: " << m << " n: " << n << " k: " << k << " transA: " << transA << " transB: " << transB << " orderB: " << orderB << " orderC: " << orderC << " idx_base: " << idx_base << " diag: " << diag << " uplo: " << uplo << " alg: " << alg << " filename: " << filename << std::endl;
+    std::cout << "m: " << m << " n: " << n << " k: " << k << " transA: " << transA
+              << " transB: " << transB << " orderB: " << orderB << " orderC: " << orderC
+              << " idx_base: " << idx_base << " diag: " << diag << " uplo: " << uplo
+              << " alg: " << alg << " filename: " << filename << std::endl;
 
 #if(defined(CUDART_VERSION))
     if(orderB != orderC)

--- a/clients/include/testing_spsm_csr.hpp
+++ b/clients/include/testing_spsm_csr.hpp
@@ -204,11 +204,6 @@ hipsparseStatus_t testing_spsm_csr(Arguments argus)
 
     std::string filename = argus.filename;
 
-    std::cout << "m: " << m << " n: " << n << " k: " << k << " transA: " << transA
-              << " transB: " << transB << " orderB: " << orderB << " orderC: " << orderC
-              << " idx_base: " << idx_base << " diag: " << diag << " uplo: " << uplo
-              << " alg: " << alg << " filename: " << filename << std::endl;
-
 #if(defined(CUDART_VERSION))
     if(orderB != orderC)
     {

--- a/clients/include/testing_spsm_csr.hpp
+++ b/clients/include/testing_spsm_csr.hpp
@@ -204,6 +204,8 @@ hipsparseStatus_t testing_spsm_csr(Arguments argus)
 
     std::string filename = argus.filename;
 
+    std::cout << "m: " << m << " n: " << n << " k: " << k << " transA: " << transA << " transB: " << transB << " orderB: " << orderB << " orderC: " << orderC << " idx_base: " << idx_base << " diag: " << diag << " uplo: " << uplo << " alg: " << alg << " filename: " << filename << std::endl;
+
 #if(defined(CUDART_VERSION))
     if(orderB != orderC)
     {
@@ -233,6 +235,12 @@ hipsparseStatus_t testing_spsm_csr(Arguments argus)
     {
         fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
         return HIPSPARSE_STATUS_INTERNAL_ERROR;
+    }
+
+    if(m != n)
+    {
+        // Skip non-square matrices
+        return HIPSPARSE_STATUS_SUCCESS;
     }
 
     // Some matrix properties

--- a/clients/tests/test_spsm_coo.cpp
+++ b/clients/tests/test_spsm_coo.cpp
@@ -25,7 +25,13 @@
 
 #include <hipsparse.h>
 
-typedef std::tuple<int,
+struct M_N
+{
+    int M;
+    int N;
+};
+
+typedef std::tuple<M_N,
                    int,
                    double,
                    hipsparseOperation_t,
@@ -36,7 +42,8 @@ typedef std::tuple<int,
                    hipsparseDiagType_t,
                    hipsparseFillMode_t>
     spsm_coo_tuple;
-typedef std::tuple<double,
+typedef std::tuple<int,
+                   double,
                    hipsparseOperation_t,
                    hipsparseOperation_t,
                    hipsparseOrder_t,
@@ -47,8 +54,8 @@ typedef std::tuple<double,
                    std::string>
     spsm_coo_bin_tuple;
 
-int spsm_coo_M_range[] = {50};
-int spsm_coo_N_range[] = {50};
+M_N spsm_coo_M_N_range[] = {{50, 50}};
+int spsm_coo_K_range[] = {22};
 
 std::vector<double> spsm_coo_alpha_range = {2.0};
 
@@ -84,8 +91,9 @@ protected:
 Arguments setup_spsm_coo_arguments(spsm_coo_tuple tup)
 {
     Arguments arg;
-    arg.M         = std::get<0>(tup);
-    arg.N         = std::get<1>(tup);
+    arg.M         = std::get<0>(tup).M;
+    arg.N         = std::get<0>(tup).N;
+    arg.K         = std::get<1>(tup);
     arg.alpha     = std::get<2>(tup);
     arg.transA    = std::get<3>(tup);
     arg.transB    = std::get<4>(tup);
@@ -101,18 +109,19 @@ Arguments setup_spsm_coo_arguments(spsm_coo_tuple tup)
 Arguments setup_spsm_coo_arguments(spsm_coo_bin_tuple tup)
 {
     Arguments arg;
-    arg.alpha     = std::get<0>(tup);
-    arg.transA    = std::get<1>(tup);
-    arg.transB    = std::get<2>(tup);
-    arg.orderB    = std::get<3>(tup);
-    arg.orderC    = std::get<4>(tup);
-    arg.idx_base  = std::get<5>(tup);
-    arg.diag_type = std::get<6>(tup);
-    arg.fill_mode = std::get<7>(tup);
+    arg.K         = std::get<0>(tup);
+    arg.alpha     = std::get<1>(tup);
+    arg.transA    = std::get<2>(tup);
+    arg.transB    = std::get<3>(tup);
+    arg.orderB    = std::get<4>(tup);
+    arg.orderC    = std::get<5>(tup);
+    arg.idx_base  = std::get<6>(tup);
+    arg.diag_type = std::get<7>(tup);
+    arg.fill_mode = std::get<8>(tup);
     arg.timing    = 0;
 
     // Determine absolute path of test matrix
-    std::string bin_file = std::get<8>(tup);
+    std::string bin_file = std::get<9>(tup);
 
     // Matrices are stored at the same path in matrices directory
     arg.filename = get_filename(bin_file);
@@ -177,8 +186,8 @@ TEST_P(parameterized_spsm_coo_bin, spsm_coo_bin_i64_double)
 
 INSTANTIATE_TEST_SUITE_P(spsm_coo,
                          parameterized_spsm_coo,
-                         testing::Combine(testing::ValuesIn(spsm_coo_M_range),
-                                          testing::ValuesIn(spsm_coo_N_range),
+                         testing::Combine(testing::ValuesIn(spsm_coo_M_N_range),
+                                          testing::ValuesIn(spsm_coo_K_range),
                                           testing::ValuesIn(spsm_coo_alpha_range),
                                           testing::ValuesIn(spsm_coo_transA_range),
                                           testing::ValuesIn(spsm_coo_transB_range),
@@ -190,7 +199,8 @@ INSTANTIATE_TEST_SUITE_P(spsm_coo,
 
 INSTANTIATE_TEST_SUITE_P(spsm_coo_bin,
                          parameterized_spsm_coo_bin,
-                         testing::Combine(testing::ValuesIn(spsm_coo_alpha_range),
+                         testing::Combine(testing::ValuesIn(spsm_coo_K_range),
+                                          testing::ValuesIn(spsm_coo_alpha_range),
                                           testing::ValuesIn(spsm_coo_transA_range),
                                           testing::ValuesIn(spsm_coo_transB_range),
                                           testing::ValuesIn(spsm_coo_orderB_range),

--- a/clients/tests/test_spsm_coo.cpp
+++ b/clients/tests/test_spsm_coo.cpp
@@ -55,7 +55,7 @@ typedef std::tuple<int,
     spsm_coo_bin_tuple;
 
 M_N spsm_coo_M_N_range[] = {{50, 50}};
-int spsm_coo_K_range[] = {22};
+int spsm_coo_K_range[]   = {22};
 
 std::vector<double> spsm_coo_alpha_range = {2.0};
 

--- a/clients/tests/test_spsm_csr.cpp
+++ b/clients/tests/test_spsm_csr.cpp
@@ -55,7 +55,7 @@ typedef std::tuple<int,
     spsm_csr_bin_tuple;
 
 M_N spsm_csr_M_N_range[] = {{50, 50}};
-int spsm_csr_K_range[] = {22};
+int spsm_csr_K_range[]   = {22};
 
 std::vector<double> spsm_csr_alpha_range = {2.0};
 

--- a/clients/tests/test_spsm_csr.cpp
+++ b/clients/tests/test_spsm_csr.cpp
@@ -25,7 +25,13 @@
 
 #include <hipsparse.h>
 
-typedef std::tuple<int,
+struct M_N
+{
+    int M;
+    int N;
+};
+
+typedef std::tuple<M_N,
                    int,
                    double,
                    hipsparseOperation_t,
@@ -36,7 +42,8 @@ typedef std::tuple<int,
                    hipsparseDiagType_t,
                    hipsparseFillMode_t>
     spsm_csr_tuple;
-typedef std::tuple<double,
+typedef std::tuple<int,
+                   double,
                    hipsparseOperation_t,
                    hipsparseOperation_t,
                    hipsparseOrder_t,
@@ -47,8 +54,8 @@ typedef std::tuple<double,
                    std::string>
     spsm_csr_bin_tuple;
 
-int spsm_csr_M_range[] = {50};
-int spsm_csr_N_range[] = {50};
+M_N spsm_csr_M_N_range[] = {{50, 50}};
+int spsm_csr_K_range[] = {22};
 
 std::vector<double> spsm_csr_alpha_range = {2.0};
 
@@ -84,8 +91,9 @@ protected:
 Arguments setup_spsm_csr_arguments(spsm_csr_tuple tup)
 {
     Arguments arg;
-    arg.M         = std::get<0>(tup);
-    arg.N         = std::get<1>(tup);
+    arg.M         = std::get<0>(tup).M;
+    arg.N         = std::get<0>(tup).N;
+    arg.K         = std::get<1>(tup);
     arg.alpha     = std::get<2>(tup);
     arg.transA    = std::get<3>(tup);
     arg.transB    = std::get<4>(tup);
@@ -101,18 +109,19 @@ Arguments setup_spsm_csr_arguments(spsm_csr_tuple tup)
 Arguments setup_spsm_csr_arguments(spsm_csr_bin_tuple tup)
 {
     Arguments arg;
-    arg.alpha     = std::get<0>(tup);
-    arg.transA    = std::get<1>(tup);
-    arg.transB    = std::get<2>(tup);
-    arg.orderB    = std::get<3>(tup);
-    arg.orderC    = std::get<4>(tup);
-    arg.idx_base  = std::get<5>(tup);
-    arg.diag_type = std::get<6>(tup);
-    arg.fill_mode = std::get<7>(tup);
+    arg.K         = std::get<0>(tup);
+    arg.alpha     = std::get<1>(tup);
+    arg.transA    = std::get<2>(tup);
+    arg.transB    = std::get<3>(tup);
+    arg.orderB    = std::get<4>(tup);
+    arg.orderC    = std::get<5>(tup);
+    arg.idx_base  = std::get<6>(tup);
+    arg.diag_type = std::get<7>(tup);
+    arg.fill_mode = std::get<8>(tup);
     arg.timing    = 0;
 
     // Determine absolute path of test matrix
-    std::string bin_file = std::get<8>(tup);
+    std::string bin_file = std::get<9>(tup);
 
     // Matrices are stored at the same path in matrices directory
     arg.filename = get_filename(bin_file);
@@ -177,8 +186,8 @@ TEST_P(parameterized_spsm_csr_bin, spsm_csr_bin_i64_double)
 
 INSTANTIATE_TEST_SUITE_P(spsm_csr,
                          parameterized_spsm_csr,
-                         testing::Combine(testing::ValuesIn(spsm_csr_M_range),
-                                          testing::ValuesIn(spsm_csr_N_range),
+                         testing::Combine(testing::ValuesIn(spsm_csr_M_N_range),
+                                          testing::ValuesIn(spsm_csr_K_range),
                                           testing::ValuesIn(spsm_csr_alpha_range),
                                           testing::ValuesIn(spsm_csr_transA_range),
                                           testing::ValuesIn(spsm_csr_transB_range),
@@ -190,7 +199,8 @@ INSTANTIATE_TEST_SUITE_P(spsm_csr,
 
 INSTANTIATE_TEST_SUITE_P(spsm_csr_bin,
                          parameterized_spsm_csr_bin,
-                         testing::Combine(testing::ValuesIn(spsm_csr_alpha_range),
+                         testing::Combine(testing::ValuesIn(spsm_csr_K_range),
+                                          testing::ValuesIn(spsm_csr_alpha_range),
                                           testing::ValuesIn(spsm_csr_transA_range),
                                           testing::ValuesIn(spsm_csr_transB_range),
                                           testing::ValuesIn(spsm_csr_orderB_range),


### PR DESCRIPTION
Fix SpSM testing where we missed passing K parameter and it was therefore defaulting to -1. Bug was recently introduced in https://github.com/ROCm/hipSPARSE/pull/491.