### PR TITLE
Add spmv preprocess documentation

### DIFF
--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -378,6 +378,7 @@ Function name                                     single double single complex d
 :cpp:func:`hipsparseSpVV_bufferSize()`            x      x      x              x
 :cpp:func:`hipsparseSpVV()`                       x      x      x              x
 :cpp:func:`hipsparseSpMV_bufferSize()`            x      x      x              x
+:cpp:func:`hipsparseSpMV_preprocess()`            x      x      x              x
 :cpp:func:`hipsparseSpMV()`                       x      x      x              x
 :cpp:func:`hipsparseSpMM_bufferSize()`            x      x      x              x
 :cpp:func:`hipsparseSpMM_preprocess()`            x      x      x              x

--- a/docs/reference/generic.rst
+++ b/docs/reference/generic.rst
@@ -72,6 +72,11 @@ hipsparseSpMV_bufferSize()
 
 .. doxygenfunction:: hipsparseSpMV_bufferSize
 
+hipsparseSpMV_preprocess()
+==========================
+
+.. doxygenfunction:: hipsparseSpMV_preprocess
+
 hipsparseSpMV()
 ===============
 

--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -20147,7 +20147,7 @@ hipsparseStatus_t hipsparseSpMV_bufferSize(hipsparseHandle_t           handle,
 *  \brief Preprocess step of the sparse matrix multiplication with a dense vector (optional)
 *
 *  \details
-*  \p hipsparseSpMV_preprocess performs the optional preprocess used when computing the 
+*  \p hipsparseSpMV_preprocess performs analysis on the sparse matrix \f$A\f$ when computing the 
 *  sparse matrix multiplication with a dense vector:
 *  \f[
 *    y := \alpha \cdot op(A) \cdot x + \beta \cdot y,


### PR DESCRIPTION
Adding documentation for hipsparseSpMV_preprocess routine which was missing previously.