### PR TITLE
Propagate changelog changes that were in 6.3 branch back to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ Documentation for hipSPARSE is available at
 ### Added
 
 * Added build dependencies for CentOS/RHEL 9 in install script
-* Added `azurelinux` OS name for correcting gfortran dependency
 
 ### Changed
 
@@ -35,6 +34,10 @@ Documentation for hipSPARSE is available at
 ### Optimized
 
 * Improved the user documentation
+
+### Resolved issues
+
+* Fixed the gfortran dependency for the `azurelinux` operating system.
 
 ### Known issues
 


### PR DESCRIPTION
The changes exist in the 6.3 branch but not develop. This PR brings in those changes to develop. Because the changes did not exist in develop, they also dont exist in 6.4 however I have https://github.com/ROCm/hipSPARSE/pull/578/ bringing them into 6.4.