### PR TITLE
Fixing unchecked operation when grabbing version

### DIFF
--- a/clients/benchmarks/hipsparse_bench.cpp
+++ b/clients/benchmarks/hipsparse_bench.cpp
@@ -30,13 +30,39 @@ std::string hipsparse_get_version()
 {
     int  hipsparse_ver;
     char hipsparse_rev[64];
+
+    hipsparseStatus_t status;
+
+    hipsparseHandle_t handle;
+    status = hipsparseCreate(&handle);
+    if(HIPSPARSE_STATUS_SUCCESS != status)
     {
-        hipsparseHandle_t handle;
-        hipsparseCreate(&handle);
-        hipsparseGetVersion(handle, &hipsparse_ver);
-        hipsparseGetGitRevision(handle, hipsparse_rev);
-        hipsparseDestroy(handle);
+        std::cerr << "The creation of the hipsparseHandle_t failed." << std::endl;
+        throw(status);
     }
+    
+    status = hipsparseGetVersion(handle, &hipsparse_ver);
+    if(HIPSPARSE_STATUS_SUCCESS != status)
+    {
+        std::cerr << "hipsparseGetVersion failed." << std::endl;
+        throw(status);
+    }
+    
+    status = hipsparseGetGitRevision(handle, hipsparse_rev);
+    if(HIPSPARSE_STATUS_SUCCESS != status)
+    {
+        std::cerr << "hipsparseGetGitRevision failed." << std::endl;
+        throw(status);
+    }
+    
+    status = hipsparseDestroy(handle);
+
+    if(HIPSPARSE_STATUS_SUCCESS != status)
+      {
+        std::cerr << "rocsparse_destroy_handle failed." << std::endl;
+        throw(status);
+    }
+
     std::ostringstream os;
     os << hipsparse_ver / 100000 << "." << hipsparse_ver / 100 % 1000 << "." << hipsparse_ver % 100
        << "-" << hipsparse_rev;

--- a/clients/benchmarks/hipsparse_bench.cpp
+++ b/clients/benchmarks/hipsparse_bench.cpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
-* Copyright (C) 2024 Advanced Micro Devices, Inc. All rights Reserved.
+* Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights Reserved.
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -40,25 +40,25 @@ std::string hipsparse_get_version()
         std::cerr << "The creation of the hipsparseHandle_t failed." << std::endl;
         throw(status);
     }
-    
+
     status = hipsparseGetVersion(handle, &hipsparse_ver);
     if(HIPSPARSE_STATUS_SUCCESS != status)
     {
         std::cerr << "hipsparseGetVersion failed." << std::endl;
         throw(status);
     }
-    
+
     status = hipsparseGetGitRevision(handle, hipsparse_rev);
     if(HIPSPARSE_STATUS_SUCCESS != status)
     {
         std::cerr << "hipsparseGetGitRevision failed." << std::endl;
         throw(status);
     }
-    
+
     status = hipsparseDestroy(handle);
 
     if(HIPSPARSE_STATUS_SUCCESS != status)
-      {
+    {
         std::cerr << "rocsparse_destroy_handle failed." << std::endl;
         throw(status);
     }

--- a/clients/common/utility.cpp
+++ b/clients/common/utility.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2021 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -94,7 +94,6 @@ void query_version(char* version)
     int  hipsparse_ver;
     char hipsparse_rev[64];
 
-
     hipsparseStatus_t status;
 
     hipsparseHandle_t handle;
@@ -104,31 +103,35 @@ void query_version(char* version)
         std::cerr << "The creation of the hipsparseHandle_t failed." << std::endl;
         throw(status);
     }
-    
+
     status = hipsparseGetVersion(handle, &hipsparse_ver);
     if(HIPSPARSE_STATUS_SUCCESS != status)
     {
         std::cerr << "hipsparseGetVersion failed." << std::endl;
         throw(status);
     }
-    
+
     status = hipsparseGetGitRevision(handle, hipsparse_rev);
     if(HIPSPARSE_STATUS_SUCCESS != status)
     {
         std::cerr << "hipsparseGetGitRevision failed." << std::endl;
         throw(status);
     }
-    
+
     status = hipsparseDestroy(handle);
 
     if(HIPSPARSE_STATUS_SUCCESS != status)
-      {
+    {
         std::cerr << "rocsparse_destroy_handle failed." << std::endl;
         throw(status);
     }
 
-    sprintf(version, "v%d.%d.%d-%s", hipsparse_ver / 100000, hipsparse_ver / 100 % 1000, hipsparse_ver % 100, hipsparse_rev);
-
+    sprintf(version,
+            "v%d.%d.%d-%s",
+            hipsparse_ver / 100000,
+            hipsparse_ver / 100 % 1000,
+            hipsparse_ver % 100,
+            hipsparse_rev);
 }
 
 /* ============================================================================================ */

--- a/clients/common/utility.cpp
+++ b/clients/common/utility.cpp
@@ -91,18 +91,44 @@ extern "C" {
 /*  query for hipsparse version and git commit SHA-1. */
 void query_version(char* version)
 {
+    int  hipsparse_ver;
+    char hipsparse_rev[64];
+
+
+    hipsparseStatus_t status;
+
     hipsparseHandle_t handle;
-    hipsparseCreate(&handle);
+    status = hipsparseCreate(&handle);
+    if(HIPSPARSE_STATUS_SUCCESS != status)
+    {
+        std::cerr << "The creation of the hipsparseHandle_t failed." << std::endl;
+        throw(status);
+    }
+    
+    status = hipsparseGetVersion(handle, &hipsparse_ver);
+    if(HIPSPARSE_STATUS_SUCCESS != status)
+    {
+        std::cerr << "hipsparseGetVersion failed." << std::endl;
+        throw(status);
+    }
+    
+    status = hipsparseGetGitRevision(handle, hipsparse_rev);
+    if(HIPSPARSE_STATUS_SUCCESS != status)
+    {
+        std::cerr << "hipsparseGetGitRevision failed." << std::endl;
+        throw(status);
+    }
+    
+    status = hipsparseDestroy(handle);
 
-    int ver;
-    hipsparseGetVersion(handle, &ver);
+    if(HIPSPARSE_STATUS_SUCCESS != status)
+      {
+        std::cerr << "rocsparse_destroy_handle failed." << std::endl;
+        throw(status);
+    }
 
-    char rev[128];
-    hipsparseGetGitRevision(handle, rev);
+    sprintf(version, "v%d.%d.%d-%s", hipsparse_ver / 100000, hipsparse_ver / 100 % 1000, hipsparse_ver % 100, hipsparse_rev);
 
-    sprintf(version, "v%d.%d.%d-%s", ver / 100000, ver / 100 % 1000, ver % 100, rev);
-
-    hipsparseDestroy(handle);
 }
 
 /* ============================================================================================ */


### PR DESCRIPTION
Problem

A handle is created to grab the version of hipsparse at the very beginning of the main of hipsparse-bench and hipsparse-test.
The status of these hipsparse operations is not checked, meaning that if something goes wrong during the creation of the hipsparse_handle, for instance, no device is detected or the library does not support the hardware, then the program will crash with a segmentation fault.

See 
https://github.com/ROCm/hipSPARSE/issues/608