### PR TITLE
Adding benchmarking to hipsparse Part 4

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -27,6 +27,7 @@ set(HIPSPARSE_BENCHMARK_SOURCES
   client.cpp
   hipsparse_arguments_config.cpp
   hipsparse_bench.cpp
+  hipsparse_bench_app.cpp
   hipsparse_bench_cmdlines.cpp
   hipsparse_routine.cpp
 )

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -25,10 +25,65 @@
 //#include "rocsparse.hpp"
 
 #include "hipsparse_bench.hpp"
+#include "hipsparse_bench_app.hpp"
 #include "hipsparse_routine.hpp"
 #include "utility.hpp"
 #include <hipsparse.h>
 #include <iostream>
+
+hipsparseStatus_t hipsparse_record_output_legend(const std::string& s)
+{
+    auto* s_bench_app = hipsparse_bench_app::instance();
+    if(s_bench_app)
+    {
+        auto status = s_bench_app->record_output_legend(s);
+        return status;
+    }
+    else
+    {
+        return HIPSPARSE_STATUS_SUCCESS;
+    }
+}
+
+hipsparseStatus_t hipsparse_record_output(const std::string& s)
+{
+    auto* s_bench_app = hipsparse_bench_app::instance();
+    if(s_bench_app)
+    {
+        auto status = s_bench_app->record_output(s);
+        return status;
+    }
+    else
+    {
+        return HIPSPARSE_STATUS_SUCCESS;
+    }
+}
+
+hipsparseStatus_t hipsparse_record_timing(double msec, double gflops, double gbs)
+{
+    auto* s_bench_app = hipsparse_bench_app::instance();
+    if(s_bench_app)
+    {
+        return s_bench_app->record_timing(msec, gflops, gbs);
+    }
+    else
+    {
+        return HIPSPARSE_STATUS_SUCCESS;
+    }
+}
+
+bool display_timing_info_is_stdout_disabled()
+{
+    auto* s_bench_app = hipsparse_bench_app::instance();
+    if(s_bench_app)
+    {
+        return s_bench_app->is_stdout_disabled();
+    }
+    else
+    {
+        return false;
+    }
+}
 
 int main(int argc, char* argv[])
 {

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -22,8 +22,6 @@
 *
 * ************************************************************************ */
 
-//#include "rocsparse.hpp"
-
 #include "hipsparse_bench.hpp"
 #include "hipsparse_bench_app.hpp"
 #include "hipsparse_routine.hpp"

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -87,25 +87,64 @@ bool display_timing_info_is_stdout_disabled()
 
 int main(int argc, char* argv[])
 {
-    // old style.
-    try
+    if(hipsparse_bench_app::applies(argc, argv))
     {
-        hipsparse_bench bench(argc, argv);
+        try
+        {
+            auto* s_bench_app = hipsparse_bench_app::instance(argc, argv);
+            //
+            // RUN CASES.
+            //
+            hipsparseStatus_t status = s_bench_app->run_cases();
+            if(status != HIPSPARSE_STATUS_SUCCESS)
+            {
+                return status;
+            }
 
-        // Print info devices.
-        bench.info_devices(std::cout);
+            //
+            // EXPORT FILE.
+            //
+            status = s_bench_app->export_file();
+            if(status != HIPSPARSE_STATUS_SUCCESS)
+            {
+                return status;
+            }
 
-        // Run benchmark.
-        hipsparseStatus_t status = bench.run();
-        if(status != HIPSPARSE_STATUS_SUCCESS)
+            return status;
+        }
+        catch(const hipsparseStatus_t& status)
         {
             return status;
         }
-
-        return status;
     }
-    catch(const hipsparseStatus_t& status)
+    else
     {
-        return status;
+        //
+        // old style.
+        //
+        try
+        {
+            hipsparse_bench bench(argc, argv);
+
+            //
+            // Print info devices.
+            //
+            bench.info_devices(std::cout);
+
+            //
+            // Run benchmark.
+            //
+            hipsparseStatus_t status = bench.run();
+            if(status != HIPSPARSE_STATUS_SUCCESS)
+            {
+                return status;
+            }
+
+            return status;
+        }
+        catch(const hipsparseStatus_t& status)
+        {
+            return status;
+        }
     }
 }

--- a/clients/benchmarks/hipsparse_bench_app.cpp
+++ b/clients/benchmarks/hipsparse_bench_app.cpp
@@ -125,12 +125,12 @@ void hipsparse_bench_app::confidence_interval(const double               alpha,
                                               const std::vector<double>& v,
                                               double                     interval[2])
 {
-    const size_t        size = v.size();
-    
-    static std::random_device dev;
-    static std::mt19937 rng(dev());
+    const size_t size = v.size();
+
+    static std::random_device                                       dev;
+    static std::mt19937                                             rng(dev());
     static std::uniform_int_distribution<std::mt19937::result_type> dist(0, size - 1);
-    
+
     std::vector<double> medians(nboots);
     std::vector<double> resample(resize);
 #define median_value(n__, s__) \

--- a/clients/benchmarks/hipsparse_bench_app.cpp
+++ b/clients/benchmarks/hipsparse_bench_app.cpp
@@ -1,0 +1,447 @@
+/*! \file */
+/* ************************************************************************
+* Copyright (C) 2024 Advanced Micro Devices, Inc. All rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*
+* ************************************************************************ */
+
+#include "hipsparse_bench_app.hpp"
+#include "hipsparse_bench.hpp"
+
+#include <fstream>
+#include <random>
+
+hipsparse_bench_app* hipsparse_bench_app::s_instance = nullptr;
+
+hipsparse_bench_app_base::hipsparse_bench_app_base(int argc, char** argv)
+    : m_initial_argc(hipsparse_bench_app_base::save_initial_cmdline(argc, argv, &m_initial_argv))
+    , m_bench_cmdlines(argc, argv)
+    , m_bench_timing(m_bench_cmdlines.get_nsamples(), m_bench_cmdlines.get_nruns())
+
+          {};
+
+hipsparseStatus_t hipsparse_bench_app_base::run_case(int isample, int irun, int argc, char** argv)
+{
+    hipsparse_bench bench(argc, argv);
+    return bench.run();
+}
+
+hipsparseStatus_t hipsparse_bench_app_base::run_cases()
+{
+    int    sample_argc;
+    char** sample_argv = nullptr;
+    //
+    // Loop over cases.
+    //
+    int nruns    = this->m_bench_cmdlines.get_nruns();
+    int nsamples = this->m_bench_cmdlines.get_nsamples();
+    if(is_stdout_disabled())
+    {
+        printf("// start benchmarking ... (nsamples = %d, nruns = %d)\n", nsamples, nruns);
+    }
+
+    for(int isample = 0; isample < nsamples; ++isample)
+    {
+        this->m_isample = isample;
+        //
+        // Add an item to collect data through hipsparse_record_timing
+        //
+        for(int irun = 0; irun < nruns; ++irun)
+        {
+            this->m_irun = irun;
+
+            //
+            // Get command line arguments, copy each time since it is mutable afterwards.
+            //
+            if(sample_argv == nullptr)
+            {
+                this->m_bench_cmdlines.get_argc(this->m_isample, sample_argc);
+                sample_argv = new char*[sample_argc];
+            }
+
+            this->m_bench_cmdlines.get(this->m_isample, sample_argc, sample_argv);
+
+            //
+            // Run the case.
+            //
+            hipsparseStatus_t status
+                = this->run_case(this->m_isample, this->m_irun, sample_argc, sample_argv);
+            if(status != HIPSPARSE_STATUS_SUCCESS)
+            {
+                std::cerr << "run_cases::run_case failed at line " << __LINE__ << std::endl;
+                return status;
+            }
+            if(is_stdout_disabled())
+            {
+                if((isample * nruns + irun) % 10 == 0)
+                {
+                    fprintf(stdout,
+                            "\r// %2.0f%%",
+                            (double(isample * nruns + irun + 1) / double(nsamples * nruns)) * 100);
+                    fflush(stdout);
+                }
+            }
+        }
+    }
+    if(is_stdout_disabled())
+    {
+        printf("\r// benchmarking done.\n");
+    }
+
+    if(sample_argv != nullptr)
+    {
+        delete[] sample_argv;
+    }
+    return HIPSPARSE_STATUS_SUCCESS;
+};
+
+hipsparse_bench_app::hipsparse_bench_app(int argc, char** argv)
+    : hipsparse_bench_app_base(argc, argv)
+{
+}
+
+hipsparse_bench_app::~hipsparse_bench_app() {}
+
+void hipsparse_bench_app::confidence_interval(const double               alpha,
+                                              const int                  resize,
+                                              const int                  nboots,
+                                              const std::vector<double>& v,
+                                              double                     interval[2])
+{
+    const size_t        size = v.size();
+    
+    static std::random_device dev;
+    static std::mt19937 rng(dev());
+    static std::uniform_int_distribution<std::mt19937::result_type> dist(0, size - 1);
+    
+    std::vector<double> medians(nboots);
+    std::vector<double> resample(resize);
+#define median_value(n__, s__) \
+    ((n__ % 2 == 0) ? (s__[n__ / 2 - 1] + s__[n__ / 2]) * 0.5 : s__[n__ / 2])
+
+    for(int iboot = 0; iboot < nboots; ++iboot)
+    {
+        for(int i = 0; i < resize; ++i)
+        {
+            const int j = dist(rng);
+            resample[i] = v[j];
+        }
+        std::sort(resample.begin(), resample.end());
+        medians[iboot] = median_value(resize, resample);
+    }
+
+    std::sort(medians.begin(), medians.end());
+    interval[0] = medians[int(floor(nboots * 0.5 * (1.0 - alpha)))];
+    interval[1] = medians[int(ceil(nboots * (1.0 - 0.5 * (1.0 - alpha))))];
+#undef median_value
+}
+
+void hipsparse_bench_app::export_item(std::ostream& out, hipsparse_bench_timing_t::item_t& item)
+{
+    //
+    //
+    //
+    auto N = item.m_nruns;
+    if(N > 1)
+    {
+        const double alpha = 0.95;
+        std::sort(item.msec.begin(), item.msec.end());
+        std::sort(item.gflops.begin(), item.gflops.end());
+        std::sort(item.gbs.begin(), item.gbs.end());
+        double msec
+            = (N % 2 == 0) ? (item.msec[N / 2 - 1] + item.msec[N / 2]) * 0.5 : item.msec[N / 2];
+        double gflops = (N % 2 == 0) ? (item.gflops[N / 2 - 1] + item.gflops[N / 2]) * 0.5
+                                     : item.gflops[N / 2];
+        double gbs = (N % 2 == 0) ? (item.gbs[N / 2 - 1] + item.gbs[N / 2]) * 0.5 : item.gbs[N / 2];
+
+        double interval_msec[2], interval_gflops[2], interval_gbs[2];
+        int    nboots = 200;
+        confidence_interval(alpha, 10, nboots, item.msec, interval_msec);
+        confidence_interval(alpha, 10, nboots, item.gflops, interval_gflops);
+        confidence_interval(alpha, 10, nboots, item.gbs, interval_gbs);
+
+        out << std::endl
+            << "    \"time\": [\"" << msec << "\", \"" << interval_msec[0] << "\", \""
+            << interval_msec[1] << "\"]," << std::endl;
+        out << "    \"flops\": [\"" << gflops << "\", \"" << interval_gflops[0] << "\", \""
+            << interval_gflops[1] << "\"]," << std::endl;
+        out << "    \"bandwidth\": [\"" << gbs << "\", \"" << interval_gbs[0] << "\", \""
+            << interval_gbs[1] << "\"]";
+
+        if(!no_rawdata())
+        {
+            out << ",";
+            out << std::endl << "    \"raw_legend\": \"" << item.outputs_legend << "\"";
+            out << ",";
+            out << std::endl << "    \"raw_data\": \"" << item.outputs[0] << "\"";
+        }
+    }
+    else
+    {
+        out << std::endl
+            << "\"time\": [\"" << item.msec[0] << "\", \"" << item.msec[0] << "\", \""
+            << item.msec[0] << "\"]," << std::endl;
+        out << "\"flops\": [\"" << item.gflops[0] << "\", \"" << item.gflops[0] << "\", \""
+            << item.gflops[0] << "\"]," << std::endl;
+        out << "\"bandwidth\": [\"" << item.gbs[0] << "\", \"" << item.gbs[0] << "\", \""
+            << item.gbs[0] << "\"]";
+        if(!no_rawdata())
+        {
+            out << ",";
+            out << std::endl << "    \"raw_legend\": \"" << item.outputs_legend << "\"";
+            out << ",";
+            out << std::endl << "    \"raw_data\": ";
+            out << "\"" << item.outputs[0] << "\"";
+            out << "" << std::endl;
+        }
+    }
+}
+
+hipsparseStatus_t hipsparse_bench_app::export_file()
+{
+    const char* ofilename = this->m_bench_cmdlines.get_ofilename();
+    if(ofilename == nullptr)
+    {
+        std::cerr << "//" << std::endl;
+        std::cerr << "// hipsparse_bench_app warning: no output filename has been specified,"
+                  << std::endl;
+        std::cerr << "// default output filename is 'a.json'." << std::endl;
+        std::cerr << "//" << std::endl;
+        ofilename = "a.json";
+    }
+
+    std::ofstream out(ofilename);
+
+    int   sample_argc;
+    char* sample_argv[64];
+
+    hipsparseStatus_t status;
+
+    //
+    // Write header.
+    //
+    status = define_results_json(out);
+    if(status != HIPSPARSE_STATUS_SUCCESS)
+    {
+        std::cerr << "run_cases failed at line " << __LINE__ << std::endl;
+        return status;
+    }
+
+    //
+    // Loop over cases.
+    //
+    const size_t nsamples = m_bench_cmdlines.get_nsamples();
+    if(nsamples != m_bench_timing.size())
+    {
+        std::cerr << "incompatible sizes at line " << __LINE__ << " "
+                  << m_bench_cmdlines.get_nsamples() << " " << m_bench_timing.size() << std::endl;
+        if(m_bench_timing.size() == 0)
+        {
+            std::cerr << "No data has been harvested from running case" << std::endl;
+        }
+        exit(1);
+    }
+
+    for(int isample = 0; isample < nsamples; ++isample)
+    {
+        this->m_bench_cmdlines.get(isample, sample_argc, sample_argv);
+
+        this->define_case_json(out, isample, sample_argc, sample_argv);
+        out << "{ ";
+        {
+            this->export_item(out, this->m_bench_timing[isample]);
+        }
+        out << " }";
+        this->close_case_json(out, isample, sample_argc, sample_argv);
+    }
+
+    //
+    // Write footer.
+    //
+    status = this->close_results_json(out);
+    if(status != HIPSPARSE_STATUS_SUCCESS)
+    {
+        std::cerr << "run_cases failed at line " << __LINE__ << std::endl;
+        return status;
+    }
+    out.close();
+    return HIPSPARSE_STATUS_SUCCESS;
+}
+
+hipsparseStatus_t
+    hipsparse_bench_app::define_case_json(std::ostream& out, int isample, int argc, char** argv)
+{
+    if(isample > 0)
+        out << "," << std::endl;
+    out << std::endl;
+    out << "{ \"cmdline\": \"";
+    out << argv[0];
+    for(int i = 1; i < argc; ++i)
+        out << " " << argv[i];
+    out << " \"," << std::endl;
+    out << "  \"timing\": ";
+    return HIPSPARSE_STATUS_SUCCESS;
+}
+
+hipsparseStatus_t
+    hipsparse_bench_app::close_case_json(std::ostream& out, int isample, int argc, char** argv)
+{
+    out << " }";
+    return HIPSPARSE_STATUS_SUCCESS;
+}
+
+hipsparseStatus_t hipsparse_bench_app::define_results_json(std::ostream& out)
+{
+    out << "{" << std::endl;
+    auto        end      = std::chrono::system_clock::now();
+    std::time_t end_time = std::chrono::system_clock::to_time_t(end);
+    char*       str      = std::ctime(&end_time);
+    for(int i = 0; i >= 0; ++i)
+        if(str[i] == '\n')
+        {
+            str[i] = '\0';
+            break;
+        }
+    out << "\"date\": \"" << str << "\"," << std::endl;
+    out << "\"hipSPARSE version\": \"" << hipsparse_get_version() << "\"," << std::endl;
+
+    //
+    // !!! To fix, not necessarily the gpu used from hipsparse_bench.
+    //
+    hipDeviceProp_t prop;
+    hipGetDeviceProperties(&prop, 0);
+    gpu_config g(prop);
+    g.print_json(out);
+
+    out << std::endl << "\"cmdline\": \"" << this->m_initial_argv[0];
+
+    for(int i = 1; i < this->m_initial_argc; ++i)
+    {
+        out << " " << this->m_initial_argv[i];
+    }
+    out << "\"," << std::endl;
+
+    size_t option_index_x = this->m_bench_cmdlines.get_option_index_x();
+    out << std::endl << "\"xargs\": \[";
+    for(int j = 0; j < this->m_bench_cmdlines.get_option_nargs(option_index_x); ++j)
+    {
+        auto arg = this->m_bench_cmdlines.get_option_arg(option_index_x, j);
+        if(j > 0)
+            out << ", ";
+        out << "\"" << arg << "\"";
+    }
+    out << "]," << std::endl;
+    out << std::endl << "\"yargs\":";
+
+    //
+    // Harvest expanded options.
+    //
+    std::vector<int> y_options_size;
+    std::vector<int> y_options_index;
+    for(int k = 0; k < this->m_bench_cmdlines.get_noptions(); ++k)
+    {
+        if(k != option_index_x)
+        {
+            if(this->m_bench_cmdlines.get_option_nargs(k) > 1)
+            {
+                y_options_index.push_back(k);
+                y_options_size.push_back(this->m_bench_cmdlines.get_option_nargs(k));
+            }
+        }
+    }
+
+    const int num_y_options = y_options_index.size();
+    if(num_y_options > 0)
+    {
+        std::vector<std::vector<int>> indices(num_y_options);
+        for(int k = 0; k < num_y_options; ++k)
+        {
+            indices[k].resize(y_options_size[k], 0);
+        }
+    }
+
+    int nplots = this->m_bench_cmdlines.get_nsamples()
+                 / this->m_bench_cmdlines.get_option_nargs(option_index_x);
+    std::vector<std::string> plot_titles(nplots);
+    if(plot_titles.size() == 1)
+    {
+        plot_titles.push_back("");
+    }
+    else
+    {
+        int  n        = y_options_size[0];
+        auto argname0 = this->m_bench_cmdlines.get_option_name(y_options_index[0]);
+        for(int iplot = 0; iplot < nplots; ++iplot)
+        {
+            std::string title("");
+            int         p = n;
+
+            {
+                int  jref = iplot % p;
+                auto arg0 = this->m_bench_cmdlines.get_option_arg(y_options_index[0], jref);
+                if(argname0[1] == '-')
+                {
+                    title += std::string(argname0 + 2) + std::string("=") + arg0;
+                }
+                else
+                {
+                    title += std::string(argname0 + 1) + std::string("=") + arg0;
+                }
+            }
+
+            for(int k = 1; k < num_y_options; ++k)
+            {
+                int kref = iplot / p;
+                p *= this->m_bench_cmdlines.get_option_nargs(y_options_index[k]);
+                auto arg     = this->m_bench_cmdlines.get_option_arg(y_options_index[k], kref);
+                auto argname = this->m_bench_cmdlines.get_option_name(y_options_index[k]);
+                if(argname[1] == '-')
+                {
+                    title += std::string(",") + std::string(argname + 2) + std::string("=") + arg;
+                }
+                else
+                {
+                    title += std::string(",") + std::string(argname + 1) + std::string("=") + arg;
+                }
+            }
+            plot_titles[iplot] = title;
+        }
+    }
+    out << "[";
+    {
+        out << "\"" << plot_titles[0] << "\"";
+        for(int iplot = 1; iplot < nplots; ++iplot)
+            out << ", \"" << plot_titles[iplot] << "\"";
+    }
+    out << "]," << std::endl << std::endl;
+    ;
+    out << "\""
+        << "results"
+        << "\": [";
+
+    return HIPSPARSE_STATUS_SUCCESS;
+}
+
+hipsparseStatus_t hipsparse_bench_app::close_results_json(std::ostream& out)
+{
+    out << "]" << std::endl;
+    out << "}" << std::endl;
+    return HIPSPARSE_STATUS_SUCCESS;
+}

--- a/clients/benchmarks/hipsparse_bench_app.hpp
+++ b/clients/benchmarks/hipsparse_bench_app.hpp
@@ -207,7 +207,7 @@ public:
     {
         return s_instance;
     }
-    
+
     hipsparse_bench_app(const hipsparse_bench_app&) = delete;
     hipsparse_bench_app& operator=(const hipsparse_bench_app&) = delete;
 

--- a/clients/benchmarks/hipsparse_bench_app.hpp
+++ b/clients/benchmarks/hipsparse_bench_app.hpp
@@ -208,7 +208,7 @@ public:
         return s_instance;
     }
 
-    hipsparse_bench_app(const hipsparse_bench_app&) = delete;
+    hipsparse_bench_app(const hipsparse_bench_app&)            = delete;
     hipsparse_bench_app& operator=(const hipsparse_bench_app&) = delete;
 
     static bool applies(int argc, char** argv)
@@ -233,14 +233,14 @@ public:
     }
 
 protected:
-    void             export_item(std::ostream& out, hipsparse_bench_timing_t::item_t& item);
+    void              export_item(std::ostream& out, hipsparse_bench_timing_t::item_t& item);
     hipsparseStatus_t define_case_json(std::ostream& out, int isample, int argc, char** argv);
     hipsparseStatus_t close_case_json(std::ostream& out, int isample, int argc, char** argv);
     hipsparseStatus_t define_results_json(std::ostream& out);
     hipsparseStatus_t close_results_json(std::ostream& out);
-    void             confidence_interval(const double               alpha,
-                                         const int                  resize,
-                                         const int                  nboots,
-                                         const std::vector<double>& v,
-                                         double                     interval[2]);
+    void              confidence_interval(const double               alpha,
+                                          const int                  resize,
+                                          const int                  nboots,
+                                          const std::vector<double>& v,
+                                          double                     interval[2]);
 };

--- a/clients/benchmarks/hipsparse_bench_app.hpp
+++ b/clients/benchmarks/hipsparse_bench_app.hpp
@@ -1,0 +1,246 @@
+/*! \file */
+/* ************************************************************************
+* Copyright (C) 2024 Advanced Micro Devices, Inc. All rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*
+* ************************************************************************ */
+#pragma once
+
+#include "hipsparse.h"
+#include "hipsparse_bench_cmdlines.hpp"
+#include <iostream>
+#include <vector>
+
+//
+// Struct collecting benchmark timing results.
+//
+struct hipsparse_bench_timing_t
+{
+    //
+    // Local item
+    //
+    struct item_t
+    {
+        int                      m_nruns{};
+        std::vector<double>      msec{};
+        std::vector<double>      gflops{};
+        std::vector<double>      gbs{};
+        std::vector<std::string> outputs{};
+        std::string              outputs_legend{};
+        item_t(){};
+
+        explicit item_t(int nruns_)
+            : m_nruns(nruns_)
+            , msec(nruns_)
+            , gflops(nruns_)
+            , gbs(nruns_)
+            , outputs(nruns_){};
+
+        item_t& operator()(int nruns_)
+        {
+            this->m_nruns = nruns_;
+            this->msec.resize(nruns_);
+            this->gflops.resize(nruns_);
+            this->gbs.resize(nruns_);
+            this->outputs.resize(nruns_);
+            return *this;
+        };
+
+        hipsparseStatus_t record(int irun, double msec_, double gflops_, double gbs_)
+        {
+            if(irun >= 0 && irun < m_nruns)
+            {
+                this->msec[irun]   = msec_;
+                this->gflops[irun] = gflops_;
+                this->gbs[irun]    = gbs_;
+                return HIPSPARSE_STATUS_SUCCESS;
+            }
+            else
+            {
+                return HIPSPARSE_STATUS_INTERNAL_ERROR;
+            }
+        }
+
+        hipsparseStatus_t record(int irun, const std::string& s)
+        {
+            if(irun >= 0 && irun < m_nruns)
+            {
+                this->outputs[irun] = s;
+                return HIPSPARSE_STATUS_SUCCESS;
+            }
+            else
+            {
+                return HIPSPARSE_STATUS_INTERNAL_ERROR;
+            }
+        }
+        hipsparseStatus_t record_output_legend(const std::string& s)
+        {
+            this->outputs_legend = s;
+            return HIPSPARSE_STATUS_SUCCESS;
+        }
+    };
+
+    size_t size() const
+    {
+        return this->m_items.size();
+    };
+    item_t& operator[](size_t i)
+    {
+        return this->m_items[i];
+    }
+    const item_t& operator[](size_t i) const
+    {
+        return this->m_items[i];
+    }
+
+    hipsparse_bench_timing_t(int nsamples, int nruns_per_sample)
+        : m_items(nsamples)
+    {
+        for(int i = 0; i < nsamples; ++i)
+        {
+            m_items[i](nruns_per_sample);
+        }
+    }
+
+private:
+    std::vector<item_t> m_items;
+};
+
+class hipsparse_bench_app_base
+{
+protected:
+    //
+    // Record initial command line.
+    //
+    int    m_initial_argc{};
+    char** m_initial_argv;
+    //
+    // Set of command lines.
+    //
+    hipsparse_bench_cmdlines m_bench_cmdlines;
+    //
+    //
+    //
+    hipsparse_bench_timing_t m_bench_timing;
+
+    bool m_stdout_disabled{true};
+
+    static int save_initial_cmdline(int argc, char** argv, char*** argv_)
+    {
+        argv_[0] = new char*[argc];
+        for(int i = 0; i < argc; ++i)
+        {
+            argv_[0][i] = argv[i];
+        }
+        return argc;
+    }
+    //
+    // @brief Constructor.
+    //
+    hipsparse_bench_app_base(int argc, char** argv);
+
+    //
+    // @brief Run case.
+    //
+    hipsparseStatus_t run_case(int isample, int irun, int argc, char** argv);
+
+    //
+    // For internal use, to get the current isample and irun.
+    //
+    int m_isample{};
+    int m_irun{};
+    int get_isample() const
+    {
+        return this->m_isample;
+    };
+    int get_irun() const
+    {
+        return this->m_irun;
+    };
+
+public:
+    bool is_stdout_disabled() const
+    {
+        return m_bench_cmdlines.is_stdout_disabled();
+    }
+    bool no_rawdata() const
+    {
+        return m_bench_cmdlines.no_rawdata();
+    }
+
+    //
+    // @brief Run cases.
+    //
+    hipsparseStatus_t run_cases();
+};
+
+class hipsparse_bench_app : public hipsparse_bench_app_base
+{
+private:
+    static hipsparse_bench_app* s_instance;
+
+public:
+    static hipsparse_bench_app* instance(int argc, char** argv)
+    {
+        s_instance = new hipsparse_bench_app(argc, argv);
+        return s_instance;
+    }
+
+    static hipsparse_bench_app* instance()
+    {
+        return s_instance;
+    }
+
+    hipsparse_bench_app(const hipsparse_bench_app&) = delete;
+    hipsparse_bench_app& operator=(const hipsparse_bench_app&) = delete;
+
+    static bool applies(int argc, char** argv)
+    {
+        return hipsparse_bench_cmdlines::applies(argc, argv);
+    }
+
+    hipsparse_bench_app(int argc, char** argv);
+    ~hipsparse_bench_app();
+    hipsparseStatus_t export_file();
+    hipsparseStatus_t record_timing(double msec, double gflops, double bandwidth)
+    {
+        return this->m_bench_timing[this->m_isample].record(this->m_irun, msec, gflops, bandwidth);
+    }
+    hipsparseStatus_t record_output(const std::string& s)
+    {
+        return this->m_bench_timing[this->m_isample].record(this->m_irun, s);
+    }
+    hipsparseStatus_t record_output_legend(const std::string& s)
+    {
+        return this->m_bench_timing[this->m_isample].record_output_legend(s);
+    }
+
+protected:
+    void             export_item(std::ostream& out, hipsparse_bench_timing_t::item_t& item);
+    hipsparseStatus_t define_case_json(std::ostream& out, int isample, int argc, char** argv);
+    hipsparseStatus_t close_case_json(std::ostream& out, int isample, int argc, char** argv);
+    hipsparseStatus_t define_results_json(std::ostream& out);
+    hipsparseStatus_t close_results_json(std::ostream& out);
+    void             confidence_interval(const double               alpha,
+                                         const int                  resize,
+                                         const int                  nboots,
+                                         const std::vector<double>& v,
+                                         double                     interval[2]);
+};

--- a/clients/benchmarks/hipsparse_bench_app.hpp
+++ b/clients/benchmarks/hipsparse_bench_app.hpp
@@ -207,8 +207,8 @@ public:
     {
         return s_instance;
     }
-
-    hipsparse_bench_app(const hipsparse_bench_app&)            = delete;
+    
+    hipsparse_bench_app(const hipsparse_bench_app&) = delete;
     hipsparse_bench_app& operator=(const hipsparse_bench_app&) = delete;
 
     static bool applies(int argc, char** argv)

--- a/clients/benchmarks/hipsparse_bench_cmdlines.cpp
+++ b/clients/benchmarks/hipsparse_bench_cmdlines.cpp
@@ -15,7 +15,7 @@ int hipsparse_bench_cmdlines::get_nsamples() const
 {
     return this->m_cmd.get_nsamples();
 };
-int hipsparse_bench_cmdlines::get_option_index_x() const
+size_t hipsparse_bench_cmdlines::get_option_index_x() const
 {
     return this->m_cmd.get_option_index_x();
 };

--- a/clients/benchmarks/hipsparse_bench_cmdlines.hpp
+++ b/clients/benchmarks/hipsparse_bench_cmdlines.hpp
@@ -183,7 +183,7 @@ private:
             return this->m_nsamples;
         }
 
-        int get_option_index_x() const
+        size_t get_option_index_x() const
         {
             return this->m_option_index_x;
         }
@@ -369,7 +369,7 @@ private:
 
             const int option_x_nargs = this->m_options[this->m_option_index_x].args.size();
             int       N              = option_x_nargs;
-            for(int iopt = 0; iopt < num_options; ++iopt)
+            for(size_t iopt = 0; iopt < num_options; ++iopt)
             {
                 cmdline_option& option = this->m_options[iopt];
 
@@ -559,7 +559,7 @@ private:
         std::vector<cmdline_arg> m_args;
         bool                     m_has_bench_option{};
         int                      m_bench_nruns{1};
-        int                      m_option_index_x;
+        size_t                   m_option_index_x;
         int                      m_nsamples;
         bool                     m_is_stdout_disabled{true};
         bool                     m_no_rawdata{};
@@ -586,7 +586,7 @@ public:
     // @brief Get the number of samples..
     //
     int         get_nsamples() const;
-    int         get_option_index_x() const;
+    size_t      get_option_index_x() const;
     int         get_option_nargs(int i);
     const char* get_option_arg(int i, int j);
     const char* get_option_name(int i);

--- a/clients/include/display.hpp
+++ b/clients/include/display.hpp
@@ -48,7 +48,7 @@ static constexpr const char* s_analysis_timing_info_time = "analysis msec";
 hipsparseStatus_t hipsparse_record_output_legend(const std::string& s);
 hipsparseStatus_t hipsparse_record_output(const std::string& s);
 hipsparseStatus_t hipsparse_record_timing(double msec, double gflops, double gbs);
-bool display_timing_info_is_stdout_disabled();
+bool              display_timing_info_is_stdout_disabled();
 
 inline auto& operator<<(std::ostream& out, const hipComplex& z)
 {

--- a/clients/include/display.hpp
+++ b/clients/include/display.hpp
@@ -38,10 +38,17 @@
 #include <sstream>
 #include <vector>
 
+#include <hipsparse.h>
+
 static constexpr const char* s_timing_info_perf          = "GFlop/s";
 static constexpr const char* s_timing_info_bandwidth     = "GB/s";
 static constexpr const char* s_timing_info_time          = "msec";
 static constexpr const char* s_analysis_timing_info_time = "analysis msec";
+
+hipsparseStatus_t hipsparse_record_output_legend(const std::string& s);
+hipsparseStatus_t hipsparse_record_output(const std::string& s);
+hipsparseStatus_t hipsparse_record_timing(double msec, double gflops, double gbs);
+bool display_timing_info_is_stdout_disabled();
 
 inline auto& operator<<(std::ostream& out, const hipComplex& z)
 {
@@ -62,84 +69,6 @@ struct display_key_t
     //
     // Enumerate keys.
     //
-    // typedef enum enum_
-    // {
-    //     trans_A = 0,
-    //     trans_B,
-    //     trans_X,
-    //     nnz_A,
-    //     nnz_B,
-    //     nnz_C,
-    //     nnz_D,
-    //     batch_count_A,
-    //     batch_count_B,
-    //     batch_count_C,
-    //     batch_stride,
-    //     iters,
-    //     function,
-    //     ctype,
-    //     itype,
-    //     jtype,
-    //     alpha,
-    //     beta,
-    //     gflops,
-    //     bandwidth,
-    //     time_ms,
-    //     analysis_time_ms,
-    //     algorithm,
-    //     size,
-    //     mask_size,
-    //     M,
-    //     N,
-    //     K,
-    //     Mb,
-    //     Mb_A,
-    //     Mb_C,
-    //     Nb,
-    //     Nb_A,
-    //     Nb_C,
-    //     Kb,
-    //     LD,
-    //     nrhs,
-    //     ell_width,
-    //     csr_nnz,
-    //     ell_nnz,
-    //     coo_nnz,
-    //     dir_A,
-    //     nnzb_A,
-    //     nnzb_B,
-    //     nnzb_C,
-    //     nnzb_D,
-    //     bdir_A,
-    //     bdim_A,
-    //     rbdim_A,
-    //     cbdim_A,
-    //     rbdim_C,
-    //     cbdim_C,
-    //     analysis_ms,
-    //     order,
-    //     diag_type,
-    //     fill_mode,
-    //     analysis_policy,
-    //     solve_policy,
-    //     permute,
-    //     format,
-    //     action,
-    //     partition,
-    //     threshold,
-    //     percentage,
-    //     pivot,
-
-    //     bdir        = bdir_A,
-    //     bdim        = bdim_A,
-    //     rbdim       = rbdim_A,
-    //     cbdim       = cbdim_A,
-    //     dir         = dir_A,
-    //     nnzb        = nnzb_A,
-    //     trans       = trans_A,
-    //     nnz         = nnz_A,
-    //     batch_count = batch_count_A
-    // } key_t;
     typedef enum enum_
     {
         gflops = 0,
@@ -464,310 +393,6 @@ struct display_key_t
         }
         }
     }
-
-    // static const char* to_str(key_t key_)
-    // {
-    //     switch(key_)
-    //     {
-    //     case gflops:
-    //     {
-    //         return s_timing_info_perf;
-    //     }
-
-    //     case order:
-    //     {
-    //         return "order";
-    //     }
-
-    //     case diag_type:
-    //     {
-    //         return "diag_type";
-    //     }
-
-    //     case permute:
-    //     {
-    //         return "permute";
-    //     }
-
-    //     case format:
-    //     {
-    //         return "format";
-    //     }
-
-    //     case action:
-    //     {
-    //         return "action";
-    //     }
-
-    //     case partition:
-    //     {
-    //         return "partition";
-    //     }
-
-    //     case threshold:
-    //     {
-    //         return "threshold";
-    //     }
-
-    //     case percentage:
-    //     {
-    //         return "percentage";
-    //     }
-
-    //     case pivot:
-    //     {
-    //         return "pivot";
-    //     }
-
-    //     case analysis_ms:
-    //     {
-    //         return "analysis";
-    //     }
-
-    //     case fill_mode:
-    //     {
-    //         return "fill_mode";
-    //     }
-
-    //     case analysis_policy:
-    //     {
-    //         return "analysis_policy";
-    //     }
-
-    //     case solve_policy:
-    //     {
-    //         return "solve_policy";
-    //     }
-
-    //     case algorithm:
-    //     {
-    //         return "algorithm";
-    //     }
-
-    //     case size:
-    //     {
-    //         return "size";
-    //     }
-
-    //     case mask_size:
-    //     {
-    //         return "mask_size";
-    //     }
-
-    //     case M:
-    //     {
-    //         return "M";
-    //     }
-
-    //     case Mb:
-    //     {
-    //         return "Mb";
-    //     }
-
-    //     case Mb_A:
-    //     {
-    //         return "Mb_A";
-    //     }
-
-    //     case Mb_C:
-    //     {
-    //         return "Mb_C";
-    //     }
-
-    //     case bdir_A:
-    //     {
-    //         return "bdir_A";
-    //     }
-
-    //     case dir_A:
-    //     {
-    //         return "dir_A";
-    //     }
-
-    //     case bdim_A:
-    //     {
-    //         return "bdim_A";
-    //     }
-    //     case rbdim_A:
-    //     {
-    //         return "rbdim_A";
-    //     }
-    //     case cbdim_A:
-    //     {
-    //         return "cbdim_A";
-    //     }
-    //     case rbdim_C:
-    //     {
-    //         return "rbdim_C";
-    //     }
-    //     case cbdim_C:
-    //     {
-    //         return "cbdim_C";
-    //     }
-
-    //     case N:
-    //     {
-    //         return "N";
-    //     }
-
-    //     case Nb:
-    //     {
-    //         return "Nb";
-    //     }
-    //     case Nb_A:
-    //     {
-    //         return "Nb_A";
-    //     }
-    //     case Nb_C:
-    //     {
-    //         return "Nb_C";
-    //     }
-
-    //     case K:
-    //     {
-    //         return "K";
-    //     }
-
-    //     case Kb:
-    //     {
-    //         return "Kb";
-    //     }
-
-    //     case LD:
-    //     {
-    //         return "LD";
-    //     }
-
-    //     case nrhs:
-    //     {
-    //         return "nrhs";
-    //     }
-
-    //     case ell_width:
-    //     {
-    //         return "ell_width";
-    //     }
-    //     case csr_nnz:
-    //     {
-    //         return "csr_nnz";
-    //     }
-    //     case ell_nnz:
-    //     {
-    //         return "ell_nnz";
-    //     }
-    //     case coo_nnz:
-    //     {
-    //         return "coo_nnz";
-    //     }
-
-    //     case bandwidth:
-    //     {
-    //         return s_timing_info_bandwidth;
-    //     }
-
-    //     case time_ms:
-    //     {
-    //         return s_timing_info_time;
-    //     }
-
-    //     case analysis_time_ms:
-    //     {
-    //         return s_analysis_timing_info_time;
-    //     }
-
-    //     case alpha:
-    //     {
-    //         return "alpha";
-    //     }
-    //     case beta:
-    //     {
-    //         return "beta";
-    //     }
-    //     case trans_A:
-    //     {
-    //         return "transA";
-    //     }
-    //     case trans_B:
-    //     {
-    //         return "transB";
-    //     }
-    //     case trans_X:
-    //     {
-    //         return "transX";
-    //     }
-
-    //     case nnzb_A:
-    //     {
-    //         return "nnzb_A";
-    //     }
-    //     case nnzb_B:
-    //     {
-    //         return "nnzb_B";
-    //     }
-    //     case nnzb_C:
-    //     {
-    //         return "nnzb_C";
-    //     }
-    //     case nnzb_D:
-    //     {
-    //         return "nnzb_D";
-    //     }
-
-    //     case nnz_A:
-    //     {
-    //         return "nnz_A";
-    //     }
-    //     case nnz_B:
-    //     {
-    //         return "nnz_B";
-    //     }
-    //     case nnz_C:
-    //     {
-    //         return "nnz_C";
-    //     }
-    //     case nnz_D:
-    //     {
-    //         return "nnz_D";
-    //     }
-    //     case batch_count_A:
-    //     {
-    //         return "batch_count_A";
-    //     }
-    //     case batch_count_B:
-    //     {
-    //         return "batch_count_B";
-    //     }
-    //     case batch_count_C:
-    //     {
-    //         return "batch_count_C";
-    //     }
-    //     case batch_stride:
-    //     {
-    //         return "batch_stride";
-    //     }
-    //     case iters:
-    //     {
-    //         return "iter";
-    //     }
-    //     case function:
-    //     {
-    //         return "function";
-    //     }
-    //     case ctype:
-    //     {
-    //         return "ctype";
-    //     }
-
-    //     case itype:
-    //     {
-    //         return "itype";
-    //     }
-    //     case jtype:
-    //     {
-    //         return "jtype";
-    //     }
-    //     }
-    // }
 };
 
 template <typename S>
@@ -922,7 +547,7 @@ inline void display_timing_info_generate(std::ostream& out, int n, S name, T t, 
 {
     double values[3]{};
     display_timing_info_grab_results(values, name, t, ts...);
-    //rocsparse_record_timing(values[0], values[1], values[2]);
+    hipsparse_record_timing(values[0], values[1], values[2]);
     display_timing_info_values(out, n, name, t, ts...);
 }
 
@@ -931,7 +556,7 @@ inline void display_timing_info_generate_params(std::ostream& out, int n, S name
 {
     double values[3]{};
     display_timing_info_grab_results(values, name, t, ts...);
-    //rocsparse_record_timing(values[0], values[1], values[2]);
+    hipsparse_record_timing(values[0], values[1], values[2]);
     display_timing_info_values_noresults(out, n, name, t, ts...);
 }
 
@@ -974,34 +599,34 @@ inline void display_timing_info_main(S name, Ts... ts)
         out_legend.precision(2);
         out_legend.setf(std::ios::fixed);
         out_legend.setf(std::ios::left);
-        //if(!display_timing_info_is_stdout_disabled())
-        //{
-        display_timing_info_legend(out_legend, n, name, ts...);
-        std::cout << out_legend.str() << std::endl;
-        //}
-        //else
-        //{
-        //    // store the string.
-        //    display_timing_info_legend_noresults(out_legend, n, name, ts...);
-        //    rocsparse_record_output_legend(out_legend.str());
-        //}
+        if(!display_timing_info_is_stdout_disabled())
+        {
+            display_timing_info_legend(out_legend, n, name, ts...);
+            std::cout << out_legend.str() << std::endl;
+        }
+        else
+        {
+            // store the string.
+            display_timing_info_legend_noresults(out_legend, n, name, ts...);
+            hipsparse_record_output_legend(out_legend.str());
+        }
     }
 
     std::ostringstream out;
     out.precision(2);
     out.setf(std::ios::fixed);
     out.setf(std::ios::left);
-    //if(!display_timing_info_is_stdout_disabled())
-    //{
-    display_timing_info_generate(out, n, name, ts...);
-    std::cout << out.str() << std::endl;
-    //}
-    //else
-    //{
-    //    display_timing_info_generate_params(out, n, name, ts...);
-    //    // store the string.
-    //    rocsparse_record_output(out.str());
-    //}
+    if(!display_timing_info_is_stdout_disabled())
+    {
+        display_timing_info_generate(out, n, name, ts...);
+        std::cout << out.str() << std::endl;
+    }
+    else
+    {
+        display_timing_info_generate_params(out, n, name, ts...);
+        // store the string.
+        hipsparse_record_output(out.str());
+    }
 }
 
 inline void hipsparse_get_matrixname(const char* f, char* name)

--- a/clients/include/display.hpp
+++ b/clients/include/display.hpp
@@ -31,12 +31,12 @@
 #define DISPLAY_HPP
 
 #include <fstream>
-#include <hip/hip_runtime_api.h>
 #include <hip/hip_complex.h>
-#include <sstream>
-#include <vector>
+#include <hip/hip_runtime_api.h>
 #include <iomanip>
 #include <iostream>
+#include <sstream>
+#include <vector>
 
 static constexpr const char* s_timing_info_perf          = "GFlop/s";
 static constexpr const char* s_timing_info_bandwidth     = "GB/s";
@@ -976,8 +976,8 @@ inline void display_timing_info_main(S name, Ts... ts)
         out_legend.setf(std::ios::left);
         //if(!display_timing_info_is_stdout_disabled())
         //{
-            display_timing_info_legend(out_legend, n, name, ts...);
-            std::cout << out_legend.str() << std::endl;
+        display_timing_info_legend(out_legend, n, name, ts...);
+        std::cout << out_legend.str() << std::endl;
         //}
         //else
         //{
@@ -993,8 +993,8 @@ inline void display_timing_info_main(S name, Ts... ts)
     out.setf(std::ios::left);
     //if(!display_timing_info_is_stdout_disabled())
     //{
-        display_timing_info_generate(out, n, name, ts...);
-        std::cout << out.str() << std::endl;
+    display_timing_info_generate(out, n, name, ts...);
+    std::cout << out.str() << std::endl;
     //}
     //else
     //{
@@ -1038,26 +1038,26 @@ inline void hipsparse_get_matrixname(const char* f, char* name)
     name[ddir - cdir] = '\0';
 }
 
-#define display_timing_info(...)                                                             \
-    do                                                                                       \
-    {                                                                                        \
-        const char* ctypename = hipsparse_datatype2string(argus.compute_type);                 \
-        const char* itypename = hipsparse_indextype2string(argus.index_type_I);                \
-        const char* jtypename = hipsparse_indextype2string(argus.index_type_J);                \
-                                                                                             \
-        display_timing_info_main(__VA_ARGS__,                                                \
-                                 display_key_t::iters,                                       \
-                                 argus.iters,                                                \
-                                 "verified",                                                 \
-                                 (argus.unit_check ? "yes" : "no"),                          \
-                                 display_key_t::function,                                    \
-                                 &argus.function_name[0],                                    \
-                                 display_key_t::ctype,                                       \
-                                 ctypename,                                                  \
-                                 display_key_t::itype,                                       \
-                                 itypename,                                                  \
-                                 display_key_t::jtype,                                       \
-                                 jtypename);                                                 \
+#define display_timing_info(...)                                                \
+    do                                                                          \
+    {                                                                           \
+        const char* ctypename = hipsparse_datatype2string(argus.compute_type);  \
+        const char* itypename = hipsparse_indextype2string(argus.index_type_I); \
+        const char* jtypename = hipsparse_indextype2string(argus.index_type_J); \
+                                                                                \
+        display_timing_info_main(__VA_ARGS__,                                   \
+                                 display_key_t::iters,                          \
+                                 argus.iters,                                   \
+                                 "verified",                                    \
+                                 (argus.unit_check ? "yes" : "no"),             \
+                                 display_key_t::function,                       \
+                                 &argus.function_name[0],                       \
+                                 display_key_t::ctype,                          \
+                                 ctypename,                                     \
+                                 display_key_t::itype,                          \
+                                 itypename,                                     \
+                                 display_key_t::jtype,                          \
+                                 jtypename);                                    \
     } while(false)
 
 #endif // DISPLAY_HPP

--- a/clients/include/display.hpp
+++ b/clients/include/display.hpp
@@ -1,0 +1,1063 @@
+/*! \file */
+/* ************************************************************************
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+
+/*! \file
+ *  \brief display.hpp provides common testing utilities.
+ */
+
+#pragma once
+#ifndef DISPLAY_HPP
+#define DISPLAY_HPP
+
+#include <fstream>
+#include <hip/hip_runtime_api.h>
+#include <hip/hip_complex.h>
+#include <sstream>
+#include <vector>
+#include <iomanip>
+#include <iostream>
+
+static constexpr const char* s_timing_info_perf          = "GFlop/s";
+static constexpr const char* s_timing_info_bandwidth     = "GB/s";
+static constexpr const char* s_timing_info_time          = "msec";
+static constexpr const char* s_analysis_timing_info_time = "analysis msec";
+
+inline auto& operator<<(std::ostream& out, const hipComplex& z)
+{
+    std::stringstream ss;
+    ss << '(' << z.x << ',' << z.y << ')';
+    return out << ss.str();
+}
+
+inline auto& operator<<(std::ostream& out, const hipDoubleComplex& z)
+{
+    std::stringstream ss;
+    ss << '(' << z.x << ',' << z.y << ')';
+    return out << ss.str();
+}
+
+struct display_key_t
+{
+    //
+    // Enumerate keys.
+    //
+    // typedef enum enum_
+    // {
+    //     trans_A = 0,
+    //     trans_B,
+    //     trans_X,
+    //     nnz_A,
+    //     nnz_B,
+    //     nnz_C,
+    //     nnz_D,
+    //     batch_count_A,
+    //     batch_count_B,
+    //     batch_count_C,
+    //     batch_stride,
+    //     iters,
+    //     function,
+    //     ctype,
+    //     itype,
+    //     jtype,
+    //     alpha,
+    //     beta,
+    //     gflops,
+    //     bandwidth,
+    //     time_ms,
+    //     analysis_time_ms,
+    //     algorithm,
+    //     size,
+    //     mask_size,
+    //     M,
+    //     N,
+    //     K,
+    //     Mb,
+    //     Mb_A,
+    //     Mb_C,
+    //     Nb,
+    //     Nb_A,
+    //     Nb_C,
+    //     Kb,
+    //     LD,
+    //     nrhs,
+    //     ell_width,
+    //     csr_nnz,
+    //     ell_nnz,
+    //     coo_nnz,
+    //     dir_A,
+    //     nnzb_A,
+    //     nnzb_B,
+    //     nnzb_C,
+    //     nnzb_D,
+    //     bdir_A,
+    //     bdim_A,
+    //     rbdim_A,
+    //     cbdim_A,
+    //     rbdim_C,
+    //     cbdim_C,
+    //     analysis_ms,
+    //     order,
+    //     diag_type,
+    //     fill_mode,
+    //     analysis_policy,
+    //     solve_policy,
+    //     permute,
+    //     format,
+    //     action,
+    //     partition,
+    //     threshold,
+    //     percentage,
+    //     pivot,
+
+    //     bdir        = bdir_A,
+    //     bdim        = bdim_A,
+    //     rbdim       = rbdim_A,
+    //     cbdim       = cbdim_A,
+    //     dir         = dir_A,
+    //     nnzb        = nnzb_A,
+    //     trans       = trans_A,
+    //     nnz         = nnz_A,
+    //     batch_count = batch_count_A
+    // } key_t;
+    typedef enum enum_
+    {
+        gflops = 0,
+        bandwidth,
+        time_ms,
+        iters,
+        function,
+        ctype,
+        itype,
+        jtype,
+        size,
+        M,
+        N,
+        K,
+        LD,
+        Mb,
+        MbA,
+        MbC,
+        Nb,
+        NbA,
+        NbC,
+        Kb,
+        nrhs,
+        ell_width,
+        ell_nnz,
+        coo_nnz,
+        nnz,
+        nnzA,
+        nnzB,
+        nnzC,
+        nnzb,
+        nnzbA,
+        nnzbC,
+        block_dim,
+        row_block_dim,
+        row_block_dimA,
+        row_block_dimC,
+        col_block_dim,
+        col_block_dimA,
+        col_block_dimC,
+        batch_count,
+        batch_countA,
+        batch_countB,
+        batch_countC,
+        batch_stride,
+        alpha,
+        beta,
+        percentage,
+        threshold,
+        trans,
+        transA,
+        transB,
+        transC,
+        transX,
+        direction,
+        order,
+        format,
+        fill_mode,
+        diag_type,
+        solve_policy,
+        action,
+        partition,
+        algorithm,
+        permute
+    } key_t;
+
+    static const char* to_str(key_t key_)
+    {
+        switch(key_)
+        {
+        case gflops:
+        {
+            return s_timing_info_perf;
+        }
+        case bandwidth:
+        {
+            return s_timing_info_bandwidth;
+        }
+        case time_ms:
+        {
+            return s_timing_info_time;
+        }
+        case iters:
+        {
+            return "iters";
+        }
+        case function:
+        {
+            return "function";
+        }
+        case ctype:
+        {
+            return "ctype";
+        }
+        case itype:
+        {
+            return "itype";
+        }
+        case jtype:
+        {
+            return "jtype";
+        }
+        case size:
+        {
+            return "size";
+        }
+        case M:
+        {
+            return "M";
+        }
+        case N:
+        {
+            return "N";
+        }
+        case K:
+        {
+            return "K";
+        }
+        case LD:
+        {
+            return "LD";
+        }
+        case Mb:
+        {
+            return "Mb";
+        }
+        case MbA:
+        {
+            return "MbA";
+        }
+        case MbC:
+        {
+            return "MbC";
+        }
+        case Nb:
+        {
+            return "Nb";
+        }
+        case NbA:
+        {
+            return "NbA";
+        }
+        case NbC:
+        {
+            return "NbC";
+        }
+        case Kb:
+        {
+            return "Kb";
+        }
+        case nrhs:
+        {
+            return "nrhs";
+        }
+        case ell_width:
+        {
+            return "ell_width";
+        }
+        case ell_nnz:
+        {
+            return "ell_nnz";
+        }
+        case coo_nnz:
+        {
+            return "coo_nnz";
+        }
+        case nnz:
+        {
+            return "nnz";
+        }
+        case nnzA:
+        {
+            return "nnzA";
+        }
+        case nnzB:
+        {
+            return "nnzB";
+        }
+        case nnzC:
+        {
+            return "nnzC";
+        }
+        case nnzb:
+        {
+            return "nnzb";
+        }
+        case nnzbA:
+        {
+            return "nnzbA";
+        }
+        case nnzbC:
+        {
+            return "nnzbC";
+        }
+        case block_dim:
+        {
+            return "block_dim";
+        }
+        case row_block_dim:
+        {
+            return "row_block_dim";
+        }
+        case row_block_dimA:
+        {
+            return "row_block_dimA";
+        }
+        case row_block_dimC:
+        {
+            return "row_block_dimC";
+        }
+        case col_block_dim:
+        {
+            return "col_block_dim";
+        }
+        case col_block_dimA:
+        {
+            return "col_block_dimA";
+        }
+        case col_block_dimC:
+        {
+            return "col_block_dimC";
+        }
+        case batch_count:
+        {
+            return "batch_count";
+        }
+        case batch_countA:
+        {
+            return "batch_countA";
+        }
+        case batch_countB:
+        {
+            return "batch_countB";
+        }
+        case batch_countC:
+        {
+            return "batch_countC";
+        }
+        case batch_stride:
+        {
+            return "batch_stride";
+        }
+        case alpha:
+        {
+            return "alpha";
+        }
+        case beta:
+        {
+            return "beta";
+        }
+        case percentage:
+        {
+            return "percentage";
+        }
+        case threshold:
+        {
+            return "threshold";
+        }
+        case trans:
+        {
+            return "trans";
+        }
+        case transA:
+        {
+            return "transA";
+        }
+        case transB:
+        {
+            return "transB";
+        }
+        case transC:
+        {
+            return "transC";
+        }
+        case transX:
+        {
+            return "transX";
+        }
+        case direction:
+        {
+            return "dir";
+        }
+        case order:
+        {
+            return "order";
+        }
+        case format:
+        {
+            return "format";
+        }
+        case fill_mode:
+        {
+            return "uplo";
+        }
+        case diag_type:
+        {
+            return "diag";
+        }
+        case solve_policy:
+        {
+            return "solve_policy";
+        }
+        case action:
+        {
+            return "action";
+        }
+        case partition:
+        {
+            return "partition";
+        }
+        case algorithm:
+        {
+            return "algorithm";
+        }
+        case permute:
+        {
+            return "permute";
+        }
+        default:
+        {
+            return nullptr;
+        }
+        }
+    }
+
+    // static const char* to_str(key_t key_)
+    // {
+    //     switch(key_)
+    //     {
+    //     case gflops:
+    //     {
+    //         return s_timing_info_perf;
+    //     }
+
+    //     case order:
+    //     {
+    //         return "order";
+    //     }
+
+    //     case diag_type:
+    //     {
+    //         return "diag_type";
+    //     }
+
+    //     case permute:
+    //     {
+    //         return "permute";
+    //     }
+
+    //     case format:
+    //     {
+    //         return "format";
+    //     }
+
+    //     case action:
+    //     {
+    //         return "action";
+    //     }
+
+    //     case partition:
+    //     {
+    //         return "partition";
+    //     }
+
+    //     case threshold:
+    //     {
+    //         return "threshold";
+    //     }
+
+    //     case percentage:
+    //     {
+    //         return "percentage";
+    //     }
+
+    //     case pivot:
+    //     {
+    //         return "pivot";
+    //     }
+
+    //     case analysis_ms:
+    //     {
+    //         return "analysis";
+    //     }
+
+    //     case fill_mode:
+    //     {
+    //         return "fill_mode";
+    //     }
+
+    //     case analysis_policy:
+    //     {
+    //         return "analysis_policy";
+    //     }
+
+    //     case solve_policy:
+    //     {
+    //         return "solve_policy";
+    //     }
+
+    //     case algorithm:
+    //     {
+    //         return "algorithm";
+    //     }
+
+    //     case size:
+    //     {
+    //         return "size";
+    //     }
+
+    //     case mask_size:
+    //     {
+    //         return "mask_size";
+    //     }
+
+    //     case M:
+    //     {
+    //         return "M";
+    //     }
+
+    //     case Mb:
+    //     {
+    //         return "Mb";
+    //     }
+
+    //     case Mb_A:
+    //     {
+    //         return "Mb_A";
+    //     }
+
+    //     case Mb_C:
+    //     {
+    //         return "Mb_C";
+    //     }
+
+    //     case bdir_A:
+    //     {
+    //         return "bdir_A";
+    //     }
+
+    //     case dir_A:
+    //     {
+    //         return "dir_A";
+    //     }
+
+    //     case bdim_A:
+    //     {
+    //         return "bdim_A";
+    //     }
+    //     case rbdim_A:
+    //     {
+    //         return "rbdim_A";
+    //     }
+    //     case cbdim_A:
+    //     {
+    //         return "cbdim_A";
+    //     }
+    //     case rbdim_C:
+    //     {
+    //         return "rbdim_C";
+    //     }
+    //     case cbdim_C:
+    //     {
+    //         return "cbdim_C";
+    //     }
+
+    //     case N:
+    //     {
+    //         return "N";
+    //     }
+
+    //     case Nb:
+    //     {
+    //         return "Nb";
+    //     }
+    //     case Nb_A:
+    //     {
+    //         return "Nb_A";
+    //     }
+    //     case Nb_C:
+    //     {
+    //         return "Nb_C";
+    //     }
+
+    //     case K:
+    //     {
+    //         return "K";
+    //     }
+
+    //     case Kb:
+    //     {
+    //         return "Kb";
+    //     }
+
+    //     case LD:
+    //     {
+    //         return "LD";
+    //     }
+
+    //     case nrhs:
+    //     {
+    //         return "nrhs";
+    //     }
+
+    //     case ell_width:
+    //     {
+    //         return "ell_width";
+    //     }
+    //     case csr_nnz:
+    //     {
+    //         return "csr_nnz";
+    //     }
+    //     case ell_nnz:
+    //     {
+    //         return "ell_nnz";
+    //     }
+    //     case coo_nnz:
+    //     {
+    //         return "coo_nnz";
+    //     }
+
+    //     case bandwidth:
+    //     {
+    //         return s_timing_info_bandwidth;
+    //     }
+
+    //     case time_ms:
+    //     {
+    //         return s_timing_info_time;
+    //     }
+
+    //     case analysis_time_ms:
+    //     {
+    //         return s_analysis_timing_info_time;
+    //     }
+
+    //     case alpha:
+    //     {
+    //         return "alpha";
+    //     }
+    //     case beta:
+    //     {
+    //         return "beta";
+    //     }
+    //     case trans_A:
+    //     {
+    //         return "transA";
+    //     }
+    //     case trans_B:
+    //     {
+    //         return "transB";
+    //     }
+    //     case trans_X:
+    //     {
+    //         return "transX";
+    //     }
+
+    //     case nnzb_A:
+    //     {
+    //         return "nnzb_A";
+    //     }
+    //     case nnzb_B:
+    //     {
+    //         return "nnzb_B";
+    //     }
+    //     case nnzb_C:
+    //     {
+    //         return "nnzb_C";
+    //     }
+    //     case nnzb_D:
+    //     {
+    //         return "nnzb_D";
+    //     }
+
+    //     case nnz_A:
+    //     {
+    //         return "nnz_A";
+    //     }
+    //     case nnz_B:
+    //     {
+    //         return "nnz_B";
+    //     }
+    //     case nnz_C:
+    //     {
+    //         return "nnz_C";
+    //     }
+    //     case nnz_D:
+    //     {
+    //         return "nnz_D";
+    //     }
+    //     case batch_count_A:
+    //     {
+    //         return "batch_count_A";
+    //     }
+    //     case batch_count_B:
+    //     {
+    //         return "batch_count_B";
+    //     }
+    //     case batch_count_C:
+    //     {
+    //         return "batch_count_C";
+    //     }
+    //     case batch_stride:
+    //     {
+    //         return "batch_stride";
+    //     }
+    //     case iters:
+    //     {
+    //         return "iter";
+    //     }
+    //     case function:
+    //     {
+    //         return "function";
+    //     }
+    //     case ctype:
+    //     {
+    //         return "ctype";
+    //     }
+
+    //     case itype:
+    //     {
+    //         return "itype";
+    //     }
+    //     case jtype:
+    //     {
+    //         return "jtype";
+    //     }
+    //     }
+    // }
+};
+
+template <typename S>
+inline const char* display_to_string(S s)
+{
+    return s;
+};
+template <>
+inline const char* display_to_string(display_key_t::key_t s)
+{
+    return display_key_t::to_str(s);
+};
+
+//
+// Template to display timing information.
+//
+template <typename S, typename T, typename... Ts>
+inline void display_timing_info_legend(std::ostream& out, int n, S name, T t)
+{
+    out << std::setw(n) << display_to_string(name);
+}
+
+template <typename S, typename T, typename... Ts>
+inline void display_timing_info_legend(std::ostream& out, int n, S name, T t, Ts... ts)
+{
+    out << std::setw(n) << display_to_string(name);
+    display_timing_info_legend(out, n, ts...);
+}
+
+template <typename S, typename T, typename... Ts>
+inline void display_timing_info_values(std::ostream& out, int n, S name, T t)
+{
+    out << std::setw(n) << t;
+}
+
+template <typename S, typename T, typename... Ts>
+inline void display_timing_info_values(std::ostream& out, int n, S name, T t, Ts... ts)
+{
+    out << std::setw(n) << t;
+    display_timing_info_values(out, n, ts...);
+}
+
+template <typename S, typename T, typename... Ts>
+inline void display_timing_info_legend_noresults(std::ostream& out, int n, S name_, T t)
+{
+    const char* name = display_to_string(name_);
+    if(strcmp(name, s_timing_info_perf) && strcmp(name, s_timing_info_bandwidth)
+       && strcmp(name, s_timing_info_time))
+    {
+        out << " " << name;
+    }
+}
+
+template <typename S, typename T, typename... Ts>
+inline void display_timing_info_legend_noresults(std::ostream& out, int n, S name_, T t, Ts... ts)
+{
+    const char* name = display_to_string(name_);
+    if(strcmp(name, s_timing_info_perf) && strcmp(name, s_timing_info_bandwidth)
+       && strcmp(name, s_timing_info_time))
+    {
+        out << " " << name;
+    }
+    display_timing_info_legend_noresults(out, n, ts...);
+}
+
+template <typename S, typename T, typename... Ts>
+inline void display_timing_info_values_noresults(std::ostream& out, int n, S name_, T t)
+{
+    const char* name = display_to_string(name_);
+
+    if(strcmp(name, s_timing_info_perf) && strcmp(name, s_timing_info_bandwidth)
+       && strcmp(name, s_timing_info_time))
+    {
+        out << " " << t;
+    }
+}
+
+template <typename S, typename T, typename... Ts>
+inline void display_timing_info_values_noresults(std::ostream& out, int n, S name_, T t, Ts... ts)
+{
+    const char* name = display_to_string(name_);
+    if(strcmp(name, s_timing_info_perf) && strcmp(name, s_timing_info_bandwidth)
+       && strcmp(name, s_timing_info_time))
+    {
+        out << " " << t;
+    }
+    display_timing_info_values_noresults(out, n, ts...);
+}
+
+template <typename T>
+inline void grab_results(double values[3], display_key_t::key_t key, T t)
+{
+}
+
+template <>
+inline void grab_results<double>(double values[3], display_key_t::key_t key, double t)
+{
+    const char* name = display_to_string(key);
+    if(!strcmp(name, s_timing_info_perf))
+    {
+        values[1] = t;
+    }
+    else if(!strcmp(name, s_timing_info_bandwidth))
+    {
+        values[2] = t;
+    }
+    else if(!strcmp(name, s_timing_info_time))
+    {
+        values[0] = t;
+    }
+}
+
+template <typename T>
+inline void grab_results(double values[3], const char* name, T t)
+{
+}
+
+template <>
+inline void grab_results<double>(double values[3], const char* name, double t)
+{
+    if(!strcmp(name, s_timing_info_perf))
+    {
+        values[1] = t;
+    }
+    else if(!strcmp(name, s_timing_info_bandwidth))
+    {
+        values[2] = t;
+    }
+    else if(!strcmp(name, s_timing_info_time))
+    {
+        values[0] = t;
+    }
+}
+
+template <typename S, typename T, typename... Ts>
+inline void display_timing_info_grab_results(double values[3], S name, T t)
+{
+    grab_results(values, name, t);
+}
+
+template <typename S, typename T, typename... Ts>
+inline void display_timing_info_grab_results(double values[3], S name, T t, Ts... ts)
+{
+    grab_results(values, name, t);
+    display_timing_info_grab_results(values, ts...);
+}
+
+//bool display_timing_info_is_stdout_disabled();
+
+template <typename S, typename T, typename... Ts>
+inline void display_timing_info_generate(std::ostream& out, int n, S name, T t, Ts... ts)
+{
+    double values[3]{};
+    display_timing_info_grab_results(values, name, t, ts...);
+    //rocsparse_record_timing(values[0], values[1], values[2]);
+    display_timing_info_values(out, n, name, t, ts...);
+}
+
+template <typename S, typename T, typename... Ts>
+inline void display_timing_info_generate_params(std::ostream& out, int n, S name, T t, Ts... ts)
+{
+    double values[3]{};
+    display_timing_info_grab_results(values, name, t, ts...);
+    //rocsparse_record_timing(values[0], values[1], values[2]);
+    display_timing_info_values_noresults(out, n, name, t, ts...);
+}
+
+template <typename S, typename T, typename... Ts>
+inline void display_timing_info_max_size_strings(int mx[1], S name_, T t)
+{
+    const char* name = display_to_string(name_);
+    int         len  = strlen(name);
+    mx[0]            = std::max(len, mx[0]);
+}
+
+template <typename S, typename T, typename... Ts>
+inline void display_timing_info_max_size_strings(int mx[1], S name_, T t, Ts... ts)
+{
+    const char* name = display_to_string(name_);
+    int         len  = strlen(name);
+    mx[0]            = std::max(len, mx[0]);
+    display_timing_info_max_size_strings(mx, ts...);
+}
+
+template <typename S, typename... Ts>
+inline void display_timing_info_main(S name, Ts... ts)
+{
+    //
+    // To configure the size of std::setw.
+    //
+    int n = 0;
+    display_timing_info_max_size_strings(&n, name, ts...);
+
+    //
+    //
+    //
+    n += 4;
+
+    //
+    // Legend
+    //
+    {
+        std::ostringstream out_legend;
+        out_legend.precision(2);
+        out_legend.setf(std::ios::fixed);
+        out_legend.setf(std::ios::left);
+        //if(!display_timing_info_is_stdout_disabled())
+        //{
+            display_timing_info_legend(out_legend, n, name, ts...);
+            std::cout << out_legend.str() << std::endl;
+        //}
+        //else
+        //{
+        //    // store the string.
+        //    display_timing_info_legend_noresults(out_legend, n, name, ts...);
+        //    rocsparse_record_output_legend(out_legend.str());
+        //}
+    }
+
+    std::ostringstream out;
+    out.precision(2);
+    out.setf(std::ios::fixed);
+    out.setf(std::ios::left);
+    //if(!display_timing_info_is_stdout_disabled())
+    //{
+        display_timing_info_generate(out, n, name, ts...);
+        std::cout << out.str() << std::endl;
+    //}
+    //else
+    //{
+    //    display_timing_info_generate_params(out, n, name, ts...);
+    //    // store the string.
+    //    rocsparse_record_output(out.str());
+    //}
+}
+
+inline void hipsparse_get_matrixname(const char* f, char* name)
+{
+    int n = 0;
+    while(f[n] != '\0')
+        ++n;
+    int cdir = 0;
+    for(int i = 0; i < n; ++i)
+    {
+        if(f[i] == '/' || f[i] == '\\')
+        {
+            cdir = i + 1;
+        }
+    }
+    int ddir = cdir;
+    for(int i = cdir; i < n; ++i)
+    {
+        if(f[i] == '.')
+        {
+            ddir = i;
+        }
+    }
+
+    if(ddir == cdir)
+    {
+        ddir = n;
+    }
+
+    for(int i = cdir; i < ddir; ++i)
+    {
+        name[i - cdir] = f[i];
+    }
+    name[ddir - cdir] = '\0';
+}
+
+#define display_timing_info(...)                                                             \
+    do                                                                                       \
+    {                                                                                        \
+        const char* ctypename = hipsparse_datatype2string(argus.compute_type);                 \
+        const char* itypename = hipsparse_indextype2string(argus.index_type_I);                \
+        const char* jtypename = hipsparse_indextype2string(argus.index_type_J);                \
+                                                                                             \
+        display_timing_info_main(__VA_ARGS__,                                                \
+                                 display_key_t::iters,                                       \
+                                 argus.iters,                                                \
+                                 "verified",                                                 \
+                                 (argus.unit_check ? "yes" : "no"),                          \
+                                 display_key_t::function,                                    \
+                                 &argus.function_name[0],                                    \
+                                 display_key_t::ctype,                                       \
+                                 ctypename,                                                  \
+                                 display_key_t::itype,                                       \
+                                 itypename,                                                  \
+                                 display_key_t::jtype,                                       \
+                                 jtypename);                                                 \
+    } while(false)
+
+#endif // DISPLAY_HPP

--- a/clients/include/hipsparse_datatype2string.hpp
+++ b/clients/include/hipsparse_datatype2string.hpp
@@ -253,3 +253,273 @@ constexpr auto hipsparse_fillmode2string(hipsparseFillMode_t fill_mode)
     }
     return "invalid";
 }
+
+constexpr auto hipsparse_solvepolicy2string(hipsparseSolvePolicy_t policy)
+{
+    switch(policy)
+    {
+    case HIPSPARSE_SOLVE_POLICY_NO_LEVEL:
+        return "no_level";
+    case HIPSPARSE_SOLVE_POLICY_USE_LEVEL:
+        return "use_level";
+    }
+    return "invalid";
+}
+
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11022)
+constexpr auto hipsparse_sddmmalg2string(hipsparseSDDMMAlg_t alg)
+{
+    switch(alg)
+    {
+    case HIPSPARSE_SDDMM_ALG_DEFAULT:
+        return "default";
+    }
+    return "invalid";
+}
+#endif
+
+#if(!defined(CUDART_VERSION))
+constexpr auto hipsparse_spmmalg2string(hipsparseSpMMAlg_t alg)
+{
+    switch(alg)
+    {
+    case HIPSPARSE_SPMM_ALG_DEFAULT:
+        return "default";
+    case HIPSPARSE_SPMM_COO_ALG1:
+        return "coo_alg1";
+    case HIPSPARSE_SPMM_COO_ALG2:
+        return "coo_alg2";
+    case HIPSPARSE_SPMM_COO_ALG3:
+        return "coo_alg3";
+    case HIPSPARSE_SPMM_COO_ALG4:
+        return "coo_alg4";
+    case HIPSPARSE_SPMM_CSR_ALG1:
+        return "csr_alg1";
+    case HIPSPARSE_SPMM_CSR_ALG2:
+        return "csr_alg2";
+    case HIPSPARSE_SPMM_CSR_ALG3:
+        return "csr_alg3";
+    case HIPSPARSE_SPMM_BLOCKED_ELL_ALG1:
+        return "bell_alg1";
+    }
+    return "invalid";
+}
+#else
+#if(CUDART_VERSION >= 12000)
+constexpr auto hipsparse_spmmalg2string(hipsparseSpMMAlg_t alg)
+{
+    switch(alg)
+    {
+    case HIPSPARSE_SPMM_ALG_DEFAULT:
+        return "default";
+    case HIPSPARSE_SPMM_COO_ALG1:
+        return "coo_alg1";
+    case HIPSPARSE_SPMM_COO_ALG2:
+        return "coo_alg2";
+    case HIPSPARSE_SPMM_COO_ALG3:
+        return "coo_alg3";
+    case HIPSPARSE_SPMM_COO_ALG4:
+        return "coo_alg4";
+    case HIPSPARSE_SPMM_CSR_ALG1:
+        return "csr_alg1";
+    case HIPSPARSE_SPMM_CSR_ALG2:
+        return "csr_alg2";
+    case HIPSPARSE_SPMM_CSR_ALG3:
+        return "csr_alg3";
+    case HIPSPARSE_SPMM_BLOCKED_ELL_ALG1:
+        return "bell_alg1";
+    }
+    return "invalid";
+}
+#elif(CUDART_VERSION >= 11021 && CUDART_VERSION < 12000)
+constexpr auto hipsparse_spmmalg2string(hipsparseSpMMAlg_t alg)
+{
+    switch(alg)
+    {
+    case HIPSPARSE_SPMM_ALG_DEFAULT:
+        return "default";
+    case HIPSPARSE_SPMM_COO_ALG1:
+        return "coo_alg1";
+    case HIPSPARSE_SPMM_COO_ALG2:
+        return "coo_alg2";
+    case HIPSPARSE_SPMM_COO_ALG3:
+        return "coo_alg3";
+    case HIPSPARSE_SPMM_COO_ALG4:
+        return "coo_alg4";
+    case HIPSPARSE_SPMM_CSR_ALG1:
+        return "csr_alg1";
+    case HIPSPARSE_SPMM_CSR_ALG2:
+        return "csr_alg2";
+    case HIPSPARSE_SPMM_CSR_ALG3:
+        return "csr_alg3";
+    case HIPSPARSE_SPMM_BLOCKED_ELL_ALG1:
+        return "bell_alg1";
+    }
+    return "invalid";
+}
+#elif(CUDART_VERSION >= 11003 && CUDART_VERSION < 11021)
+constexpr auto hipsparse_spmmalg2string(hipsparseSpMMAlg_t alg)
+{
+    switch(alg)
+    {
+    case HIPSPARSE_SPMM_ALG_DEFAULT:
+        return "default";
+    case HIPSPARSE_SPMM_COO_ALG1:
+        return "coo_alg1";
+    case HIPSPARSE_SPMM_COO_ALG2:
+        return "coo_alg2";
+    case HIPSPARSE_SPMM_COO_ALG3:
+        return "coo_alg3";
+    case HIPSPARSE_SPMM_COO_ALG4:
+        return "coo_alg4";
+    case HIPSPARSE_SPMM_CSR_ALG1:
+        return "csr_alg1";
+    case HIPSPARSE_SPMM_CSR_ALG2:
+        return "csr_alg2";
+    case HIPSPARSE_SPMM_BLOCKED_ELL_ALG1:
+        return "bell_alg1";
+    }
+    return "invalid";
+}
+#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 11003)
+constexpr auto hipsparse_spmmalg2string(hipsparseSpMMAlg_t alg)
+{
+    switch(alg)
+    {
+    case HIPSPARSE_MM_ALG_DEFAULT:
+        return "default";
+    case HIPSPARSE_COOMM_ALG1:
+        return "coo_alg1";
+    case HIPSPARSE_COOMM_ALG2:
+        return "coo_alg2";
+    case HIPSPARSE_COOMM_ALG3:
+        return "coo_alg3";
+    case HIPSPARSE_CSRMM_ALG1:
+        return "csr_alg1";
+    }
+    return "invalid";
+}
+#endif
+#endif
+
+#if(!defined(CUDART_VERSION))
+constexpr auto hipsparse_spmvalg2string(hipsparseSpMVAlg_t alg)
+{
+    switch(alg)
+    {
+    case HIPSPARSE_SPMV_ALG_DEFAULT:
+        return "default";
+    case HIPSPARSE_SPMV_COO_ALG1:
+        return "coo_alg1";
+    case HIPSPARSE_SPMV_COO_ALG2:
+        return "coo_alg2";
+    case HIPSPARSE_SPMV_CSR_ALG1:
+        return "csr_alg1";
+    case HIPSPARSE_SPMV_CSR_ALG2:
+        return "csr_alg2";
+    }
+    return "invalid";
+}
+#else
+#if(CUDART_VERSION >= 12000)
+constexpr auto hipsparse_spmvalg2string(hipsparseSpMVAlg_t alg)
+{
+    switch(alg)
+    {
+    case HIPSPARSE_SPMV_ALG_DEFAULT:
+        return "default";
+    case HIPSPARSE_SPMV_COO_ALG1:
+        return "coo_alg1";
+    case HIPSPARSE_SPMV_COO_ALG2:
+        return "coo_alg2";
+    case HIPSPARSE_SPMV_CSR_ALG1:
+        return "csr_alg1";
+    case HIPSPARSE_SPMV_CSR_ALG2:
+        return "csr_alg2";
+    }
+    return "invalid";
+}
+#elif(CUDART_VERSION >= 11021 && CUDART_VERSION < 12000)
+constexpr auto hipsparse_spmvalg2string(hipsparseSpMVAlg_t alg)
+{
+    switch(alg)
+    {
+    case HIPSPARSE_SPMV_ALG_DEFAULT:
+        return "default";
+    case HIPSPARSE_SPMV_COO_ALG1:
+        return "coo_alg1";
+    case HIPSPARSE_SPMV_COO_ALG2:
+        return "coo_alg2";
+    case HIPSPARSE_SPMV_CSR_ALG1:
+        return "csr_alg1";
+    case HIPSPARSE_SPMV_CSR_ALG2:
+        return "csr_alg2";
+    }
+    return "invalid";
+}
+#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 11021)
+constexpr auto hipsparse_spmvalg2string(hipsparseSpMVAlg_t alg)
+{
+    switch(alg)
+    {
+    case HIPSPARSE_MV_ALG_DEFAULT:
+        return "default";
+    case HIPSPARSE_COOMV_ALG:
+        return "coo_alg1";
+    case HIPSPARSE_CSRMV_ALG1:
+        return "csr_alg1";
+    case HIPSPARSE_CSRMV_ALG2:
+        return "csr_alg2";
+    }
+    return "invalid";
+}
+#endif
+#endif
+
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
+constexpr auto hipsparse_spsmalg2string(hipsparseSpSMAlg_t alg)
+{
+    switch(alg)
+    {
+    case HIPSPARSE_SPSM_ALG_DEFAULT:
+        return "default";
+    }
+    return "invalid";
+}
+#endif
+
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11030)
+constexpr auto hipsparse_spsvalg2string(hipsparseSpSVAlg_t alg)
+{
+    switch(alg)
+    {
+    case HIPSPARSE_SPSV_ALG_DEFAULT:
+        return "default";
+    }
+    return "invalid";
+}
+#endif
+
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
+constexpr auto hipsparse_sparsetodensealg2string(hipsparseSparseToDenseAlg_t alg)
+{
+    switch(alg)
+    {
+    case HIPSPARSE_SPARSETODENSE_ALG_DEFAULT:
+        return "default";
+    }
+    return "invalid";
+}
+#endif
+
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
+constexpr auto hipsparse_densetosparsealg2string(hipsparseDenseToSparseAlg_t alg)
+{
+    switch(alg)
+    {
+    case HIPSPARSE_DENSETOSPARSE_ALG_DEFAULT:
+        return "default";
+    }
+    return "invalid";
+}
+#endif

--- a/clients/include/testing_axpby.hpp
+++ b/clients/include/testing_axpby.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_AXPBY_HPP
 #define TESTING_AXPBY_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse_arguments.hpp"
@@ -194,8 +195,20 @@ hipsparseStatus_t testing_axpby(Arguments argus)
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::size,
+                            size,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::alpha,
+                            alpha,
+                            display_key_t::beta,
+                            beta,
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIPSPARSE_ERROR(hipsparseDestroySpVec(x));

--- a/clients/include/testing_axpyi.hpp
+++ b/clients/include/testing_axpyi.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_AXPYI_HPP
 #define TESTING_AXPYI_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -182,8 +183,18 @@ hipsparseStatus_t testing_axpyi(Arguments argus)
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::size,
+                            N,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
 #endif

--- a/clients/include/testing_bsr2csr.hpp
+++ b/clients/include/testing_bsr2csr.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_BSR2CSR_HPP
 #define TESTING_BSR2CSR_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -468,8 +469,22 @@ hipsparseStatus_t testing_bsr2csr(Arguments argus)
         double gbyte_count = bsr2csr_gbyte_count<T>(mb, block_dim, nnzb);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::Mb,
+                            mb,
+                            display_key_t::Nb,
+                            nb,
+                            display_key_t::block_dim,
+                            block_dim,
+                            display_key_t::nnzb,
+                            nnzb,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     return HIPSPARSE_STATUS_SUCCESS;

--- a/clients/include/testing_bsric02.hpp
+++ b/clients/include/testing_bsric02.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_BSRIC02_HPP
 #define TESTING_BSRIC02_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -714,8 +715,20 @@ hipsparseStatus_t testing_bsric02(Arguments argus)
         double gbyte_count = bsric0_gbyte_count<T>(mb, block_dim, nnzb);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::Mb,
+                            mb,
+                            display_key_t::nnzb,
+                            nnzb,
+                            display_key_t::block_dim,
+                            block_dim,
+                            display_key_t::direction,
+                            hipsparse_direction2string(dir),
+                            display_key_t::solve_policy,
+                            hipsparse_solvepolicy2string(policy),
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_bsrilu02.hpp
+++ b/clients/include/testing_bsrilu02.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_BSRILU02_HPP
 #define TESTING_BSRILU02_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -737,8 +738,20 @@ hipsparseStatus_t testing_bsrilu02(Arguments argus)
         double gbyte_count = bsrilu0_gbyte_count<T>(mb, block_dim, nnzb);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::Mb,
+                            mb,
+                            display_key_t::nnzb,
+                            nnzb,
+                            display_key_t::block_dim,
+                            block_dim,
+                            display_key_t::direction,
+                            hipsparse_direction2string(dir),
+                            display_key_t::solve_policy,
+                            hipsparse_solvepolicy2string(policy),
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_bsrmm.hpp
+++ b/clients/include/testing_bsrmm.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_BSRMM_HPP
 #define TESTING_BSRMM_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -712,8 +713,36 @@ hipsparseStatus_t testing_bsrmm(Arguments argus)
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::K,
+                            k,
+                            display_key_t::direction,
+                            dirA,
+                            display_key_t::transA,
+                            transA,
+                            display_key_t::transB,
+                            transB,
+                            display_key_t::nnzb,
+                            nnzb,
+                            display_key_t::block_dim,
+                            block_dim,
+                            display_key_t::nnzB,
+                            nnz_B,
+                            display_key_t::nnzC,
+                            nnz_C,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     return HIPSPARSE_STATUS_SUCCESS;

--- a/clients/include/testing_bsrmv.hpp
+++ b/clients/include/testing_bsrmv.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_BSRMV_HPP
 #define TESTING_BSRMV_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -552,8 +553,24 @@ hipsparseStatus_t testing_bsrmv(Arguments argus)
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFlops/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::block_dim,
+                            block_dim,
+                            display_key_t::direction,
+                            hipsparse_direction2string(dir),
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     return HIPSPARSE_STATUS_SUCCESS;

--- a/clients/include/testing_bsrsm2.hpp
+++ b/clients/include/testing_bsrsm2.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_BSRSM2_HPP
 #define TESTING_BSRSM2_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -883,8 +884,32 @@ hipsparseStatus_t testing_bsrsm2(Arguments argus)
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::nnz,
+                            nnzb * block_dim * block_dim,
+                            display_key_t::nrhs,
+                            nrhs,
+                            display_key_t::block_dim,
+                            block_dim,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::transA,
+                            hipsparse_operation2string(transA),
+                            display_key_t::transX,
+                            hipsparse_operation2string(transX),
+                            display_key_t::diag_type,
+                            hipsparse_diagtype2string(HIPSPARSE_DIAG_TYPE_NON_UNIT),
+                            display_key_t::fill_mode,
+                            hipsparse_fillmode2string(HIPSPARSE_FILL_MODE_LOWER),
+                            display_key_t::solve_policy,
+                            hipsparse_solvepolicy2string(HIPSPARSE_SOLVE_POLICY_USE_LEVEL),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_bsrsv2.hpp
+++ b/clients/include/testing_bsrsv2.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_BSRSV2_HPP
 #define TESTING_BSRSV2_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -763,8 +764,26 @@ hipsparseStatus_t testing_bsrsv2(Arguments argus)
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFlops/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::nnz,
+                            nnzb * block_dim * block_dim,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::trans,
+                            hipsparse_operation2string(trans),
+                            display_key_t::diag_type,
+                            hipsparse_diagtype2string(diag_type),
+                            display_key_t::fill_mode,
+                            hipsparse_fillmode2string(fill_mode),
+                            display_key_t::solve_policy,
+                            hipsparse_solvepolicy2string(policy),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_coo2csr.hpp
+++ b/clients/include/testing_coo2csr.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_COO2CSR_HPP
 #define TESTING_COO2CSR_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -170,8 +171,16 @@ hipsparseStatus_t testing_coo2csr(Arguments argus)
         double gbyte_count = coo2csr_gbyte_count<T>(m, nnz);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     return HIPSPARSE_STATUS_SUCCESS;

--- a/clients/include/testing_coosort.hpp
+++ b/clients/include/testing_coosort.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_COOSORT_HPP
 #define TESTING_COOSORT_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -328,8 +329,20 @@ hipsparseStatus_t testing_coosort(Arguments argus)
         double gbyte_count = coosort_gbyte_count(nnz, permute);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::permute,
+                            (permute ? "yes" : "no"),
+                            display_key_t::direction,
+                            (by_row ? "row" : "column"),
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_cscsort.hpp
+++ b/clients/include/testing_cscsort.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_CSCSORT_HPP
 #define TESTING_CSCSORT_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -284,8 +285,18 @@ hipsparseStatus_t testing_cscsort(Arguments argus)
         double gbyte_count = cscsort_gbyte_count(n, nnz, permute);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::permute,
+                            (permute ? "yes" : "no"),
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_csr2bsr.hpp
+++ b/clients/include/testing_csr2bsr.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_CSR2BSR_HPP
 #define TESTING_CSR2BSR_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -413,6 +414,7 @@ hipsparseStatus_t testing_csr2bsr(Arguments argus)
     }
 
     int mb = (m + block_dim - 1) / block_dim;
+    int nb = (n + block_dim - 1) / block_dim;
 
     // Allocate memory on the device
     auto dcsr_row_ptr_managed
@@ -591,8 +593,22 @@ hipsparseStatus_t testing_csr2bsr(Arguments argus)
         double gbyte_count = csr2bsr_gbyte_count<T>(m, mb, nnz, hbsr_nnzb, block_dim);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::Mb,
+                            mb,
+                            display_key_t::Nb,
+                            nb,
+                            display_key_t::block_dim,
+                            block_dim,
+                            display_key_t::nnzb,
+                            hbsr_nnzb,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     return HIPSPARSE_STATUS_SUCCESS;

--- a/clients/include/testing_csr2coo.hpp
+++ b/clients/include/testing_csr2coo.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_CSR2COO_HPP
 #define TESTING_CSR2COO_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -161,8 +162,16 @@ hipsparseStatus_t testing_csr2coo(Arguments argus)
         double gbyte_count = csr2coo_gbyte_count<T>(m, nnz);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     return HIPSPARSE_STATUS_SUCCESS;

--- a/clients/include/testing_csr2csc.hpp
+++ b/clients/include/testing_csr2csc.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_CSR2CSC_HPP
 #define TESTING_CSR2CSC_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -344,8 +345,18 @@ hipsparseStatus_t testing_csr2csc(Arguments argus)
         double gbyte_count = csr2csc_gbyte_count<T>(m, n, nnz, action);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::action,
+                            hipsparse_action2string(action),
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_csr2csc_ex2.hpp
+++ b/clients/include/testing_csr2csc_ex2.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_CSR2CSC_EX2_HPP
 #define TESTING_CSR2CSC_EX2_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -488,8 +489,18 @@ hipsparseStatus_t testing_csr2csc_ex2(Arguments argus)
         double gbyte_count = csr2csc_gbyte_count<T>(m, n, nnz, action);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::action,
+                            hipsparse_action2string(action),
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_csr2csr_compress.hpp
+++ b/clients/include/testing_csr2csr_compress.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_CSR2CSR_COMPRESS_HPP
 #define TESTING_CSR2CSR_COMPRESS_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -513,8 +514,18 @@ hipsparseStatus_t testing_csr2csr_compress(Arguments argus)
         double gbyte_count = csr2csr_compress_gbyte_count<T>(m, hnnz_A, hnnz_C);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnzA,
+                            hnnz_A,
+                            display_key_t::nnzC,
+                            hnnz_C,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     return HIPSPARSE_STATUS_SUCCESS;

--- a/clients/include/testing_csr2gebsr.hpp
+++ b/clients/include/testing_csr2gebsr.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_CSR2GEBSR_HPP
 #define TESTING_CSR2GEBSR_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -467,6 +468,7 @@ hipsparseStatus_t testing_csr2gebsr(Arguments argus)
     }
 
     int mb = (m + row_block_dim - 1) / row_block_dim;
+    int nb = (n + col_block_dim - 1) / col_block_dim;
 
     // Allocate memory on the device
     auto dcsr_row_ptr_managed
@@ -645,8 +647,24 @@ hipsparseStatus_t testing_csr2gebsr(Arguments argus)
             = csr2gebsr_gbyte_count<T>(m, mb, nnz, hbsr_nnzb, row_block_dim, col_block_dim);
         double gpu_gbyte = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::Mb,
+                            mb,
+                            display_key_t::Nb,
+                            nb,
+                            display_key_t::row_block_dim,
+                            row_block_dim,
+                            display_key_t::col_block_dim,
+                            col_block_dim,
+                            display_key_t::nnzb,
+                            hbsr_nnzb,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     return HIPSPARSE_STATUS_SUCCESS;

--- a/clients/include/testing_csr2hyb.hpp
+++ b/clients/include/testing_csr2hyb.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_CSR2HYB_HPP
 #define TESTING_CSR2HYB_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -413,8 +414,18 @@ hipsparseStatus_t testing_csr2hyb(Arguments argus)
         double gbyte_count = csr2hyb_gbyte_count<T>(m, nnz, ell_nnz, coo_nnz);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::ell_nnz,
+                            ell_nnz,
+                            display_key_t::coo_nnz,
+                            coo_nnz,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_csrgeam.hpp
+++ b/clients/include/testing_csrgeam.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_CSRGEAM_HPP
 #define TESTING_CSRGEAM_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -1027,8 +1028,26 @@ hipsparseStatus_t testing_csrgeam(Arguments argus)
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " GFlops/s: " << gpu_gflops
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            M,
+                            display_key_t::N,
+                            N,
+                            display_key_t::nnzA,
+                            nnz_A,
+                            display_key_t::nnzB,
+                            nnz_B,
+                            display_key_t::nnzC,
+                            hnnz_C_1,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_csrgeam2.hpp
+++ b/clients/include/testing_csrgeam2.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_CSRGEAM2_HPP
 #define TESTING_CSRGEAM2_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -1098,8 +1099,26 @@ hipsparseStatus_t testing_csrgeam2(Arguments argus)
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " GFlops/s: " << gpu_gflops
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            M,
+                            display_key_t::N,
+                            N,
+                            display_key_t::nnzA,
+                            nnz_A,
+                            display_key_t::nnzB,
+                            nnz_B,
+                            display_key_t::nnzC,
+                            hnnz_C_1,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     return HIPSPARSE_STATUS_SUCCESS;

--- a/clients/include/testing_csrgemm.hpp
+++ b/clients/include/testing_csrgemm.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_CSRGEMM_HPP
 #define TESTING_CSRGEMM_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -998,8 +999,28 @@ hipsparseStatus_t testing_csrgemm(Arguments argus)
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " GFlops/s: " << gpu_gflops
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::transA,
+                            hipsparse_operation2string(trans_A),
+                            display_key_t::transB,
+                            hipsparse_operation2string(trans_B),
+                            display_key_t::M,
+                            M,
+                            display_key_t::N,
+                            N,
+                            display_key_t::K,
+                            K,
+                            display_key_t::nnzA,
+                            nnz_A,
+                            display_key_t::nnzB,
+                            nnz_B,
+                            display_key_t::nnzC,
+                            hnnz_C_1,
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_csric02.hpp
+++ b/clients/include/testing_csric02.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_CSRIC0_HPP
 #define TESTING_CSRIC0_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -370,8 +371,16 @@ hipsparseStatus_t testing_csric02(Arguments argus)
         double gbyte_count = csric0_gbyte_count<T>(m, nnz);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                                m,
+                                display_key_t::nnz,
+                                nnz,
+                                display_key_t::solve_policy,
+                                hipsparse_solvepolicy2string(policy),
+                                display_key_t::bandwidth,
+                                gpu_gbyte,
+                                display_key_t::time_ms,
+                                get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_csric02.hpp
+++ b/clients/include/testing_csric02.hpp
@@ -372,15 +372,15 @@ hipsparseStatus_t testing_csric02(Arguments argus)
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
         display_timing_info(display_key_t::M,
-                                m,
-                                display_key_t::nnz,
-                                nnz,
-                                display_key_t::solve_policy,
-                                hipsparse_solvepolicy2string(policy),
-                                display_key_t::bandwidth,
-                                gpu_gbyte,
-                                display_key_t::time_ms,
-                                get_gpu_time_msec(gpu_time_used));
+                            m,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::solve_policy,
+                            hipsparse_solvepolicy2string(policy),
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_csrilu02.hpp
+++ b/clients/include/testing_csrilu02.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_CSRILU0_HPP
 #define TESTING_CSRILU0_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -369,8 +370,16 @@ hipsparseStatus_t testing_csrilu02(Arguments argus)
         double gbyte_count = csrilu0_gbyte_count<T>(m, nnz);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::solve_policy,
+                            hipsparse_solvepolicy2string(policy),
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_csrmm.hpp
+++ b/clients/include/testing_csrmm.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_CSRMM_HPP
 #define TESTING_CSRMM_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -529,8 +530,32 @@ hipsparseStatus_t testing_csrmm(Arguments argus)
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            M,
+                            display_key_t::N,
+                            N,
+                            display_key_t::K,
+                            K,
+                            display_key_t::transA,
+                            hipsparse_operation2string(transA),
+                            display_key_t::transB,
+                            hipsparse_operation2string(transB),
+                            display_key_t::nnzA,
+                            nnz,
+                            display_key_t::nnzB,
+                            B_m * B_n,
+                            display_key_t::nnzC,
+                            C_m * C_n,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_csrmv.hpp
+++ b/clients/include/testing_csrmv.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_CSRMV_HPP
 #define TESTING_CSRMV_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -297,8 +298,22 @@ hipsparseStatus_t testing_csrmv(Arguments argus)
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            nrow,
+                            display_key_t::N,
+                            ncol,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_csrsm2.hpp
+++ b/clients/include/testing_csrsm2.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_CSRSM2_HPP
 #define TESTING_CSRSM2_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -919,8 +920,30 @@ hipsparseStatus_t testing_csrsm2(Arguments argus)
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::nrhs,
+                            nrhs,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::transA,
+                            hipsparse_operation2string(transA),
+                            display_key_t::transB,
+                            hipsparse_operation2string(transB),
+                            display_key_t::diag_type,
+                            hipsparse_diagtype2string(diag),
+                            display_key_t::fill_mode,
+                            hipsparse_fillmode2string(uplo),
+                            display_key_t::solve_policy,
+                            hipsparse_solvepolicy2string(policy),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_csrsort.hpp
+++ b/clients/include/testing_csrsort.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_CSRSORT_HPP
 #define TESTING_CSRSORT_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -272,8 +273,18 @@ hipsparseStatus_t testing_csrsort(Arguments argus)
         double gbyte_count = csrsort_gbyte_count(m, nnz, permute);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::permute,
+                            (permute ? "yes" : "no"),
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_csrsv2.hpp
+++ b/clients/include/testing_csrsv2.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_CSRSV2_HPP
 #define TESTING_CSRSV2_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -584,8 +585,26 @@ hipsparseStatus_t testing_csrsv2(Arguments argus)
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFlops/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::trans,
+                            hipsparse_operation2string(trans),
+                            display_key_t::diag_type,
+                            hipsparse_diagtype2string(diag_type),
+                            display_key_t::fill_mode,
+                            hipsparse_fillmode2string(fill_mode),
+                            display_key_t::solve_policy,
+                            hipsparse_solvepolicy2string(policy),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
 #endif

--- a/clients/include/testing_csx2dense.hpp
+++ b/clients/include/testing_csx2dense.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_CSX2DENSE_HPP
 #define TESTING_CSX2DENSE_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -280,8 +281,18 @@ hipsparseStatus_t testing_csx2dense(const Arguments& argus, FUNC1& csx2dense, FU
         double gbyte_count = csx2dense_gbyte_count<DIRA, T>(M, N, nnz);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            M,
+                            display_key_t::N,
+                            N,
+                            display_key_t::LD,
+                            LD,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_dense_to_sparse_coo.hpp
+++ b/clients/include/testing_dense_to_sparse_coo.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_DENSE_TO_SPARSE_COO_HPP
 #define TESTING_DENSE_TO_SPARSE_COO_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse_arguments.hpp"
@@ -305,8 +306,20 @@ hipsparseStatus_t testing_dense_to_sparse_coo(Arguments argus)
         double gbyte_count = dense2coo_gbyte_count<T>(m, n, (I)nnz);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::order,
+                            order,
+                            display_key_t::algorithm,
+                            hipsparse_densetosparsealg2string(alg),
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_dense_to_sparse_csc.hpp
+++ b/clients/include/testing_dense_to_sparse_csc.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_DENSE_TO_SPARSE_CSC_HPP
 #define TESTING_DENSE_TO_SPARSE_CSC_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse_arguments.hpp"
@@ -346,8 +347,20 @@ hipsparseStatus_t testing_dense_to_sparse_csc(Arguments argus)
         double gbyte_count = dense2csx_gbyte_count<HIPSPARSE_DIRECTION_COLUMN, T>(m, n, nnz);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::order,
+                            order,
+                            display_key_t::algorithm,
+                            hipsparse_densetosparsealg2string(alg),
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_dense_to_sparse_csr.hpp
+++ b/clients/include/testing_dense_to_sparse_csr.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_DENSE_TO_SPARSE_CSR_HPP
 #define TESTING_DENSE_TO_SPARSE_CSR_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse_arguments.hpp"
@@ -346,8 +347,20 @@ hipsparseStatus_t testing_dense_to_sparse_csr(Arguments argus)
         double gbyte_count = dense2csx_gbyte_count<HIPSPARSE_DIRECTION_ROW, T>(m, n, nnz);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::order,
+                            order,
+                            display_key_t::algorithm,
+                            hipsparse_densetosparsealg2string(alg),
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_dotci.hpp
+++ b/clients/include/testing_dotci.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_DOTCI_HPP
 #define TESTING_DOTCI_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -183,8 +184,14 @@ hipsparseStatus_t testing_dotci(Arguments argus)
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::nnz,
+                            nnz,
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_doti.hpp
+++ b/clients/include/testing_doti.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_DOTI_HPP
 #define TESTING_DOTI_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -181,8 +182,14 @@ hipsparseStatus_t testing_doti(Arguments argus)
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::nnz,
+                            nnz,
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_gather.hpp
+++ b/clients/include/testing_gather.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_GATHER_HPP
 #define TESTING_GATHER_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse_arguments.hpp"
@@ -169,8 +170,12 @@ hipsparseStatus_t testing_gather(Arguments argus)
         double gbyte_count = gthr_gbyte_count<T>(nnz);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::nnz,
+                            nnz,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIPSPARSE_ERROR(hipsparseDestroySpVec(x));

--- a/clients/include/testing_gebsr2csr.hpp
+++ b/clients/include/testing_gebsr2csr.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_GEBSR2CSR_HPP
 #define TESTING_GEBSR2CSR_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -515,8 +516,24 @@ hipsparseStatus_t testing_gebsr2csr(Arguments argus)
         double gbyte_count = gebsr2csr_gbyte_count<T>(mb, row_block_dim, col_block_dim, nnzb);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::Mb,
+                            mb,
+                            display_key_t::Nb,
+                            nb,
+                            display_key_t::row_block_dim,
+                            row_block_dim,
+                            display_key_t::col_block_dim,
+                            col_block_dim,
+                            display_key_t::nnzb,
+                            nnzb,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     return HIPSPARSE_STATUS_SUCCESS;

--- a/clients/include/testing_gebsr2gebsc.hpp
+++ b/clients/include/testing_gebsr2gebsc.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_GEBSR2GEBSC_HPP
 #define TESTING_GEBSR2GEBSC_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -632,8 +633,22 @@ hipsparseStatus_t testing_gebsr2gebsc(Arguments argus)
             = gebsr2gebsc_gbyte_count<T>(mb, nb, nnzb, row_block_dim, col_block_dim, action);
         double gpu_gbyte = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::Mb,
+                            mb,
+                            display_key_t::Nb,
+                            nb,
+                            display_key_t::nnzb,
+                            nnzb,
+                            display_key_t::row_block_dim,
+                            row_block_dim,
+                            display_key_t::col_block_dim,
+                            col_block_dim,
+                            display_key_t::action,
+                            hipsparse_action2string(action),
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     return HIPSPARSE_STATUS_SUCCESS;

--- a/clients/include/testing_gebsr2gebsr.hpp
+++ b/clients/include/testing_gebsr2gebsr.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_GEBSR2GEBSR_HPP
 #define TESTING_GEBSR2GEBSR_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -945,6 +946,7 @@ hipsparseStatus_t testing_gebsr2gebsr(Arguments argus)
     int mb   = (m + row_block_dim_A - 1) / row_block_dim_A;
     int nb   = (n + col_block_dim_A - 1) / col_block_dim_A;
     int mb_C = (mb * row_block_dim_A + row_block_dim_C - 1) / row_block_dim_C;
+    int nb_C = (nb * col_block_dim_A + col_block_dim_C - 1) / col_block_dim_C;
 
     // allocate memory on device
     auto dcsr_row_ptr_managed
@@ -1266,8 +1268,34 @@ hipsparseStatus_t testing_gebsr2gebsr(Arguments argus)
                                                         hnnzb_C);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::MbA,
+                            mb,
+                            display_key_t::NbA,
+                            nb,
+                            display_key_t::MbC,
+                            mb_C,
+                            display_key_t::NbC,
+                            nb_C,
+                            display_key_t::row_block_dimA,
+                            row_block_dim_A,
+                            display_key_t::col_block_dimA,
+                            col_block_dim_A,
+                            display_key_t::row_block_dimC,
+                            row_block_dim_C,
+                            display_key_t::col_block_dimC,
+                            col_block_dim_C,
+                            display_key_t::nnzbA,
+                            nnzb,
+                            display_key_t::nnzbC,
+                            hnnzb_C,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     return HIPSPARSE_STATUS_SUCCESS;

--- a/clients/include/testing_gemmi.hpp
+++ b/clients/include/testing_gemmi.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_GEMMI_HPP
 #define TESTING_GEMMI_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -484,8 +485,28 @@ hipsparseStatus_t testing_gemmi(Arguments argus)
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            M,
+                            display_key_t::N,
+                            N,
+                            display_key_t::K,
+                            K,
+                            display_key_t::nnzA,
+                            M * K,
+                            display_key_t::nnzB,
+                            nnz,
+                            display_key_t::nnzC,
+                            M * N,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_gemvi.hpp
+++ b/clients/include/testing_gemvi.hpp
@@ -269,7 +269,8 @@ hipsparseStatus_t testing_gemvi(Arguments argus)
         gpu_time_used = (get_time_us() - gpu_time_used) / number_hot_calls;
 
         double gflop_count = gemvi_gflop_count(m, nnz);
-        double gbyte_count = gemvi_gbyte_count<T>((trans == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? m : n,
+        double gbyte_count
+            = gemvi_gbyte_count<T>((trans == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? m : n,
                                    nnz,
                                    beta != make_DataType<T>(0.0));
 

--- a/clients/include/testing_gemvi.hpp
+++ b/clients/include/testing_gemvi.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_GEMVI_HPP
 #define TESTING_GEMVI_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -267,15 +268,32 @@ hipsparseStatus_t testing_gemvi(Arguments argus)
 
         gpu_time_used = (get_time_us() - gpu_time_used) / number_hot_calls;
 
-        double gpu_gflops = gemvi_gflop_count(m, nnz) / gpu_time_used * 1e6;
-        double gpu_gbyte
-            = gemvi_gbyte_count<T>((trans == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? m : n,
+        double gflop_count = gemvi_gflop_count(m, nnz);
+        double gbyte_count = gemvi_gbyte_count<T>((trans == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? m : n,
                                    nnz,
-                                   beta != make_DataType<T>(0.0))
-              / gpu_time_used * 1e6;
+                                   beta != make_DataType<T>(0.0));
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
+        double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
+
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::trans,
+                            hipsparse_operation2string(trans),
+                            display_key_t::alpha,
+                            alpha,
+                            display_key_t::beta,
+                            beta,
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(externalBuffer));

--- a/clients/include/testing_gpsv_interleaved_batch.hpp
+++ b/clients/include/testing_gpsv_interleaved_batch.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_GPSV_INTERLEAVED_BATCH_HPP
 #define TESTING_GPSV_INTERLEAVED_BATCH_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -263,8 +264,14 @@ hipsparseStatus_t testing_gpsv_interleaved_batch(Arguments argus)
         double gbyte_count = gpsv_interleaved_batch_gbyte_count<T>(m, batch_count);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::batch_count,
+                            batch_count,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_gthr.hpp
+++ b/clients/include/testing_gthr.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_GTHR_HPP
 #define TESTING_GTHR_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -151,8 +152,12 @@ hipsparseStatus_t testing_gthr(Arguments argus)
         double gbyte_count = gthr_gbyte_count<T>(nnz);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::nnz,
+                            nnz,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_gthrz.hpp
+++ b/clients/include/testing_gthrz.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_GTHRZ_HPP
 #define TESTING_GTHRZ_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -157,8 +158,12 @@ hipsparseStatus_t testing_gthrz(Arguments argus)
         double gbyte_count = gthrz_gbyte_count<T>(nnz);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::nnz,
+                            nnz,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_gtsv.hpp
+++ b/clients/include/testing_gtsv.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_GTSV2_HPP
 #define TESTING_GTSV2_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -208,8 +209,14 @@ hipsparseStatus_t testing_gtsv2(Arguments argus)
         double gbyte_count = gtsv_gbyte_count<T>(m, n);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_gtsv2_nopivot.hpp
+++ b/clients/include/testing_gtsv2_nopivot.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_GTSV2_NOPIVOT_HPP
 #define TESTING_GTSV2_NOPIVOT_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -208,8 +209,14 @@ hipsparseStatus_t testing_gtsv2_nopivot(Arguments argus)
         double gbyte_count = gtsv_gbyte_count<T>(m, n);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_gtsv2_strided_batch.hpp
+++ b/clients/include/testing_gtsv2_strided_batch.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_GTSV2_NOPIVOT_STRIDED_BATCH_HPP
 #define TESTING_GTSV2_NOPIVOT_STRIDED_BATCH_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -234,8 +235,16 @@ hipsparseStatus_t testing_gtsv2_strided_batch(Arguments argus)
         double gbyte_count = gtsv_strided_batch_gbyte_count<T>(m, batch_count);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::batch_count,
+                            batch_count,
+                            display_key_t::batch_stride,
+                            batch_stride,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_gtsv_interleaved_batch.hpp
+++ b/clients/include/testing_gtsv_interleaved_batch.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_GTSV_INTERLEAVED_BATCH_HPP
 #define TESTING_GTSV_INTERLEAVED_BATCH_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -225,8 +226,14 @@ hipsparseStatus_t testing_gtsv_interleaved_batch(Arguments argus)
         double gbyte_count = gtsv_interleaved_batch_gbyte_count<T>(m, batch_count);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::batch_count,
+                            batch_count,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_hyb2csr.hpp
+++ b/clients/include/testing_hyb2csr.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_HYB2CSR_HPP
 #define TESTING_HYB2CSR_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -216,8 +217,16 @@ hipsparseStatus_t testing_hyb2csr(Arguments argus)
         double gbyte_count = hyb2csr_gbyte_count<T>(m, nnz, dhyb->ell_nnz, dhyb->coo_nnz);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_hybmv.hpp
+++ b/clients/include/testing_hybmv.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_HYBMV_HPP
 #define TESTING_HYBMV_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -344,8 +345,24 @@ hipsparseStatus_t testing_hybmv(Arguments argus)
         double gflop_count = spmv_gflop_count(m, nnz, h_beta != make_DataType<T>(0.0));
         double gpu_gflops  = get_gpu_gflops(gpu_time_used, gflop_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::partition,
+                            hipsparse_partition2string(part),
+                            display_key_t::ell_width,
+                            user_ell_width,
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
     return HIPSPARSE_STATUS_SUCCESS;

--- a/clients/include/testing_identity.hpp
+++ b/clients/include/testing_identity.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_IDENTITY_HPP
 #define TESTING_IDENTITY_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -116,8 +117,12 @@ hipsparseStatus_t testing_identity(Arguments argus)
         double gbyte_count = identity_gbyte_count(n);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::N,
+                            n,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_nnz.hpp
+++ b/clients/include/testing_nnz.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_NNZ_HPP
 #define TESTING_NNZ_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -286,8 +287,20 @@ hipsparseStatus_t testing_nnz(Arguments argus)
         double gbyte_count = nnz_gbyte_count<T>(M, N, dirA);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            M,
+                            display_key_t::N,
+                            N,
+                            display_key_t::LD,
+                            lda,
+                            display_key_t::nnz,
+                            h_nnz,
+                            display_key_t::direction,
+                            hipsparse_direction2string(dirA),
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     return HIPSPARSE_STATUS_SUCCESS;

--- a/clients/include/testing_prune_csr2csr.hpp
+++ b/clients/include/testing_prune_csr2csr.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_PRUNE_CSR2CSR_HPP
 #define TESTING_PRUNE_CSR2CSR_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -779,8 +780,20 @@ hipsparseStatus_t testing_prune_csr2csr(Arguments argus)
         double gbyte_count = prune_csr2csr_gbyte_count<T>(M, nnz_A, h_nnz_total_dev_host_ptr[0]);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            M,
+                            display_key_t::N,
+                            N,
+                            display_key_t::nnzA,
+                            nnz_A,
+                            display_key_t::nnzC,
+                            h_nnz_total_dev_host_ptr[0],
+                            display_key_t::threshold,
+                            threshold,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_prune_csr2csr_by_percentage.hpp
+++ b/clients/include/testing_prune_csr2csr_by_percentage.hpp
@@ -892,7 +892,7 @@ hipsparseStatus_t testing_prune_csr2csr_by_percentage(Arguments argus)
                             display_key_t::bandwidth,
                             gpu_gbyte,
                             display_key_t::time_ms,
-                            get_gpu_time_msec(gpu_time_used));        
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_prune_csr2csr_by_percentage.hpp
+++ b/clients/include/testing_prune_csr2csr_by_percentage.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_PRUNE_CSR2CSR_BY_PERCENTAGE_HPP
 #define TESTING_PRUNE_CSR2CSR_BY_PERCENTAGE_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -878,8 +879,20 @@ hipsparseStatus_t testing_prune_csr2csr_by_percentage(Arguments argus)
             = prune_csr2csr_by_percentage_gbyte_count<T>(M, nnz_A, h_nnz_total_dev_host_ptr[0]);
         double gpu_gbyte = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            M,
+                            display_key_t::N,
+                            N,
+                            display_key_t::nnzA,
+                            nnz_A,
+                            display_key_t::nnzC,
+                            h_nnz_total_dev_host_ptr[0],
+                            display_key_t::percentage,
+                            percentage,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));        
     }
 #endif
 

--- a/clients/include/testing_prune_dense2csr.hpp
+++ b/clients/include/testing_prune_dense2csr.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_PRUNE_DENSE2CSR_HPP
 #define TESTING_PRUNE_DENSE2CSR_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -470,8 +471,20 @@ hipsparseStatus_t testing_prune_dense2csr(Arguments argus)
         double gbyte_count = prune_dense2csr_gbyte_count<T>(M, N, h_nnz_total_dev_host_ptr[0]);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            M,
+                            display_key_t::N,
+                            N,
+                            display_key_t::LD,
+                            LDA,
+                            display_key_t::nnz,
+                            h_nnz_total_dev_host_ptr[0],
+                            display_key_t::threshold,
+                            threshold,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_prune_dense2csr_by_percentage.hpp
+++ b/clients/include/testing_prune_dense2csr_by_percentage.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_PRUNE_DENSE2CSR_BY_PERCENTAGE_HPP
 #define TESTING_PRUNE_DENSE2CSR_BY_PERCENTAGE_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -598,8 +599,18 @@ hipsparseStatus_t testing_prune_dense2csr_by_percentage(Arguments argus)
             = prune_dense2csr_by_percentage_gbyte_count<T>(M, N, h_nnz_total_dev_host_ptr[0]);
         double gpu_gbyte = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            M,
+                            display_key_t::M,
+                            N,
+                            display_key_t::nnz,
+                            h_nnz_total_dev_host_ptr[0],
+                            display_key_t::percentage,
+                            percentage,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_rot.hpp
+++ b/clients/include/testing_rot.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_ROT_HPP
 #define TESTING_ROT_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse_arguments.hpp"
@@ -229,8 +230,14 @@ hipsparseStatus_t testing_rot(Arguments argus)
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::nnz,
+                            nnz,
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIPSPARSE_ERROR(hipsparseDestroySpVec(x1));

--- a/clients/include/testing_roti.hpp
+++ b/clients/include/testing_roti.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_ROTI_HPP
 #define TESTING_ROTI_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -216,8 +217,14 @@ hipsparseStatus_t testing_roti(Arguments argus)
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::nnz,
+                            nnz,
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_scatter.hpp
+++ b/clients/include/testing_scatter.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SCATTER_HPP
 #define TESTING_SCATTER_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse_arguments.hpp"
@@ -174,8 +175,12 @@ hipsparseStatus_t testing_scatter(Arguments argus)
         double gbyte_count = sctr_gbyte_count<T>(nnz);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::nnz,
+                            nnz,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIPSPARSE_ERROR(hipsparseDestroySpVec(x));

--- a/clients/include/testing_sctr.hpp
+++ b/clients/include/testing_sctr.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SCTR_HPP
 #define TESTING_SCTR_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -158,8 +159,12 @@ hipsparseStatus_t testing_sctr(Arguments argus)
         double gbyte_count = sctr_gbyte_count<T>(nnz);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::nnz,
+                            nnz,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 #endif
 

--- a/clients/include/testing_sddmm_coo.hpp
+++ b/clients/include/testing_sddmm_coo.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SDDMM_COO_HPP
 #define TESTING_SDDMM_COO_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -395,7 +396,7 @@ hipsparseStatus_t testing_sddmm_coo(Arguments argus)
         for(int iter = 0; iter < number_cold_calls; ++iter)
         {
             CHECK_HIPSPARSE_ERROR(hipsparseSDDMM(
-                handle, transA, transB, d_alpha, A, B, d_beta, C2, typeT, alg, buffer));
+                handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, buffer));
         }
 
         double gpu_time_used = get_time_us();
@@ -404,7 +405,7 @@ hipsparseStatus_t testing_sddmm_coo(Arguments argus)
         for(int iter = 0; iter < number_hot_calls; ++iter)
         {
             CHECK_HIPSPARSE_ERROR(hipsparseSDDMM(
-                handle, transA, transB, d_alpha, A, B, d_beta, C2, typeT, alg, buffer));
+                handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, buffer));
         }
 
         gpu_time_used = (get_time_us() - gpu_time_used) / number_hot_calls;
@@ -415,8 +416,32 @@ hipsparseStatus_t testing_sddmm_coo(Arguments argus)
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBYTES/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::format,
+                            hipsparse_format2string(HIPSPARSE_FORMAT_COO),
+                            display_key_t::transA,
+                            hipsparse_operation2string(transA),
+                            display_key_t::transB,
+                            hipsparse_operation2string(transB),
+                            display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::K,
+                            k,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::algorithm,
+                            hipsparse_sddmmalg2string(alg),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     // free.

--- a/clients/include/testing_sddmm_coo_aos.hpp
+++ b/clients/include/testing_sddmm_coo_aos.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SDDMM_COO_AOS_HPP
 #define TESTING_SDDMM_COO_AOS_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -391,7 +392,7 @@ hipsparseStatus_t testing_sddmm_coo_aos(Arguments argus)
         for(int iter = 0; iter < number_cold_calls; ++iter)
         {
             CHECK_HIPSPARSE_ERROR(hipsparseSDDMM(
-                handle, transA, transB, d_alpha, A, B, d_beta, C2, typeT, alg, buffer));
+                handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, buffer));
         }
 
         double gpu_time_used = get_time_us();
@@ -400,7 +401,7 @@ hipsparseStatus_t testing_sddmm_coo_aos(Arguments argus)
         for(int iter = 0; iter < number_hot_calls; ++iter)
         {
             CHECK_HIPSPARSE_ERROR(hipsparseSDDMM(
-                handle, transA, transB, d_alpha, A, B, d_beta, C2, typeT, alg, buffer));
+                handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, buffer));
         }
 
         gpu_time_used = (get_time_us() - gpu_time_used) / number_hot_calls;
@@ -412,8 +413,32 @@ hipsparseStatus_t testing_sddmm_coo_aos(Arguments argus)
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBYTES/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::format,
+                            hipsparse_format2string(HIPSPARSE_FORMAT_COO_AOS),
+                            display_key_t::transA,
+                            hipsparse_operation2string(transA),
+                            display_key_t::transB,
+                            hipsparse_operation2string(transB),
+                            display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::K,
+                            k,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::algorithm,
+                            hipsparse_sddmmalg2string(alg),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     // free.

--- a/clients/include/testing_sddmm_csc.hpp
+++ b/clients/include/testing_sddmm_csc.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SDDMM_CSC_HPP
 #define TESTING_SDDMM_CSC_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -395,7 +396,7 @@ hipsparseStatus_t testing_sddmm_csc(Arguments argus)
         for(int iter = 0; iter < number_cold_calls; ++iter)
         {
             CHECK_HIPSPARSE_ERROR(hipsparseSDDMM(
-                handle, transA, transB, d_alpha, A, B, d_beta, C2, typeT, alg, buffer));
+                handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, buffer));
         }
 
         double gpu_time_used = get_time_us();
@@ -404,7 +405,7 @@ hipsparseStatus_t testing_sddmm_csc(Arguments argus)
         for(int iter = 0; iter < number_hot_calls; ++iter)
         {
             CHECK_HIPSPARSE_ERROR(hipsparseSDDMM(
-                handle, transA, transB, d_alpha, A, B, d_beta, C2, typeT, alg, buffer));
+                handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, buffer));
         }
 
         gpu_time_used = (get_time_us() - gpu_time_used) / number_hot_calls;
@@ -415,8 +416,32 @@ hipsparseStatus_t testing_sddmm_csc(Arguments argus)
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBYTES/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::format,
+                            hipsparse_format2string(HIPSPARSE_FORMAT_CSC),
+                            display_key_t::transA,
+                            hipsparse_operation2string(transA),
+                            display_key_t::transB,
+                            hipsparse_operation2string(transB),
+                            display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::K,
+                            k,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::algorithm,
+                            hipsparse_sddmmalg2string(alg),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     // free.

--- a/clients/include/testing_sddmm_csr.hpp
+++ b/clients/include/testing_sddmm_csr.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SDDMM_CSR_HPP
 #define TESTING_SDDMM_CSR_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -394,7 +395,7 @@ hipsparseStatus_t testing_sddmm_csr(Arguments argus)
         for(int iter = 0; iter < number_cold_calls; ++iter)
         {
             CHECK_HIPSPARSE_ERROR(hipsparseSDDMM(
-                handle, transA, transB, d_alpha, A, B, d_beta, C2, typeT, alg, buffer));
+                handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, buffer));
         }
 
         double gpu_time_used = get_time_us();
@@ -403,7 +404,7 @@ hipsparseStatus_t testing_sddmm_csr(Arguments argus)
         for(int iter = 0; iter < number_hot_calls; ++iter)
         {
             CHECK_HIPSPARSE_ERROR(hipsparseSDDMM(
-                handle, transA, transB, d_alpha, A, B, d_beta, C2, typeT, alg, buffer));
+                handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, buffer));
         }
 
         gpu_time_used = (get_time_us() - gpu_time_used) / number_hot_calls;
@@ -414,8 +415,32 @@ hipsparseStatus_t testing_sddmm_csr(Arguments argus)
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBYTES/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::format,
+                            hipsparse_format2string(HIPSPARSE_FORMAT_CSR),
+                            display_key_t::transA,
+                            hipsparse_operation2string(transA),
+                            display_key_t::transB,
+                            hipsparse_operation2string(transB),
+                            display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::K,
+                            k,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::algorithm,
+                            hipsparse_sddmmalg2string(alg),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     // free.

--- a/clients/include/testing_sparse_to_dense_coo.hpp
+++ b/clients/include/testing_sparse_to_dense_coo.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SPARSE_TO_DENSE_COO_HPP
 #define TESTING_SPARSE_TO_DENSE_COO_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse_arguments.hpp"
@@ -286,8 +287,20 @@ hipsparseStatus_t testing_sparse_to_dense_coo(Arguments argus)
         double gbyte_count = coo2dense_gbyte_count<T>(m, n, (I)nnz);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::order,
+                            order,
+                            display_key_t::algorithm,
+                            hipsparse_sparsetodensealg2string(alg),
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_sparse_to_dense_csc.hpp
+++ b/clients/include/testing_sparse_to_dense_csc.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SPARSE_TO_DENSE_CSC_HPP
 #define TESTING_SPARSE_TO_DENSE_CSC_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse_arguments.hpp"
@@ -323,8 +324,20 @@ hipsparseStatus_t testing_sparse_to_dense_csc(Arguments argus)
         double gbyte_count = csx2dense_gbyte_count<HIPSPARSE_DIRECTION_COLUMN, T>(m, n, nnz);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::order,
+                            order,
+                            display_key_t::algorithm,
+                            hipsparse_sparsetodensealg2string(alg),
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_sparse_to_dense_csr.hpp
+++ b/clients/include/testing_sparse_to_dense_csr.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SPARSE_TO_DENSE_CSR_HPP
 #define TESTING_SPARSE_TO_DENSE_CSR_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse_arguments.hpp"
@@ -286,8 +287,20 @@ hipsparseStatus_t testing_sparse_to_dense_csr(Arguments argus)
         double gbyte_count = csx2dense_gbyte_count<HIPSPARSE_DIRECTION_ROW, T>(m, n, nnz);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GBytes/s: " << gpu_gbyte << " time (ms): " << get_gpu_time_msec(gpu_time_used)
-                  << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::order,
+                            order,
+                            display_key_t::algorithm,
+                            hipsparse_sparsetodensealg2string(alg),
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_spmm_batched_coo.hpp
+++ b/clients/include/testing_spmm_batched_coo.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SPMM_BATCHED_COO_HPP
 #define TESTING_SPMM_BATCHED_COO_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -478,8 +479,32 @@ hipsparseStatus_t testing_spmm_batched_coo(Arguments argus)
                                                           h_beta != make_DataType<T>(0));
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBYTES/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::K,
+                            k,
+                            display_key_t::nnzA,
+                            nnz_A,
+                            display_key_t::batch_countA,
+                            batch_count_A,
+                            display_key_t::batch_countB,
+                            batch_count_B,
+                            display_key_t::batch_countC,
+                            batch_count_C,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::algorithm,
+                            hipsparse_spmmalg2string(alg),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_spmm_batched_csc.hpp
+++ b/clients/include/testing_spmm_batched_csc.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SPMM_BATCHED_CSC_HPP
 #define TESTING_SPMM_BATCHED_CSC_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -476,8 +477,32 @@ hipsparseStatus_t testing_spmm_batched_csc(Arguments argus)
                                                           h_beta != make_DataType<T>(0));
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBYTES/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::K,
+                            k,
+                            display_key_t::nnzA,
+                            nnz_A,
+                            display_key_t::batch_countA,
+                            batch_count_A,
+                            display_key_t::batch_countB,
+                            batch_count_B,
+                            display_key_t::batch_countC,
+                            batch_count_C,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::algorithm,
+                            hipsparse_spmmalg2string(alg),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_spmm_batched_csr.hpp
+++ b/clients/include/testing_spmm_batched_csr.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SPMM_BATCHED_CSR_HPP
 #define TESTING_SPMM_BATCHED_CSR_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -476,8 +477,32 @@ hipsparseStatus_t testing_spmm_batched_csr(Arguments argus)
                                                           h_beta != make_DataType<T>(0));
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBYTES/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::K,
+                            k,
+                            display_key_t::nnzA,
+                            nnz_A,
+                            display_key_t::batch_countA,
+                            batch_count_A,
+                            display_key_t::batch_countB,
+                            batch_count_B,
+                            display_key_t::batch_countC,
+                            batch_count_C,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::algorithm,
+                            hipsparse_spmmalg2string(alg),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_spmm_coo.hpp
+++ b/clients/include/testing_spmm_coo.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SPMM_COO_HPP
 #define TESTING_SPMM_COO_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -435,8 +436,26 @@ hipsparseStatus_t testing_spmm_coo(Arguments argus)
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBYTES/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::K,
+                            k,
+                            display_key_t::nnzA,
+                            nnz_A,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::algorithm,
+                            hipsparse_spmmalg2string(alg),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_spmm_csc.hpp
+++ b/clients/include/testing_spmm_csc.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SPMM_CSC_HPP
 #define TESTING_SPMM_CSC_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -425,8 +426,26 @@ hipsparseStatus_t testing_spmm_csc(Arguments argus)
             A_n, nnz_A, (I)B_m * (I)B_n, (I)C_m * (I)C_n, h_beta != make_DataType<T>(0));
         double gpu_gbyte = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBYTES/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::K,
+                            k,
+                            display_key_t::nnzA,
+                            nnz_A,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::algorithm,
+                            hipsparse_spmmalg2string(alg),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_spmm_csr.hpp
+++ b/clients/include/testing_spmm_csr.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SPMM_CSR_HPP
 #define TESTING_SPMM_CSR_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse.hpp"
@@ -427,8 +428,26 @@ hipsparseStatus_t testing_spmm_csr(Arguments argus)
             A_m, nnz_A, (I)B_m * (I)B_n, (I)C_m * (I)C_n, h_beta != make_DataType<T>(0));
         double gpu_gbyte = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBYTES/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::K,
+                            k,
+                            display_key_t::nnzA,
+                            nnz_A,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::algorithm,
+                            hipsparse_spmmalg2string(alg),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_spmv_coo.hpp
+++ b/clients/include/testing_spmv_coo.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SPMV_COO_HPP
 #define TESTING_SPMV_COO_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse_arguments.hpp"
@@ -321,8 +322,26 @@ hipsparseStatus_t testing_spmv_coo(Arguments argus)
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::transA,
+                            transA,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::algorithm,
+                            hipsparse_spmvalg2string(alg),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_spmv_coo_aos.hpp
+++ b/clients/include/testing_spmv_coo_aos.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SPMV_COO_AOS_HPP
 #define TESTING_SPMV_COO_AOS_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse_arguments.hpp"
@@ -316,8 +317,26 @@ hipsparseStatus_t testing_spmv_coo_aos(Arguments argus)
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::transA,
+                            transA,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::algorithm,
+                            hipsparse_spmvalg2string(alg),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_spmv_csr.hpp
+++ b/clients/include/testing_spmv_csr.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SPMV_CSR_HPP
 #define TESTING_SPMV_CSR_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse_arguments.hpp"
@@ -399,8 +400,26 @@ hipsparseStatus_t testing_spmv_csr(Arguments argus)
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::transA,
+                            transA,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::beta,
+                            h_beta,
+                            display_key_t::algorithm,
+                            hipsparse_spmvalg2string(alg),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_spsm_coo.hpp
+++ b/clients/include/testing_spsm_coo.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SPSM_COO_HPP
 #define TESTING_SPSM_COO_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse_arguments.hpp"
@@ -422,8 +423,24 @@ hipsparseStatus_t testing_spsm_coo(Arguments argus)
         double gbyte_count = coosv_gbyte_count<T>(m, nnz) * k;
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::K,
+                            k,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::algorithm,
+                            hipsparse_spsmalg2string(alg),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_spsm_csr.hpp
+++ b/clients/include/testing_spsm_csr.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SPSM_CSR_HPP
 #define TESTING_SPSM_CSR_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse_arguments.hpp"
@@ -414,8 +415,24 @@ hipsparseStatus_t testing_spsm_csr(Arguments argus)
         double gbyte_count = csrsv_gbyte_count<T>(m, nnz) * k;
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::K,
+                            k,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::algorithm,
+                            hipsparse_spsmalg2string(alg),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_spsv_coo.hpp
+++ b/clients/include/testing_spsv_coo.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SPSV_COO_HPP
 #define TESTING_SPSV_COO_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse_arguments.hpp"
@@ -352,8 +353,22 @@ hipsparseStatus_t testing_spsv_coo(Arguments argus)
         double gbyte_count = coosv_gbyte_count<T>(m, nnz);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::algorithm,
+                            hipsparse_spsvalg2string(alg),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_spsv_csr.hpp
+++ b/clients/include/testing_spsv_csr.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SPSV_CSR_HPP
 #define TESTING_SPSV_CSR_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse_arguments.hpp"
@@ -344,8 +345,22 @@ hipsparseStatus_t testing_spsv_csr(Arguments argus)
         double gbyte_count = csrsv_gbyte_count<T>(m, nnz);
         double gpu_gbyte   = get_gpu_gbyte(gpu_time_used, gbyte_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::M,
+                            m,
+                            display_key_t::N,
+                            n,
+                            display_key_t::nnz,
+                            nnz,
+                            display_key_t::alpha,
+                            h_alpha,
+                            display_key_t::algorithm,
+                            hipsparse_spsvalg2string(alg),
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(buffer));

--- a/clients/include/testing_spvv.hpp
+++ b/clients/include/testing_spvv.hpp
@@ -25,6 +25,7 @@
 #ifndef TESTING_SPVV_HPP
 #define TESTING_SPVV_HPP
 
+#include "display.hpp"
 #include "flops.hpp"
 #include "gbyte.hpp"
 #include "hipsparse_arguments.hpp"
@@ -252,8 +253,14 @@ hipsparseStatus_t testing_spvv(Arguments argus)
         double gpu_gbyte  = get_gpu_gbyte(gpu_time_used, gbyte_count);
         double gpu_gflops = get_gpu_gflops(gpu_time_used, gflop_count);
 
-        std::cout << "GFLOPS/s: " << gpu_gflops << " GBytes/s: " << gpu_gbyte
-                  << " time (ms): " << get_gpu_time_msec(gpu_time_used) << std::endl;
+        display_timing_info(display_key_t::nnz,
+                            nnz,
+                            display_key_t::gflops,
+                            gpu_gflops,
+                            display_key_t::bandwidth,
+                            gpu_gbyte,
+                            display_key_t::time_ms,
+                            get_gpu_time_msec(gpu_time_used));
     }
 
     CHECK_HIP_ERROR(hipFree(externalBuffer));

--- a/clients/tests/hipsparse_gtest_main.cpp
+++ b/clients/tests/hipsparse_gtest_main.cpp
@@ -146,6 +146,26 @@ public:
     }
 };
 
+hipsparseStatus_t hipsparse_record_output_legend(const std::string& s)
+{
+    return HIPSPARSE_STATUS_SUCCESS;
+}
+
+hipsparseStatus_t hipsparse_record_output(const std::string& s)
+{
+    return HIPSPARSE_STATUS_SUCCESS;
+}
+
+hipsparseStatus_t hipsparse_record_timing(double msec, double gflops, double gbs)
+{
+    return HIPSPARSE_STATUS_SUCCESS;
+}
+
+bool display_timing_info_is_stdout_disabled()
+{
+    return HIPSPARSE_STATUS_SUCCESS;
+}
+
 /* =====================================================================
       Main function:
 =================================================================== */

--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -44,6 +44,8 @@
 #include <hip/hip_complex.h>
 #include <hip/hip_runtime.h>
 
+#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
+
 /// \cond DO_NOT_DOCUMENT
 #define DEPRECATED_CUDA_12000(warning)
 #define DEPRECATED_CUDA_11000(warning)

--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -44,8 +44,6 @@
 #include <hip/hip_complex.h>
 #include <hip/hip_runtime.h>
 
-#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
-
 /// \cond DO_NOT_DOCUMENT
 #define DEPRECATED_CUDA_12000(warning)
 #define DEPRECATED_CUDA_11000(warning)


### PR DESCRIPTION
- Adds formatting code to allow displaying benchmarking results correctly to the terminal
- Adds code to allow generation of json files storing benchmarking data that can then be passed to python plotting scripts