### PR TITLE
Add c++17 to hipsparse and deprecate c++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Set CXX standard
 if (CMAKE_CXX_STANDARD EQUAL 14)
-  message(WARNING "C++14 will be deprecated in the next major release")
+  message( DEPRECATION "Builds using the C++14 standard will no longer be supported in the next major release" )
 elseif(NOT CMAKE_CXX_STANDARD EQUAL 17)
   message(FATAL_ERROR "Only C++14 and C++17 are supported")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,10 +66,19 @@ endif( )
 # hipSPARSE project
 project(hipsparse LANGUAGES CXX ${fortran_language})
 
-# Build flags
-set(CMAKE_CXX_STANDARD 14)
+# Set CXX flags
+if (NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Set CXX standard
+if (CMAKE_CXX_STANDARD EQUAL 14)
+  message(WARNING "C++14 will be deprecated in the next major release")
+elseif(NOT CMAKE_CXX_STANDARD EQUAL 17)
+  message(FATAL_ERROR "Only C++14 and C++17 are supported")
+endif()
 
 # Build options
 option(BUILD_SHARED_LIBS "Build hipSPARSE as a shared library" ON)

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -55,10 +55,19 @@ if(NOT TARGET hipsparse)
   option(BUILD_CLIENTS_BENCHMARKS "Build benchmarks" ON)
 endif()
 
-# Build flags
-set(CMAKE_CXX_STANDARD 14)
+# Set CXX flags
+if (NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Set CXX standard
+if (CMAKE_CXX_STANDARD EQUAL 14)
+  message(WARNING "C++14 will be deprecated in the next major release")
+elseif(NOT CMAKE_CXX_STANDARD EQUAL 17)
+  message(FATAL_ERROR "Only C++14 and C++17 are supported")
+endif()
 
 # If OpenMP is available, we can use it to speed up some tests
 find_package(OpenMP QUIET)

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -64,7 +64,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Set CXX standard
 if (CMAKE_CXX_STANDARD EQUAL 14)
-  message(WARNING "C++14 will be deprecated in the next major release")
+  message( DEPRECATION "Builds using the C++14 standard will no longer be supported in the next major release" )
 elseif(NOT CMAKE_CXX_STANDARD EQUAL 17)
   message(FATAL_ERROR "Only C++14 and C++17 are supported")
 endif()

--- a/clients/common/utility.cpp
+++ b/clients/common/utility.cpp
@@ -63,7 +63,6 @@ std::string hipsparse_exepath()
         result.resize(result.size() * 2);
     }
 
-    // std::filesystem::path exepath(result.begin(), result.end());
     fs::path exepath(result.begin(), result.end());
     exepath = exepath.remove_filename();
     exepath += exepath.empty() ? "" : "/";

--- a/clients/common/utility.cpp
+++ b/clients/common/utility.cpp
@@ -34,42 +34,14 @@
 #define strSUITEcmp(A, B) _stricmp(A, B)
 #endif
 
-#ifdef __cpp_lib_filesystem
-#include <filesystem>
-#else
-#include <experimental/filesystem>
-
-namespace std
-{
-    namespace filesystem = experimental::filesystem;
-}
-#endif
-#if 0
-#ifdef WIN32
-#include <windows.h>
-#endif
-
-#include "utility.hpp"
-
-#include <hip/hip_runtime_api.h>
-#include <hipsparse.h>
-#include <stdio.h>
-// #include <sys/time.h>
-#include <chrono>
-//#define _USE_MATH_DEFINES
-#include <cmath>
-#include <cstdlib>
+#include <version>
 
 #ifdef __cpp_lib_filesystem
 #include <filesystem>
+namespace fs = std::filesystem;
 #else
 #include <experimental/filesystem>
-
-namespace std
-{
-    namespace filesystem = experimental::filesystem;
-}
-#endif
+namespace fs = std::experimental::filesystem;
 #endif
 
 /* ============================================================================================ */
@@ -91,7 +63,8 @@ std::string hipsparse_exepath()
         result.resize(result.size() * 2);
     }
 
-    std::filesystem::path exepath(result.begin(), result.end());
+    // std::filesystem::path exepath(result.begin(), result.end());
+    fs::path exepath(result.begin(), result.end());
     exepath = exepath.remove_filename();
     exepath += exepath.empty() ? "" : "/";
     return exepath.string();

--- a/clients/common/utility.cpp
+++ b/clients/common/utility.cpp
@@ -34,8 +34,6 @@
 #define strSUITEcmp(A, B) _stricmp(A, B)
 #endif
 
-#include <version>
-
 #ifdef __cpp_lib_filesystem
 #include <filesystem>
 namespace fs = std::filesystem;


### PR DESCRIPTION
Summary of proposed changes:

- Use C++17 by default in hipSPARSE
- This is consistent with other math libraries
- Solves https://github.com/ROCm/hipSPARSE/issues/555