### PR TITLE
Fix empty clients-common package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Documentation for hipSPARSE is available at
 * Added build dependencies for CentOS/RHEL 9 in install script
 * Added `azurelinux` OS name for correcting gfortran dependency
 
+### Changed
+
+* Moved `hipsparse_clientmatrices.cmake` and `hipsparse_mtx2csr` files from `hipsparse-tests` package to `hipsparse-clients-common` package
+
 ### Optimized
 
 * Removed unused `GTest` dependency from `hipsparse-bench`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Documentation for hipSPARSE is available at
 
 ### Changed
 
-* Moved `hipsparse_clientmatrices.cmake` and `hipsparse_mtx2csr` files from `hipsparse-tests` package to `hipsparse-clients-common` package
+* Moved the `hipsparse_clientmatrices.cmake` and `hipsparse_mtx2csr` files from the `hipsparse-tests` package to the `hipsparse-clients-common` package
 
 ### Optimized
 

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -111,16 +111,16 @@ if(BUILD_CLIENTS_TESTS)
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
   
   add_custom_target(hipsparse-common DEPENDS "${HIPSPARSE_CLIENTMATRICES}" "${HIPSPARSE_CONVERT}")
-  
+
   rocm_install(
     PROGRAMS "${HIPSPARSE_CONVERT}"
-    COMPONENT tests
+    COMPONENT clients-common
     DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
   
   rocm_install(
     FILES "${HIPSPARSE_CLIENTMATRICES}"
-    COMPONENT tests
+    COMPONENT clients-common
     DESTINATION "${CMAKE_INSTALL_DATADIR}/hipsparse/test"
     )
   


### PR DESCRIPTION
Previously the hipsparse-clients-common package was empty which caused problems because empty packages are not installed yet the hipsparse-tests and hipsparse-benchmarks packages depend on it. The solution is to either remove the hipsparse-clients-common entirely or to add files to it so that it is not empty. I went with adding the hipsparse_clientmatrices.cmake and hipsparse_mtx2csr files to is as 1) I was not sure if removing the package entirely before major release change was ok, 2) in rocsparse the equivalent files are also part of rocsparse-clients-common so this follows that, and 3) it seems appropriate as the matrix downloading cmake script hipsparse_clientmatrices.cmake and the matrix converter hipsparse_mtx2csr could be useful for both the tests and benchmarks so making is a common package seems logical.