### PR TITLE
Build chain update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,8 +124,8 @@ endif()
 
 
 # Setup version
-rocm_setup_version(VERSION 3.3.0)
-set(hipsparse_SOVERSION 1.1.0)
+rocm_setup_version(VERSION 4.0.0)
+set(hipsparse_SOVERSION 4.0.0)
 
 # hipSPARSE library
 add_subdirectory(library)
@@ -173,14 +173,6 @@ if(BUILD_CLIENTS_SAMPLES OR BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS)
         RPM "${OPENMP_RPM}"
     )
   endif()
-  if(BUILD_CLIENTS_SAMPLES)
-    rocm_package_setup_client_component(
-      samples
-      DEPENDS
-        COMPONENT clients-common
-        DEB "${GFORTRAN_DEB}"
-        RPM "${GFORTRAN_RPM}")
-  endif()
 
   if( BUILD_CLIENTS_BENCHMARKS )
   rocm_package_setup_client_component(
@@ -197,8 +189,6 @@ if(BUILD_CLIENTS_SAMPLES OR BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS)
   if(NOT WIN32)
     rocm_package_add_rpm_dependencies(COMPONENT tests DEPENDS "${GFORTRAN_RPM}")
     rocm_package_add_deb_dependencies(COMPONENT tests DEPENDS "${GFORTRAN_DEB}")
-    rocm_package_add_rpm_dependencies(COMPONENT samples DEPENDS "${GFORTRAN_RPM}")
-    rocm_package_add_deb_dependencies(COMPONENT samples DEPENDS "${GFORTRAN_DEB}")
     rocm_package_add_rpm_dependencies(COMPONENT benchmarks DEPENDS "${GFORTRAN_RPM}")
     rocm_package_add_deb_dependencies(COMPONENT benchmarks DEPENDS "${GFORTRAN_DEB}")
   endif()

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2018-2020 Advanced Micro Devices, Inc. All rights Reserved.
+# Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -55,23 +55,26 @@ else()
 endif()
 
 # ROCm cmake package
-find_package(ROCM 0.7.3 QUIET CONFIG PATHS ${CMAKE_PREFIX_PATH})
-if(NOT ROCM_FOUND)
-  set(PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern)
-  set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
-  file(DOWNLOAD https://github.com/ROCm/rocm-cmake/archive/${rocm_cmake_tag}.zip
-       ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip STATUS status LOG log)
+find_package(ROCmCMakeBuildTools 0.11.0 QUIET CONFIG PATHS ${CMAKE_PREFIX_PATH})
+if(NOT ROCmCMakeBuildTools_FOUND)
+  find_package(ROCM 0.11.0 QUIET CONFIG PATHS ${CMAKE_PREFIX_PATH}) # deprecated fallback
+  if(NOT ROCM_FOUND)
+    set(PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern)
+    set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
+    file(DOWNLOAD https://github.com/ROCm/rocm-cmake/archive/${rocm_cmake_tag}.zip
+         ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip STATUS status LOG log)
 
-  list(GET status 0 status_code)
-  list(GET status 1 status_string)
+    list(GET status 0 status_code)
+    list(GET status 1 status_string)
 
-  if(NOT status_code EQUAL 0)
-    message(FATAL_ERROR "error: downloading
-    'https://github.com/ROCm/rocm-cmake/archive/${rocm_cmake_tag}.zip' failed
-    status_code: ${status_code}
-    status_string: ${status_string}
-    log: ${log}
-    ")
+    if(NOT status_code EQUAL 0)
+      message(FATAL_ERROR "error: downloading
+      'https://github.com/ROCm/rocm-cmake/archive/${rocm_cmake_tag}.zip' failed
+      status_code: ${status_code}
+      status_string: ${status_string}
+      log: ${log}
+      ")
+    endif()
   endif()
 
   execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
@@ -81,7 +84,7 @@ if(NOT ROCM_FOUND)
   execute_process( COMMAND ${CMAKE_COMMAND} --build rocm-cmake-${rocm_cmake_tag} --target install
                   WORKING_DIRECTORY ${PROJECT_EXTERN_DIR})
 
-  find_package( ROCM 0.7.3 REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR}/rocm-cmake )
+  find_package(ROCmCMakeBuildTools 0.11.0 REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR}/rocm-cmake )
 endif()
 
 include(ROCMSetupVersion)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -23,6 +23,8 @@
 
 # Dependencies
 
+include(FetchContent)
+
 if( NOT DEFINED ENV{HIP_PATH})
     if(WIN32)
         set( HIP_PATH "C:/hip" )
@@ -57,34 +59,20 @@ endif()
 # ROCm cmake package
 find_package(ROCmCMakeBuildTools 0.11.0 QUIET CONFIG PATHS ${CMAKE_PREFIX_PATH})
 if(NOT ROCmCMakeBuildTools_FOUND)
-  find_package(ROCM 0.11.0 QUIET CONFIG PATHS ${CMAKE_PREFIX_PATH}) # deprecated fallback
+  find_package(ROCM 0.7.3 QUIET CONFIG PATHS ${CMAKE_PREFIX_PATH}) # deprecated fallback
   if(NOT ROCM_FOUND)
+    message(STATUS "ROCmCMakeBuildTools not found. Fetching...")
     set(PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern)
-    set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
-    file(DOWNLOAD https://github.com/ROCm/rocm-cmake/archive/${rocm_cmake_tag}.zip
-         ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip STATUS status LOG log)
-
-    list(GET status 0 status_code)
-    list(GET status 1 status_string)
-
-    if(NOT status_code EQUAL 0)
-      message(FATAL_ERROR "error: downloading
-      'https://github.com/ROCm/rocm-cmake/archive/${rocm_cmake_tag}.zip' failed
-      status_code: ${status_code}
-      status_string: ${status_string}
-      log: ${log}
-      ")
-    endif()
+    set(rocm_cmake_tag "rocm-6.4.0" CACHE STRING "rocm-cmake tag to download")
+    FetchContent_Declare(
+      rocm-cmake
+      GIT_REPOSITORY https://github.com/ROCm/rocm-cmake.git
+      GIT_TAG ${rocm_cmake_tag}
+      SOURCE_SUBDIR "DISABLE ADDING TO BUILD"
+    )
+    FetchContent_MakeAvailable(rocm-cmake)
+    find_package(ROCmCMakeBuildTools CONFIG REQUIRED NO_DEFAULT_PATH PATHS "${rocm-cmake_SOURCE_DIR}")
   endif()
-
-  execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
-                  WORKING_DIRECTORY ${PROJECT_EXTERN_DIR})
-  execute_process( COMMAND ${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=${PROJECT_EXTERN_DIR}/rocm-cmake .
-                  WORKING_DIRECTORY ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag} )
-  execute_process( COMMAND ${CMAKE_COMMAND} --build rocm-cmake-${rocm_cmake_tag} --target install
-                  WORKING_DIRECTORY ${PROJECT_EXTERN_DIR})
-
-  find_package(ROCmCMakeBuildTools 0.11.0 REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR}/rocm-cmake )
 endif()
 
 include(ROCMSetupVersion)


### PR DESCRIPTION
- Removed empty samples package `hipsparse-samples`
- VERSION and SOVERSION major bump for 7.0
- Replaced ROCM package with ROCmCMakeBuildTools