### PR TITLE
Add missing chrono header

### DIFF
--- a/clients/benchmarks/hipsparse_bench_app.cpp
+++ b/clients/benchmarks/hipsparse_bench_app.cpp
@@ -25,6 +25,7 @@
 #include "hipsparse_bench_app.hpp"
 #include "hipsparse_bench.hpp"
 
+#include <chrono>
 #include <fstream>
 #include <random>
 


### PR DESCRIPTION
hipsparse_bench_app.cpp uses std::chrono without importing it and fails to build with Microsoft's runtime library.