### PR TITLE
Expand README note and change reference to NVIDIA CUDA cuSPARSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ application and a 'worker' SPARSE library, where it marshals inputs to the backe
 results to your application. hipSPARSE exports an interface that doesn't require the client to change,
 regardless of the chosen backend. Currently, hipSPARSE supports
 [rocSPARSE](https://github.com/ROCmSoftwarePlatform/rocSPARSE) and
-[cuSPARSE](https://developer.nvidia.com/cusparse) backends.
+[NVIDIA CUDA cuSPARSE](https://developer.nvidia.com/cusparse) backends.
 
 ## Documentation
 
-Documentation for hipSPARSE is available at
-[https://rocm.docs.amd.com/projects/hipSPARSE/en/latest/](https://rocm.docs.amd.com/projects/hipSPARSE/en/latest/).
+> [!NOTE]
+> The published hipSPARSE documentation is available at [https://rocm.docs.amd.com/projects/hipSPARSE/en/latest/](https://rocm.docs.amd.com/projects/hipSPARSE/en/latest/index.html) in an organized, easy-to-read format, with search and a table of contents. The documentation source files reside in the hipSPARSE/docs folder of this repository. As with all ROCm projects, the documentation is open source. For more information, see [Contribute to ROCm documentation](https://rocm.docs.amd.com/en/latest/contribute/contributing.html).
 
 To build our documentation locally, run the following code:
 
@@ -67,8 +67,8 @@ on our wiki.
 
 ## Interface examples
 
-The hipSPARSE interface is compatible with rocSPARSE and cuSPARSE-v2 APIs. Porting a CUDA
-application that calls the cuSPARSE API to an application that calls the hipSPARSE API is relatively
+The hipSPARSE interface is compatible with rocSPARSE and CUDA cuSPARSE-v2 APIs. Porting a CUDA
+application that calls the CUDA cuSPARSE API to an application that calls the hipSPARSE API is relatively
 straightforward. For example, the hipSPARSE SCSRMV interface is:
 
 ### CSRMV API

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@
 hipSPARSE documentation
 ********************************************************************
 
-hipSPARSE exposes a common interface that provides basic linear algebra subroutines for sparse computation implemented on top of the AMD ROCm runtime and toolchains. hipSPARSE is a SPARSE marshalling library supporting both rocSPARSE and cuSPARSE as backends.
+hipSPARSE exposes a common interface that provides basic linear algebra subroutines for sparse computation implemented on top of the AMD ROCm runtime and toolchains. hipSPARSE is a SPARSE marshalling library supporting both rocSPARSE and NVIDIA CUDA cuSPARSE as backends.
 It sits between the application and a `worker` SPARSE library, marshalling inputs into the backend library and marshalling results back to the application. hipSPARSE is created using the HIP programming language and optimized for AMD's latest discrete GPUs.
 
 The code is open and hosted here: `<https://github.com/ROCmSoftwarePlatform/hipSPARSE>`__

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -27,7 +27,7 @@ The code is open and hosted here: https://github.com/ROCmSoftwarePlatform/hipSPA
 hipSPARSE is a SPARSE marshalling library, with multiple supported backends.
 It sits between the application and a `worker` SPARSE library, marshalling inputs into the backend library and marshalling results back to the application.
 hipSPARSE exports an interface that does not require the client to change, regardless of the chosen backend.
-Currently, hipSPARSE supports rocSPARSE and cuSPARSE as backends.
+Currently, hipSPARSE supports rocSPARSE and NVIDIA CUDA cuSPARSE as backends.
 hipSPARSE focuses on convenience and portability.
 If performance outweighs these factors, then using rocSPARSE itself is highly recommended.
 rocSPARSE can also be found on `GitHub <https://github.com/ROCmSoftwarePlatform/rocSPARSE/>`_.


### PR DESCRIPTION
I've changed the initial documentation note in the README.md file to our new standard note, which has more detail. I've also changed references to cuSPARSE to NVIDIA CUDA cuSPARSE (first instance) or CUDA cuSPARSE.