### PR TITLE
Add datatypes to hipDataTypeToHCCDataType

### DIFF
--- a/library/include/hipsparse.h
+++ b/library/include/hipsparse.h
@@ -18570,7 +18570,7 @@ hipsparseStatus_t hipsparseCreateConstCsr(hipsparseConstSpMatDescr_t* spMatDescr
 /*! \ingroup generic_module
 *  \brief Create a sparse CSC matrix descriptor
 *  \details
-*  \p hipsparseCreateCsr creates a sparse CSC matrix descriptor. It should be
+*  \p hipsparseCreateCsc creates a sparse CSC matrix descriptor. It should be
 *  destroyed at the end using \p hipsparseDestroySpMat.
 */
 #if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)

--- a/library/src/amd_detail/hipsparse.cpp
+++ b/library/src/amd_detail/hipsparse.cpp
@@ -477,6 +477,12 @@ namespace hipsparse
     {
         switch(datatype)
         {
+        case rocsparse_datatype_i8_r:
+            return HIP_R_8I;
+        case rocsparse_datatype_i32_r:
+            return HIP_R_32I;
+        case rocsparse_datatype_f16_r:
+            return HIP_R_16F;
         case rocsparse_datatype_f32_r:
             return HIP_R_32F;
         case rocsparse_datatype_f64_r:

--- a/library/src/amd_detail/hipsparse.cpp
+++ b/library/src/amd_detail/hipsparse.cpp
@@ -454,6 +454,12 @@ namespace hipsparse
     {
         switch(datatype)
         {
+        case HIP_R_8I:
+            return rocsparse_datatype_i8_r;
+        case HIP_R_32I:
+            return rocsparse_datatype_i32_r
+        case HIP_R_16F:
+            return rocsparse_datatype_f16_r;
         case HIP_R_32F:
             return rocsparse_datatype_f32_r;
         case HIP_R_64F:

--- a/library/src/amd_detail/hipsparse.cpp
+++ b/library/src/amd_detail/hipsparse.cpp
@@ -457,7 +457,7 @@ namespace hipsparse
         case HIP_R_8I:
             return rocsparse_datatype_i8_r;
         case HIP_R_32I:
-            return rocsparse_datatype_i32_r
+            return rocsparse_datatype_i32_r;
         case HIP_R_16F:
             return rocsparse_datatype_f16_r;
         case HIP_R_32F:

--- a/library/src/nvidia_detail/hipsparse.cpp
+++ b/library/src/nvidia_detail/hipsparse.cpp
@@ -454,6 +454,12 @@ namespace hipsparse
     {
         switch(datatype)
         {
+        case HIP_R_8I:
+            return CUDA_R_8I;
+        case HIP_R_32I:
+            return CUDA_R_32I;
+        case HIP_R_16F:
+            return CUDA_R_16F;
         case HIP_R_32F:
             return CUDA_R_32F;
         case HIP_R_64F:
@@ -471,6 +477,12 @@ namespace hipsparse
     {
         switch(datatype)
         {
+        case CUDA_R_8I:
+            return HIP_R_8I;
+        case CUDA_R_32I:
+            return HIP_R_32I;
+        case CUDA_R_16F:
+            return HIP_R_16F;
         case CUDA_R_32F:
             return HIP_R_32F;
         case CUDA_R_64F:


### PR DESCRIPTION
Add int8, int32, and float16 data types to hipDataTypeToHCCDataType so that sparse matrix descriptors can be used with these data types. For float16 data type, requires https://github.com/ROCm/rocSPARSE-internal/pull/908 to be merged to rocSPARSE prior to merge this PR.