### PR TITLE
Update precheckincuda job settings

### DIFF
--- a/.jenkins/precheckin-cuda.groovy
+++ b/.jenkins/precheckin-cuda.groovy
@@ -57,7 +57,8 @@ def runCI =
 ci: { 
     String urlJobName = auxiliary.getTopJobName(env.BUILD_URL)
 
-    def propertyList = auxiliary.appendPropertyList(propertyList)
+    def propertyList = [:]
+    propertyList = auxiliary.appendPropertyList(propertyList)
 
     def jobNameList = [:]
     jobNameList = auxiliary.appendJobNameList(jobNameList, 'hipSPARSE')


### PR DESCRIPTION
Get property and job name list from settings in XML file for runs.
```
jobNameList = auxiliary.appendJobNameList(jobNameList, 'hipSPARSE')
```

Still updates the default hardcoded OS/GPU label (ubuntu20-cuda11 to ubuntu22-cuda12) for clarity, but this is to be a fallback
```
runCI(['ubuntu22-cuda12':['anycuda']], urlJobName)
```

