### PR TITLE
Docs: Part 2 of the hipSPARSE documentation refresh

### DIFF
--- a/docs/howto/using-hipsparse.rst
+++ b/docs/howto/using-hipsparse.rst
@@ -1,6 +1,6 @@
 .. meta::
-  :description: rocSPARSE documentation and API reference library
-  :keywords: rocSPARSE, ROCm, API, documentation
+  :description: rocSPARSE usage guide and documentation
+  :keywords: rocSPARSE, ROCm, API, documentation, usage guide, device management, stream management, storage format, pointer mode
 
 .. _hipsparse-docs:
 
@@ -8,58 +8,109 @@
 Using hipSPARSE
 ********************************************************************
 
-HIP Device Management
+This topic discusses how to use hipSPARSE, including a discussion of device and stream
+management, storage formats, and pointer mode.
+
+HIP device management
 =====================
 
-Before starting a HIP kernel you can call :cpp:func:`hipSetDevice` to set a device. If you do not call the function, the system uses the default device. Unless you explicitly call :cpp:func:`hipSetDevice` to specify another device, HIP kernels are always launched on device 0.
-This is a HIP (and CUDA) device management approach and is not specific to the hipSPARSE library. hipSPARSE honors this approach and assumes you have already set the preferred device before a hipSPARSE routine call.
+Before starting a HIP kernel, you can call :cpp:func:`hipSetDevice` to set a device.
+If you do not call the function, the system uses the default device. Unless you explicitly
+call :cpp:func:`hipSetDevice` to specify another device, HIP kernels are always launched on device ``0``.
+This is a HIP (and CUDA) device management approach and is not specific to the hipSPARSE library.
+hipSPARSE honors this approach and assumes you have already set the preferred device before a hipSPARSE routine call.
 
-Once you set the device, you can create a handle with :ref:`hipsparse_create_handle_`.
-Subsequent hipSPARSE routines take this handle as an input parameter. hipSPARSE ONLY queries (by :cpp:func:`hipGetDevice`) the specified device. If hipSPARSE does not see a valid device, it returns an error message. It is you responsibility to provide a valid device to hipSPARSE and ensure the device safety.
+After you set the device, you can create a handle with :ref:`hipsparse_create_handle_`.
+Subsequent hipSPARSE routines take this handle as an input parameter.
+hipSPARSE only queries the specified device (using :cpp:func:`hipGetDevice`).
+It is your responsibility to provide a valid device to hipSPARSE and ensure device safety.
+If it's not a valid device, hipSPARSE returns an error message.
 
-If you want to change device, you must destroy the current handle using :ref:`hipsparse_destroy_handle_`, and create another handle using :ref:`hipsparse_create_handle_` specifying another device.
+To change to another device, you must destroy the current handle using :ref:`hipsparse_destroy_handle_`,
+then create another handle using :ref:`hipsparse_create_handle_`, specifying another device.
 
 .. note::
-  :cpp:func:`hipSetDevice` and :cpp:func:`hipGetDevice` are NOT part of the hipSPARSE API. They are part of the `HIP Runtime API - Device Management <https://rocm.docs.amd.com/projects/HIP/en/latest/doxygen/html/group___device.html>`_.
 
-HIP Stream Management
+   :cpp:func:`hipSetDevice` and :cpp:func:`hipGetDevice` are not part of the hipSPARSE API.
+   They are part of the `HIP runtime API for device management <https://rocm.docs.amd.com/projects/HIP/en/latest/doxygen/html/group___device.html>`_.
+
+HIP stream management
 =====================
 
-HIP kernels are always launched in a queue (also known as stream). If you do not explicitly specify a stream, the system provides and maintains a default stream. You cannot create or destroy the default stream. However, you can freely create new streams (with :cpp:func:`hipStreamCreate`) and bind it to the hipSPARSE handle using :ref:`hipsparse_set_stream_`. HIP kernels are invoked in hipSPARSE routines. The hipSPARSE handle is always associated with a stream, and hipSPARSE passes its stream to the kernels inside the routine. One hipSPARSE routine only takes one stream in a single invocation. If you create a stream, you are responsible for destroying it. Refer to `HIP Runtime API - Stream Management <https://rocm.docs.amd.com/projects/HIP/en/latest/doxygen/html/group___stream.html>`_ for more information. 
+HIP kernels are always launched in a queue (also known as stream). If you do not explicitly specify a stream,
+the system provides and maintains a default stream, which you cannot create or destroy.
+However, you can freely create new streams (using :cpp:func:`hipStreamCreate`) and bind them to the
+hipSPARSE handle using :ref:`hipsparse_set_stream_`. The hipSPARSE routines invoke HIP kernels.
+A hipSPARSE handle is always associated with a stream, which hipSPARSE passes to the kernels inside the routine.
+One hipSPARSE routine only takes one stream in a single invocation.
+If you create a stream, you are responsible for destroying it.
+See the `HIP stream management API <https://rocm.docs.amd.com/projects/HIP/en/latest/doxygen/html/group___stream.html>`_ for more information. 
 
-Asynchronous Execution
+Asynchronous execution
 ======================
 
-Except functions having memory allocation inside preventing asynchronicity, all hipSPARSE library functions are non-blocking and executed asynchronously with respect to the host, unless otherwise stated. The function may return before the actual computation has finished. To force synchronization, use either :cpp:func:`hipDeviceSynchronize` or :cpp:func:`hipStreamSynchronize`. This will ensure that all previously executed hipSPARSE functions on the device, or in the particular stream, have completed.
+Except for functions which allocate memory themselves, preventing asynchronicity,
+all hipSPARSE library functions are non-blocking and execute asynchronously with respect to the host,
+unless otherwise stated. These functions might return before the actual computation has finished.
+To force synchronization, use either :cpp:func:`hipDeviceSynchronize` or :cpp:func:`hipStreamSynchronize`.
+This ensures that all previously executed hipSPARSE functions on the device or in the stream have completed.
 
-Multiple Streams and Multiple Devices
+Multiple streams and multiple devices
 =====================================
 
-If a system has multiple HIP devices, you can run multiple hipSPARSE handles concurrently. However, you can NOT run a single hipSPARSE handle on different discrete devices. Each handle is associated with a particular single device, and a new handle should be created for each additional device.
+If a system has multiple HIP devices, you can run multiple hipSPARSE handles concurrently.
+However, you cannot run a single hipSPARSE handle on different discrete devices
+because each handle is associated with a particular device. A new handle must be created for each additional device.
 
-Storage Formats
+Interface examples
+=====================================
+
+The hipSPARSE interface is compatible with the :doc:`rocSPARSE <rocsparse:index>` and NVIDIA CUDA cuSPARSE-v2 APIs.
+Porting a CUDA application that calls the CUDA cuSPARSE API to an application that calls the hipSPARSE API
+is relatively straightforward. For example, the hipSPARSE SCSRMV API interface is as follows:
+
+.. code-block:: cpp
+
+   hipsparseStatus_t
+   hipsparseScsrmv(hipsparseHandle_t handle,
+                  hipsparseOperation_t transA,
+                  int m, int n, int nnz, const float *alpha,
+                  const hipsparseMatDescr_t descrA,
+                  const float *csrValA,
+                  const int *csrRowPtrA, const int *csrColIndA,
+                  const float *x, const float *beta,
+                  float *y);
+
+hipSPARSE assumes matrix ``A`` and vectors ``x`` and ``y`` are allocated in the GPU memory space and filled with data.
+You are responsible for copying data to and from the host and device memory.
+
+Storage formats
 ===============
 
-The following describes supported matrix storage formats.  
+This section describes the supported matrix storage formats.  
 
 .. note::
-    The different storage formats support indexing from a base of 0 or 1 as described in :ref:`index_base`. 
+
+   The different storage formats support indexing with a base of 0 or 1, as described in :ref:`index_base`. 
 
 COO storage format
 ------------------
-The Coordinate (COO) storage format represents a :math:`m \times n` matrix by
+
+The Coordinate (COO) storage format represents an :math:`m \times n` matrix by:
 
 =========== ==================================================================
-m           number of rows (integer).
-n           number of columns (integer).
-nnz         number of non-zero elements (integer).
-coo_val     array of ``nnz`` elements containing the data (floating point).
-coo_row_ind array of ``nnz`` elements containing the row indices (integer).
-coo_col_ind array of ``nnz`` elements containing the column indices (integer).
+m           Number of rows (integer).
+n           Number of columns (integer).
+nnz         Number of non-zero elements (integer).
+coo_val     Array of ``nnz`` elements containing the data (floating point).
+coo_row_ind Array of ``nnz`` elements containing the row indices (integer).
+coo_col_ind Array of ``nnz`` elements containing the column indices (integer).
 =========== ==================================================================
 
-The COO matrix is expected to be sorted by row indices and column indices per row. Furthermore, each pair of indices should appear only once.
-Consider the following :math:`3 \times 5` matrix and the corresponding COO structures, with :math:`m = 3, n = 5` and :math:`\text{nnz} = 8` using zero based indexing:
+The COO matrix is expected to be sorted by row indices and column indices per row.
+Furthermore, each pair of indices should appear only once.
+Consider the following :math:`3 \times 5` matrix and the corresponding COO structures,
+with :math:`m = 3, n = 5` and :math:`\text{nnz} = 8` using zero-based indexing:
 
 .. math::
 
@@ -81,18 +132,21 @@ where
 
 COO (AoS) storage format
 ------------------------
-The Coordinate (COO) Array of Structure (AoS) storage format represents a :math:`m \times n` matrix by
+
+The Coordinate (COO) Array of Structure (AoS) storage format represents an :math:`m \times n` matrix by:
 
 ======= ==========================================================================================
-m           number of rows (integer).
-n           number of columns (integer).
-nnz         number of non-zero elements (integer).
-coo_val     array of ``nnz`` elements containing the data (floating point).
-coo_ind     array of ``2 * nnz`` elements containing alternating row and column indices (integer).
+m           Number of rows (integer).
+n           Number of columns (integer).
+nnz         Number of non-zero elements (integer).
+coo_val     Array of ``nnz`` elements containing the data (floating point).
+coo_ind     Array of ``2 * nnz`` elements containing alternating row and column indices (integer).
 ======= ==========================================================================================
 
-The COO (AoS) matrix is expected to be sorted by row indices and column indices per row. Furthermore, each pair of indices should appear only once.
-Consider the following :math:`3 \times 5` matrix and the corresponding COO (AoS) structures, with :math:`m = 3, n = 5` and :math:`\text{nnz} = 8` using zero based indexing:
+The COO (AoS) matrix is expected to be sorted by row indices and column indices per row.
+Furthermore, each pair of indices should appear only once.
+Consider the following :math:`3 \times 5` matrix and the corresponding COO (AoS) structures,
+with :math:`m = 3, n = 5` and :math:`\text{nnz} = 8` using zero-based indexing:
 
 .. math::
 
@@ -113,19 +167,22 @@ where
 
 CSR storage format
 ------------------
-The Compressed Sparse Row (CSR) storage format represents a :math:`m \times n` matrix by
+
+The Compressed Sparse Row (CSR) storage format represents an :math:`m \times n` matrix by:
 
 =========== =========================================================================
-m           number of rows (integer).
-n           number of columns (integer).
-nnz         number of non-zero elements (integer).
-csr_val     array of ``nnz`` elements containing the data (floating point).
-csr_row_ptr array of ``m+1`` elements that point to the start of every row (integer).
-csr_col_ind array of ``nnz`` elements containing the column indices (integer).
+m           Number of rows (integer).
+n           Number of columns (integer).
+nnz         Number of non-zero elements (integer).
+csr_val     Array of ``nnz`` elements containing the data (floating point).
+csr_row_ptr Array of ``m+1`` elements that point to the start of every row (integer).
+csr_col_ind Array of ``nnz`` elements containing the column indices (integer).
 =========== =========================================================================
 
-The CSR matrix is expected to be sorted by column indices within each row. Furthermore, each pair of indices should appear only once.
-Consider the following :math:`3 \times 5` matrix and the corresponding CSR structures, with :math:`m = 3, n = 5` and :math:`\text{nnz} = 8` using one based indexing:
+The CSR matrix is expected to be sorted by column indices within each row.
+Furthermore, each pair of indices should appear only once.
+Consider the following :math:`3 \times 5` matrix and the corresponding CSR structures,
+with :math:`m = 3, n = 5` and :math:`\text{nnz} = 8` using one-based indexing:
 
 .. math::
 
@@ -147,19 +204,22 @@ where
 
 CSC storage format
 ------------------
-The Compressed Sparse Column (CSC) storage format represents a :math:`m \times n` matrix by
+
+The Compressed Sparse Column (CSC) storage format represents an :math:`m \times n` matrix by:
 
 =========== =========================================================================
-m           number of rows (integer).
-n           number of columns (integer).
-nnz         number of non-zero elements (integer).
-csc_val     array of ``nnz`` elements containing the data (floating point).
-csc_col_ptr array of ``n+1`` elements that point to the start of every column (integer).
-csc_row_ind array of ``nnz`` elements containing the row indices (integer).
+m           Number of rows (integer).
+n           Number of columns (integer).
+nnz         Number of non-zero elements (integer).
+csc_val     Array of ``nnz`` elements containing the data (floating point).
+csc_col_ptr Array of ``n+1`` elements that point to the start of every column (integer).
+csc_row_ind Array of ``nnz`` elements containing the row indices (integer).
 =========== =========================================================================
 
-The CSC matrix is expected to be sorted by row indices within each column. Furthermore, each pair of indices should appear only once.
-Consider the following :math:`3 \times 5` matrix and the corresponding CSC structures, with :math:`m = 3, n = 5` and :math:`\text{nnz} = 8` using one based indexing:
+The CSC matrix is expected to be sorted by row indices within each column.
+Furthermore, each pair of indices should appear only once.
+Consider the following :math:`3 \times 5` matrix and the corresponding CSC structures,
+with :math:`m = 3, n = 5` and :math:`\text{nnz} = 8` using one-based indexing:
 
 .. math::
 
@@ -181,20 +241,24 @@ where
 
 BSR storage format
 ------------------
-The Block Compressed Sparse Row (BSR) storage format represents a :math:`(mb \cdot \text{bsr_dim}) \times (nb \cdot \text{bsr_dim})` matrix by
 
-=========== ====================================================================================================================================
-mb          number of block rows (integer)
-nb          number of block columns (integer)
-nnzb        number of non-zero blocks (integer)
-bsr_val     array of ``nnzb * bsr_dim * bsr_dim`` elements containing the data (floating point). Blocks can be stored column-major or row-major.
-bsr_row_ptr array of ``mb+1`` elements that point to the start of every block row (integer).
-bsr_col_ind array of ``nnzb`` elements containing the block column indices (integer).
-bsr_dim     dimension of each block (integer).
-=========== ====================================================================================================================================
+The Block Compressed Sparse Row (BSR) storage format represents an :math:`(mb \cdot \text{bsr_dim}) \times (nb \cdot \text{bsr_dim})` matrix by:
 
-The BSR matrix is expected to be sorted by column indices within each row. If :math:`m` or :math:`n` are not evenly divisible by the block dimension, then zeros are padded to the matrix, such that :math:`mb = (m + \text{bsr_dim} - 1) / \text{bsr_dim}` and :math:`nb = (n + \text{bsr_dim} - 1) / \text{bsr_dim}`.
-Consider the following :math:`4 \times 3` matrix and the corresponding BSR structures, with :math:`\text{bsr_dim} = 2, mb = 2, nb = 2` and :math:`\text{nnzb} = 4` using zero based indexing and column-major storage:
+=========== ==============================================================================================================================================
+mb          Number of block rows (integer).
+nb          Number of block columns (integer).
+nnzb        Number of non-zero blocks (integer).
+bsr_val     Array of ``nnzb * bsr_dim * bsr_dim`` elements containing the data (floating point). Blocks can be stored in column-major or row-major format.
+bsr_row_ptr Array of ``mb+1`` elements that point to the start of every block row (integer).
+bsr_col_ind Array of ``nnzb`` elements containing the block column indices (integer).
+bsr_dim     Dimension of each block (integer).
+=========== ==============================================================================================================================================
+
+The BSR matrix is expected to be sorted by column indices within each row.
+If :math:`m` or :math:`n` are not evenly divisible by the block dimension, then zeros are padded to the matrix,
+such that :math:`mb = (m + \text{bsr_dim} - 1) / \text{bsr_dim}` and :math:`nb = (n + \text{bsr_dim} - 1) / \text{bsr_dim}`.
+Consider the following :math:`4 \times 3` matrix and the corresponding BSR structures,
+with :math:`\text{bsr_dim} = 2, mb = 2, nb = 2` and :math:`\text{nnzb} = 4` using zero-based indexing and column-major storage:
 
 .. math::
 
@@ -235,7 +299,7 @@ such that
         A_{10} & A_{11} \\
       \end{pmatrix}
 
-with arrays representation
+with arrays represented as
 
 .. math::
 
@@ -247,23 +311,28 @@ with arrays representation
 
 GEBSR storage format
 --------------------
-The General Block Compressed Sparse Row (GEBSR) storage format represents a :math:`(mb \cdot \text{bsr_row_dim}) \times (nb \cdot \text{bsr_col_dim})` matrix by
 
-=========== ====================================================================================================================================
-mb          number of block rows (integer)
-nb          number of block columns (integer)
-nnzb        number of non-zero blocks (integer)
-bsr_val     array of ``nnzb * bsr_row_dim * bsr_col_dim`` elements containing the data (floating point). Blocks can be stored column-major or row-major.
-bsr_row_ptr array of ``mb+1`` elements that point to the start of every block row (integer).
-bsr_col_ind array of ``nnzb`` elements containing the block column indices (integer).
-bsr_row_dim row dimension of each block (integer).
-bsr_col_dim column dimension of each block (integer).
-=========== ====================================================================================================================================
+The General Block Compressed Sparse Row (GEBSR) storage format represents an :math:`(mb \cdot \text{bsr_row_dim}) \times (nb \cdot \text{bsr_col_dim})` matrix by:
 
-The GEBSR matrix is expected to be sorted by column indices within each row. If :math:`m` is not evenly divisible by the row block dimension or :math:`n` is not evenly
-divisible by the column block dimension, then zeros are padded to the matrix, such that :math:`mb = (m + \text{bsr_row_dim} - 1) / \text{bsr_row_dim}` and
-:math:`nb = (n + \text{bsr_col_dim} - 1) / \text{bsr_col_dim}`. Consider the following :math:`4 \times 5` matrix and the corresponding GEBSR structures,
-with :math:`\text{bsr_row_dim} = 2`, :math:`\text{bsr_col_dim} = 3`, mb = 2, nb = 2` and :math:`\text{nnzb} = 4` using zero based indexing and column-major storage:
+=========== ======================================================================================================================================================
+mb          Number of block rows (integer).
+nb          Number of block columns (integer).
+nnzb        Number of non-zero blocks (integer).
+bsr_val     Array of ``nnzb * bsr_row_dim * bsr_col_dim`` elements containing the data (floating point). Blocks can be stored in column-major or row-major format.
+bsr_row_ptr Array of ``mb+1`` elements that point to the start of every block row (integer).
+bsr_col_ind Array of ``nnzb`` elements containing the block column indices (integer).
+bsr_row_dim Row dimension of each block (integer).
+bsr_col_dim Column dimension of each block (integer).
+=========== ======================================================================================================================================================
+
+The GEBSR matrix is expected to be sorted by column indices within each row.
+If :math:`m` is not evenly divisible by the row block dimension or :math:`n` is not evenly
+divisible by the column block dimension, then zeros are padded to the matrix,
+such that :math:`mb = (m + \text{bsr_row_dim} - 1) / \text{bsr_row_dim}` and
+:math:`nb = (n + \text{bsr_col_dim} - 1) / \text{bsr_col_dim}`. Consider the following :math:`4 \times 5` matrix
+and the corresponding GEBSR structures,
+with :math:`\text{bsr_row_dim} = 2`, :math:`\text{bsr_col_dim} = 3`, :math:`mb = 2`, :math:`nb = 2`, and :math:`\text{nnzb} = 4`
+using zero-based indexing and column-major storage:
 
 .. math::
 
@@ -304,7 +373,7 @@ such that
         A_{10} & A_{11} \\
       \end{pmatrix}
 
-with arrays representation
+with arrays represented as
 
 .. math::
 
@@ -316,18 +385,21 @@ with arrays representation
 
 ELL storage format
 ------------------
-The Ellpack-Itpack (ELL) storage format represents a :math:`m \times n` matrix by
+
+The Ellpack-Itpack (ELL) storage format represents an :math:`m \times n` matrix by:
 
 =========== ================================================================================
-m           number of rows (integer).
-n           number of columns (integer).
-ell_width   maximum number of non-zero elements per row (integer)
-ell_val     array of ``m times ell_width`` elements containing the data (floating point).
-ell_col_ind array of ``m times ell_width`` elements containing the column indices (integer).
+m           Number of rows (integer).
+n           Number of columns (integer).
+ell_width   Maximum number of non-zero elements per row (integer)
+ell_val     Array of ``m * ell_width`` elements containing the data (floating point).
+ell_col_ind Array of ``m * ell_width`` elements containing the column indices (integer).
 =========== ================================================================================
 
-The ELL matrix is assumed to be stored in column-major format. Rows with less than ``ell_width`` non-zero elements are padded with zeros (``ell_val``) and :math:`-1` (``ell_col_ind``).
-Consider the following :math:`3 \times 5` matrix and the corresponding ELL structures, with :math:`m = 3, n = 5` and :math:`\text{ell_width} = 3` using zero based indexing:
+The ELL matrix is assumed to be stored in column-major format.
+Rows with less than ``ell_width`` non-zero elements are padded with zeros (``ell_val``) and :math:`-1` (``ell_col_ind``).
+Consider the following :math:`3 \times 5` matrix and the corresponding ELL structures,
+with :math:`m = 3, n = 5`, and :math:`\text{ell_width} = 3` using zero-based indexing:
 
 .. math::
 
@@ -350,47 +422,64 @@ where
 
 HYB storage format
 ------------------
-The Hybrid (HYB) storage format represents a :math:`m \times n` matrix by
+
+The Hybrid (HYB) storage format represents an :math:`m \times n` matrix by:
 
 =========== =========================================================================================
-m           number of rows (integer).
-n           number of columns (integer).
-nnz         number of non-zero elements of the COO part (integer)
-ell_width   maximum number of non-zero elements per row of the ELL part (integer)
-ell_val     array of ``m times ell_width`` elements containing the ELL part data (floating point).
-ell_col_ind array of ``m times ell_width`` elements containing the ELL part column indices (integer).
-coo_val     array of ``nnz`` elements containing the COO part data (floating point).
-coo_row_ind array of ``nnz`` elements containing the COO part row indices (integer).
-coo_col_ind array of ``nnz`` elements containing the COO part column indices (integer).
+m           Number of rows (integer).
+n           Number of columns (integer).
+nnz         Number of non-zero elements of the COO part (integer).
+ell_width   Maximum number of non-zero elements per row of the ELL part (integer).
+ell_val     Array of ``m * ell_width`` elements containing the ELL-part data (floating point).
+ell_col_ind Array of ``m * ell_width`` elements containing the ELL-part column indices (integer).
+coo_val     Array of ``nnz`` elements containing the COO-part data (floating point).
+coo_row_ind Array of ``nnz`` elements containing the COO-part row indices (integer).
+coo_col_ind Array of ``nnz`` elements containing the COO-part column indices (integer).
 =========== =========================================================================================
 
-The HYB format is a combination of the ELL and COO sparse matrix formats. Typically, the regular part of the matrix is stored in ELL storage format, and the irregular part of the matrix is stored in COO storage format. Three different partitioning schemes can be applied when converting a CSR matrix to a matrix in HYB storage format. For further details on the partitioning schemes, see :ref:`hipsparse_hyb_partition_`.
+The HYB format is a combination of the ELL and COO sparse matrix formats.
+Typically, the regular part of the matrix is stored in ELL storage format and the irregular part
+of the matrix is stored in COO storage format. Three different partitioning schemes can be applied when
+converting a CSR matrix to a matrix in HYB storage format. For further details on the partitioning schemes,
+see :ref:`hipsparse_hyb_partition_`.
 
 .. _index_base:
 
 Storage schemes and indexing base
 =================================
-hipSPARSE supports 0 and 1 based indexing.
-The index base is selected by the :cpp:enum:`hipsparseIndexBase_t` type which is either passed as standalone parameter or as part of the :cpp:type:`hipsparseMatDescr_t` type.
 
-Furthermore, dense vectors are represented with a 1D array, stored linearly in memory.
-Sparse vectors are represented by a 1D data array stored linearly in memory that hold all non-zero elements and a 1D indexing array stored linearly in memory that hold the positions of the corresponding non-zero elements.
+hipSPARSE supports 0-based and 1-based indexing.
+The index base is selected by the :cpp:enum:`hipsparseIndexBase_t` type, which is either passed
+as a standalone parameter or as part of the :cpp:type:`hipsparseMatDescr_t` type.
+
+Dense vectors are represented with a 1D array, stored linearly in memory.
+Sparse vectors are represented by a 1D data array stored linearly in memory that holds all non-zero elements
+and a 1D indexing array stored linearly in memory that holds the positions of the corresponding non-zero elements.
 
 Pointer mode
 ============
-The auxiliary functions :cpp:func:`hipsparseSetPointerMode` and :cpp:func:`hipsparseGetPointerMode` are used to set and get the value of the state variable :cpp:enum:`hipsparsePointerMode_t`.
-If :cpp:enum:`hipsparsePointerMode_t` is equal to :cpp:enumerator:`HIPSPARSE_POINTER_MODE_HOST`, then scalar parameters must be allocated on the host.
-If :cpp:enum:`hipsparsePointerMode_t` is equal to :cpp:enumerator:`HIPSPARSE_POINTER_MODE_DEVICE`, then scalar parameters must be allocated on the device.
+
+The auxiliary functions :cpp:func:`hipsparseSetPointerMode` and :cpp:func:`hipsparseGetPointerMode` are
+used to set and get the value of the state variable :cpp:enum:`hipsparsePointerMode_t`.
+If :cpp:enum:`hipsparsePointerMode_t` is equal to :cpp:enumerator:`HIPSPARSE_POINTER_MODE_HOST`,
+then scalar parameters must be allocated on the host.
+If :cpp:enum:`hipsparsePointerMode_t` is equal to :cpp:enumerator:`HIPSPARSE_POINTER_MODE_DEVICE`,
+then scalar parameters must be allocated on the device.
 
 There are two types of scalar parameter:
 
-  1. Scaling parameters, such as `alpha` and `beta` used for example in :cpp:func:`hipsparseScsrmv` and :cpp:func:`hipsparseSbsrmv`
-  2. Scalar results from functions such as :cpp:func:`hipsparseSdoti` or :cpp:func:`hipsparseCdotci` 
+#. Scaling parameters, such as ``alpha`` and ``beta``, that are used, for example, in :cpp:func:`hipsparseScsrmv` and :cpp:func:`hipsparseSbsrmv`
+#. Scalar results from functions such as :cpp:func:`hipsparseSdoti` or :cpp:func:`hipsparseCdotci` 
 
-For scalar parameters such as alpha and beta, memory can be allocated on the host heap or stack, when :cpp:enum:`hipsparsePointerMode_t` is equal to :cpp:enumerator:`HIPSPARSE_POINTER_MODE_HOST`.
-The kernel launch is asynchronous, and if the scalar parameter is on the heap, it can be freed after the return from the kernel launch.
-When :cpp:enum:`hipsparsePointerMode_t` is equal to :cpp:enumerator:`HIPSPARSE_POINTER_MODE_DEVICE`, the scalar parameter must not be changed till the kernel completes.
+For scalar parameters such as ``alpha`` and ``beta``, memory can be allocated on the host heap or stack
+when :cpp:enum:`hipsparsePointerMode_t` is equal to :cpp:enumerator:`HIPSPARSE_POINTER_MODE_HOST`.
+The kernel launch is asynchronous, and if the scalar parameter is on the heap, it can be freed after
+the return from the kernel launch.
+When :cpp:enum:`hipsparsePointerMode_t` is equal to :cpp:enumerator:`HIPSPARSE_POINTER_MODE_DEVICE`,
+the scalar parameter must not be changed until the kernel completes.
 
-For scalar results, when :cpp:enum:`hipsparsePointerMode_t` is equal to :cpp:enumerator:`HIPSPARSE_POINTER_MODE_HOST`, the function blocks the CPU till the GPU has copied the result back to the host.
-Using :cpp:enum:`hipsparsePointerMode_t` equal to :cpp:enumerator:`HIPSPARSE_POINTER_MODE_DEVICE`, the function will return after the asynchronous launch.
-Similarly to vector and matrix results, the scalar result is only available when the kernel has completed execution.
+For scalar results, when :cpp:enum:`hipsparsePointerMode_t` is equal to :cpp:enumerator:`HIPSPARSE_POINTER_MODE_HOST`,
+the function blocks the CPU until the GPU has copied the result back to the host.
+When :cpp:enum:`hipsparsePointerMode_t` is equal to :cpp:enumerator:`HIPSPARSE_POINTER_MODE_DEVICE`,
+the function returns after the asynchronous launch.
+Similar to the vector and matrix results, the scalar result is only available when the kernel has completed execution.

--- a/docs/howto/using-hipsparse.rst
+++ b/docs/howto/using-hipsparse.rst
@@ -15,15 +15,15 @@ HIP device management
 =====================
 
 Before starting a HIP kernel, you can call :cpp:func:`hipSetDevice` to set a device.
-If you do not call the function, the system uses the default device. Unless you explicitly
+The system uses the default device if you don't call the function. Unless you explicitly
 call :cpp:func:`hipSetDevice` to specify another device, HIP kernels are always launched on device ``0``.
-This is a HIP (and CUDA) device management approach and is not specific to the hipSPARSE library.
+This HIP (and CUDA) device management approach is not specific to the hipSPARSE library.
 hipSPARSE honors this approach and assumes you have already set the preferred device before a hipSPARSE routine call.
 
 After you set the device, you can create a handle with :ref:`hipsparse_create_handle_`.
 Subsequent hipSPARSE routines take this handle as an input parameter.
 hipSPARSE only queries the specified device (using :cpp:func:`hipGetDevice`).
-It is your responsibility to provide a valid device to hipSPARSE and ensure device safety.
+You are responsible for providing a valid device to hipSPARSE and ensuring device safety.
 If it's not a valid device, hipSPARSE returns an error message.
 
 To change to another device, you must destroy the current handle using :ref:`hipsparse_destroy_handle_`,
@@ -37,7 +37,7 @@ then create another handle using :ref:`hipsparse_create_handle_`, specifying ano
 HIP stream management
 =====================
 
-HIP kernels are always launched in a queue (also known as stream). If you do not explicitly specify a stream,
+HIP kernels are always launched in a queue (also known as a stream). If you don't explicitly specify a stream,
 the system provides and maintains a default stream, which you cannot create or destroy.
 However, you can freely create new streams (using :cpp:func:`hipStreamCreate`) and bind them to the
 hipSPARSE handle using :ref:`hipsparse_set_stream_`. The hipSPARSE routines invoke HIP kernels.
@@ -49,11 +49,11 @@ See the `HIP stream management API <https://rocm.docs.amd.com/projects/HIP/en/la
 Asynchronous execution
 ======================
 
-Except for functions which allocate memory themselves, preventing asynchronicity,
+Except for functions that allocate memory themselves, preventing asynchronicity,
 all hipSPARSE library functions are non-blocking and execute asynchronously with respect to the host,
 unless otherwise stated. These functions might return before the actual computation has finished.
 To force synchronization, use either :cpp:func:`hipDeviceSynchronize` or :cpp:func:`hipStreamSynchronize`.
-This ensures that all previously executed hipSPARSE functions on the device or in the stream have completed.
+This ensures that all previously executed hipSPARSE functions on the device or stream have been completed.
 
 Multiple streams and multiple devices
 =====================================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,7 +36,7 @@ The hipSPARSE public repository is located at `<https://github.com/ROCm/hipSPARS
   .. grid-item-card:: API reference
 
     * :doc:`Exported functions <./reference/api>`
-    * :doc:`hipSPARSE datatypes <./reference/types>`
+    * :doc:`hipSPARSE data types <./reference/types>`
     * :doc:`hipSPARSE precision support <./reference/precision>`
     * :doc:`Sparse auxiliary functions <./reference/auxiliary>`
     * :doc:`Sparse level 1 functions <./reference/level1>`

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -1,6 +1,6 @@
 .. meta::
-  :description: hipSPARSE documentation and API reference library
-  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation
+  :description: Documentation for exported hipSPARSE API functions
+  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation, exported functions
 
 .. _api:
 
@@ -8,7 +8,9 @@
 Exported hipSPARSE functions
 ********************************************************************
 
-Auxiliary Functions
+This topic provides a list of the exported hipSPARSE functions in various categories.
+
+Auxiliary functions
 ===================
 
 +------------------------------------------+
@@ -177,7 +179,7 @@ Auxiliary Functions
 |:cpp:func:`hipsparseDnMatSetValues`       |
 +------------------------------------------+
 
-Sparse Level 1 Functions
+Sparse level 1 functions
 ========================
 
 ================================================ ====== ====== ============== ==============
@@ -192,7 +194,7 @@ Function name                                    single double single complex do
 :cpp:func:`hipsparseXsctr() <hipsparseSsctr>`    x      x      x              x
 ================================================ ====== ====== ============== ==============
 
-Sparse Level 2 Functions
+Sparse level 2 functions
 ========================
 
 ============================================================================== ====== ====== ============== ==============
@@ -216,7 +218,7 @@ Function name                                                                  s
 :cpp:func:`hipsparseXgemvi() <hipsparseSgemvi>`                                x      x      x              x
 ============================================================================== ====== ====== ============== ==============
 
-Sparse Level 3 Functions
+Sparse level 3 functions
 ========================
 
 ============================================================================= ====== ====== ============== ==============
@@ -236,7 +238,7 @@ Function name                                                                 si
 :cpp:func:`hipsparseXgemmi() <hipsparseSgemmi>`                               x      x      x              x
 ============================================================================= ====== ====== ============== ==============
 
-Sparse Extra Functions
+Sparse extra functions
 ======================
 
 ================================================================================== ====== ====== ============== ==============
@@ -254,7 +256,7 @@ Function name                                                                   
 :cpp:func:`hipsparseXcsrgemm2() <hipsparseScsrgemm2>`                              x      x      x              x
 ================================================================================== ====== ====== ============== ==============
 
-Preconditioner Functions
+Preconditioner functions
 ========================
 
 ===================================================================================================================== ====== ====== ============== ==============
@@ -292,7 +294,7 @@ Function name                                                                   
 :cpp:func:`hipsparseXgpsvInterleavedBatch() <hipsparseSgpsvInterleavedBatch>`                                         x      x      x              x
 ===================================================================================================================== ====== ====== ============== ==============
 
-Conversion Functions
+Conversion functions
 ====================
 
 ====================================================================================================================== ====== ====== ============== ==============
@@ -351,7 +353,7 @@ Function name                                                                   
 :cpp:func:`hipsparseXcsr2csru() <hipsparseScsr2csru>`                                                                  x      x      x              x
 ====================================================================================================================== ====== ====== ============== ==============
 
-Reordering Functions
+Reordering functions
 ====================
 
 ======================================================= ====== ====== ============== ==============
@@ -360,7 +362,7 @@ Function name                                           single double single com
 :cpp:func:`hipsparseXcsrcolor() <hipsparseScsrcolor>`   x      x      x              x
 ======================================================= ====== ====== ============== ==============
 
-Sparse Generic Functions
+Sparse generic functions
 ========================
 
 ================================================= ====== ====== ============== ==============

--- a/docs/reference/auxiliary.rst
+++ b/docs/reference/auxiliary.rst
@@ -1,6 +1,6 @@
 .. meta::
-  :description: hipSPARSE documentation and API reference library
-  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation
+  :description: hipSPARSE sparse auxiliary functions API documentation
+  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation, auxiliary functions
 
 .. _hipsparse_auxiliary_functions:
 
@@ -8,9 +8,10 @@
 Sparse auxiliary functions
 ********************************************************************
 
-This module holds all sparse auxiliary functions.
+This module contains all sparse auxiliary functions.
 
-The functions that are contained in the auxiliary module describe all available helper functions that are required for subsequent library calls.
+The functions that are contained in the auxiliary module describe all available helper functions
+that are required for subsequent library calls.
 
 .. _hipsparse_create_handle_:
 

--- a/docs/reference/conversion.rst
+++ b/docs/reference/conversion.rst
@@ -1,6 +1,6 @@
 .. meta::
-  :description: hipSPARSE documentation and API reference library
-  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation
+  :description: hipSPARSE sparse conversion functions API documentation
+  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation, conversion functions
 
 .. _hipsparse_conversion_functions:
 
@@ -8,9 +8,10 @@
 Sparse conversion functions
 ********************************************************************
 
-This module holds all sparse conversion routines.
+This module contains all sparse conversion routines.
 
-The sparse conversion routines describe operations on a matrix in sparse format to obtain a matrix in a different sparse format.
+The sparse conversion routines describe operations performed on a matrix in sparse format
+to obtain a matrix in a different sparse format.
 
 hipsparseXnnz()
 ===============

--- a/docs/reference/extra.rst
+++ b/docs/reference/extra.rst
@@ -1,6 +1,6 @@
 .. meta::
-  :description: hipSPARSE documentation and API reference library
-  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation
+  :description: hipSPARSE sparse extra functions API documentation
+  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation, extra functions
 
 .. _hipsparse_extra_functions:
 
@@ -8,7 +8,7 @@
 Sparse extra functions
 ********************************************************************
 
-This module holds all sparse extra routines.
+This module contains all sparse extra routines.
 
 The sparse extra routines describe operations that manipulate sparse matrices.
 

--- a/docs/reference/generic.rst
+++ b/docs/reference/generic.rst
@@ -1,6 +1,6 @@
 .. meta::
-  :description: hipSPARSE documentation and API reference library
-  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation
+  :description: hipSPARSE sparse generic functions API documentation
+  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation, generic functions
 
 .. _hipsparse_generic_functions:
 
@@ -8,7 +8,7 @@
 Sparse generic functions
 ********************************************************************
 
-This module holds all sparse generic routines.
+This module contains all sparse generic routines.
 
 The sparse generic routines describe operations that manipulate sparse matrices.
 

--- a/docs/reference/level1.rst
+++ b/docs/reference/level1.rst
@@ -1,6 +1,6 @@
 .. meta::
-  :description: hipSPARSE documentation and API reference library
-  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation
+  :description: hipSPARSE sparse level 1 functions API documentation
+  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation, level 1 functions
 
 .. _hipsparse_level1_functions:
 
@@ -8,7 +8,8 @@
 Sparse level 1 functions
 ********************************************************************
 
-The sparse level 1 routines describe operations between a vector in sparse format and a vector in dense format. This section describes all hipSPARSE level 1 sparse linear algebra functions.
+The sparse level 1 routines describe operations between a vector in sparse format and a vector in dense format.
+This section describes all hipSPARSE level 1 sparse linear algebra functions.
 
 hipsparseXaxpyi()
 =================

--- a/docs/reference/level2.rst
+++ b/docs/reference/level2.rst
@@ -1,6 +1,6 @@
 .. meta::
-  :description: hipSPARSE documentation and API reference library
-  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation
+  :description: hipSPARSE sparse level 2 functions API documentation
+  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation, level 2 functions
 
 .. _hipsparse_level2_functions:
 
@@ -8,7 +8,7 @@
 Sparse level 2 functions
 ********************************************************************
 
-This module holds all sparse level 2 routines.
+This module contains all sparse level 2 routines.
 
 The sparse level 2 routines describe operations between a matrix in sparse format and a vector in dense format.
 

--- a/docs/reference/level3.rst
+++ b/docs/reference/level3.rst
@@ -1,6 +1,6 @@
 .. meta::
-  :description: hipSPARSE documentation and API reference library
-  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation
+  :description: hipSPARSE sparse level 3 functions API documentation
+  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation, level 3 functions
 
 .. _hipsparse_level3_functions:
 
@@ -8,9 +8,10 @@
 Sparse level 3 functions
 ********************************************************************
 
-This module holds all sparse level 3 routines.
+This module contains all sparse level 3 routines.
 
-The sparse level 3 routines describe operations between a matrix in sparse format and multiple vectors in dense format that can also be seen as a dense matrix.
+The sparse level 3 routines describe operations between a matrix in sparse format and multiple vectors in dense format
+that can also be seen as a dense matrix.
 
 hipsparseXbsrmm()
 =================

--- a/docs/reference/precision.rst
+++ b/docs/reference/precision.rst
@@ -61,7 +61,7 @@ For example, the dense matrix sparse vector multiplication function is implement
 * ``hipsparseCgemvi`` - For single-precision complex sparse matrices.
 * ``hipsparseZgemvi`` - For double-precision complex sparse matrices.
 
-In the documentation, these are often represented generically as ``hipsparseXgemvi()``, where ``X`` is a
+In the documentation, these functions are often represented generically as ``hipsparseXgemvi()``, where ``X`` is a
 placeholder for the precision type character.
 
 Understanding precision in function signatures
@@ -94,8 +94,8 @@ variant.
 Generic functions and mixed precision
 -------------------------------------
 
-hipSPARSE provides generic functions that allow for mixed precision operations. These functions use data type
-enumerations to specify precision when creating matrix/vector descriptors and during computation.
+hipSPARSE provides generic functions that allow for mixed-precision operations. These functions use data type
+enumerations to specify precision when creating matrix or vector descriptors and during computation.
 
 For example, when creating a sparse matrix descriptor:
 
@@ -126,10 +126,10 @@ This approach enables:
 
 * Using different precision types for matrices and vectors.
 * Specifying computation precision independently of storage precision.
-* Supporting mixed precision workflows with a unified API.
+* Supporting mixed-precision workflows with a unified API.
 
 The advantage of using different data types is to save on memory bandwidth and storage when a user application
-allows while performing the actual computation in a higher precision.
+allows for it while performing the actual computation in a higher precision.
 
 Real versus complex precision
 -----------------------------

--- a/docs/reference/precond.rst
+++ b/docs/reference/precond.rst
@@ -1,6 +1,6 @@
 .. meta::
-  :description: hipSPARSE documentation and API reference library
-  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation
+  :description: hipSPARSE preconditioner functions API documentation
+  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation, preconditioner functions
 
 .. _hipsparse_precond_functions:
 
@@ -8,7 +8,7 @@
 Preconditioner functions
 ********************************************************************
 
-This module holds all sparse preconditioners.
+This module contains all sparse preconditioners.
 
 The sparse preconditioners describe manipulations on a matrix in sparse format to obtain a sparse preconditioner matrix.
 

--- a/docs/reference/reference.rst
+++ b/docs/reference/reference.rst
@@ -1,6 +1,6 @@
 .. meta::
-  :description: rocFFT documentation and API reference library
-  :keywords: rocFFT, ROCm, API, documentation
+  :description: rocFFT API reference library introduction
+  :keywords: rocFFT, ROCm, API, documentation, introduction
 
 .. _api-index:
 
@@ -8,7 +8,8 @@
 hipSPARSE API reference guide
 ********************************************
 
-The *hipSPARSE API Reference Guide* presents an Index of hipSPARSE functions, datatypes, and details of the different hipSPARSE functions by category.  
+The hipSPARSE API reference guide includes an index of the hipSPARSE functions, along with data types
+and details of the different hipSPARSE functions by category.  
 
 * :ref:`api`
 * :ref:`hipsparse-types`
@@ -16,7 +17,7 @@ The *hipSPARSE API Reference Guide* presents an Index of hipSPARSE functions, da
 * :ref:`hipsparse_level1_functions` between a vector in sparse format and a vector in dense format
 * :ref:`hipsparse_level2_functions` between a matrix in sparse format and a vector in dense format
 * :ref:`hipsparse_level3_functions` between a matrix in sparse format and multiple vectors (matrix) in dense format
-* :ref:`hipsparse_extra_functions` for proposing linear algebra operations
+* :ref:`hipsparse_extra_functions` for additional linear algebra operations
 * :ref:`hipsparse_precond_functions` on a matrix in sparse format to obtain a preconditioner
 * :ref:`hipsparse_conversion_functions` to convert a matrix in sparse format to a different storage format
 * :ref:`hipsparse_reordering_functions` for reordering sparse matrices

--- a/docs/reference/reference.rst
+++ b/docs/reference/reference.rst
@@ -9,7 +9,7 @@ hipSPARSE API reference guide
 ********************************************
 
 The hipSPARSE API reference guide includes an index of the hipSPARSE functions, along with data types
-and details of the different hipSPARSE functions by category.  
+and details of the different hipSPARSE functions by category.
 
 * :ref:`api`
 * :ref:`hipsparse-types`
@@ -21,4 +21,6 @@ and details of the different hipSPARSE functions by category.
 * :ref:`hipsparse_precond_functions` on a matrix in sparse format to obtain a preconditioner
 * :ref:`hipsparse_conversion_functions` to convert a matrix in sparse format to a different storage format
 * :ref:`hipsparse_reordering_functions` for reordering sparse matrices
-* :ref:`hipsparse_generic_functions` for manipulating sparse matrices 
+* :ref:`hipsparse_generic_functions` for manipulating sparse matrices
+
+For information about precision support in these functions, see :doc:`hipSPARSE precision support <./precision>`.

--- a/docs/reference/reorder.rst
+++ b/docs/reference/reorder.rst
@@ -1,6 +1,6 @@
 .. meta::
-  :description: hipSPARSE documentation and API reference library
-  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation
+  :description: hipSPARSE sparse reordering functions API documentation
+  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation, sparse reordering functions
 
 .. _hipsparse_reordering_functions:
 
@@ -8,7 +8,7 @@
 Sparse reordering functions
 ********************************************************************
 
-This module holds all sparse reordering routines.
+This module contains all sparse reordering routines.
 
 hipsparseXcsrcolor()
 ====================

--- a/docs/reference/types.rst
+++ b/docs/reference/types.rst
@@ -1,11 +1,11 @@
 .. meta::
-  :description: hipSPARSE documentation and API reference library
-  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation
+  :description: hipSPARSE data types documentation
+  :keywords: hipSPARSE, rocSPARSE, ROCm, API, documentation, data types
 
 .. _hipsparse-types:
 
 ********************************************************************
-hipSPARSE datatypes
+hipSPARSE data types
 ********************************************************************
 
 hipsparseHandle_t

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -31,7 +31,7 @@ subtrees:
       - file: reference/api.rst
         title: Exported functions
       - file: reference/types.rst
-        title: hipSPARSE datatypes
+        title: hipSPARSE data types
       - file: reference/precision.rst
         title: hipSPARSE precision support
       - file: reference/auxiliary.rst


### PR DESCRIPTION
This PR continues the hipSPARSE docs refresh by providing copy edits to the usage guide and the non-autogenerated parts of the API reference documents (titles, heading, and introduction). It also adds the interface example from the read me to the usage guide.