### PR TITLE
skip hipblasLT for static CI jobs

### DIFF
--- a/.jenkins/static.groovy
+++ b/.jenkins/static.groovy
@@ -18,7 +18,7 @@ def runCI =
     prj.paths.build_command = './install.sh -c --static'
     prj.compiler.compiler_name = 'amdclang++'
     prj.compiler.compiler_path = '/opt/rocm/bin/amdclang++'
-    prj.libraryDependencies = ['hipBLAS-common', 'hipBLASLt', 'rocBLAS', 'rocSPARSE', 'rocPRIM']
+    prj.libraryDependencies = ['hipBLAS-common', 'rocBLAS', 'rocSPARSE', 'rocPRIM']
     prj.defaults.ccache = false
 
     // Define test architectures, optional rocm version argument is available


### PR DESCRIPTION
Use old dependencies for static job, ie no hipblaslt