### PR TITLE
Disable PDF and EPUB formats on Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 sphinx:
    configuration: docs/conf.py
 
-formats: [htmlzip, pdf, epub]
+formats: [htmlzip, epub]
 
 python:
    install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 sphinx:
    configuration: docs/conf.py
 
-formats: [htmlzip, epub]
+formats: [htmlzip]
 
 python:
    install:


### PR DESCRIPTION
PDF and EPUB builds are failing

The HTML and HTMLZIP formats used by the site still pass