### PR TITLE
SWDEV-536813 - add missing C includes

### DIFF
--- a/clients/include/hipsparse_test_unique_ptr.hpp
+++ b/clients/include/hipsparse_test_unique_ptr.hpp
@@ -27,11 +27,10 @@
 
 #include "arg_check.hpp"
 
+#include <cstdio>
 #include <hip/hip_runtime_api.h>
 #include <hipsparse.h>
 #include <memory>
-#include <cstdio>
-
 
 #define PRINT_IF_HIP_ERROR(INPUT_STATUS_FOR_CHECK)                \
     {                                                             \
@@ -95,7 +94,7 @@ namespace hipsparse_test
         }
     };
 
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
     struct hyb_struct
     {
         hipsparseHybMat_t hyb;
@@ -145,7 +144,7 @@ namespace hipsparse_test
         }
     };
 
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
     struct csrsv2_struct
     {
         csrsv2Info_t info;
@@ -243,7 +242,7 @@ namespace hipsparse_test
         }
     };
 
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
     struct csrgemm2_struct
     {
         csrgemm2Info_t info;
@@ -293,7 +292,7 @@ namespace hipsparse_test
         }
     };
 
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
     struct spgemm_struct
     {
         hipsparseSpGEMMDescr_t descr;

--- a/clients/include/hipsparse_test_unique_ptr.hpp
+++ b/clients/include/hipsparse_test_unique_ptr.hpp
@@ -94,7 +94,7 @@ namespace hipsparse_test
         }
     };
 
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
     struct hyb_struct
     {
         hipsparseHybMat_t hyb;
@@ -144,7 +144,7 @@ namespace hipsparse_test
         }
     };
 
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
     struct csrsv2_struct
     {
         csrsv2Info_t info;
@@ -242,7 +242,7 @@ namespace hipsparse_test
         }
     };
 
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
     struct csrgemm2_struct
     {
         csrgemm2Info_t info;
@@ -292,7 +292,7 @@ namespace hipsparse_test
         }
     };
 
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
     struct spgemm_struct
     {
         hipsparseSpGEMMDescr_t descr;

--- a/clients/include/hipsparse_test_unique_ptr.hpp
+++ b/clients/include/hipsparse_test_unique_ptr.hpp
@@ -32,6 +32,7 @@
 #include <memory>
 #include <cstdio>
 
+
 #define PRINT_IF_HIP_ERROR(INPUT_STATUS_FOR_CHECK)                \
     {                                                             \
         hipError_t TMP_STATUS_FOR_CHECK = INPUT_STATUS_FOR_CHECK; \

--- a/clients/include/hipsparse_test_unique_ptr.hpp
+++ b/clients/include/hipsparse_test_unique_ptr.hpp
@@ -30,6 +30,7 @@
 #include <hip/hip_runtime_api.h>
 #include <hipsparse.h>
 #include <memory>
+#include <cstdio>
 
 #define PRINT_IF_HIP_ERROR(INPUT_STATUS_FOR_CHECK)                \
     {                                                             \

--- a/library/src/amd_detail/conversion/hipsparse_csru2csr.cpp
+++ b/library/src/amd_detail/conversion/hipsparse_csru2csr.cpp
@@ -29,6 +29,7 @@
 #include <rocsparse/rocsparse.h>
 
 #include "../utility.h"
+#include <cassert>
 
 // csru2csr struct - to hold permutation array
 struct csru2csrInfo

--- a/library/src/amd_detail/hipsparse_auxiliary.cpp
+++ b/library/src/amd_detail/hipsparse_auxiliary.cpp
@@ -29,6 +29,7 @@
 #include <rocsparse/rocsparse.h>
 
 #include "utility.h"
+#include <cstdio>
 
 hipsparseStatus_t hipsparseCreate(hipsparseHandle_t* handle)
 {


### PR DESCRIPTION
**Work item: **

**What were the changes?**
Added include directive for
library/src/amd_detail/conversion/hipsparse_csru2csr.cpp
library/src/amd_detail/hipsparse_auxiliary.cpp
clients/include/hipsparse_test_unique_ptr.hpp

**Why were the changes made?**
Unused headers removed in ROCM7.0.

**How was the outcome achieved?**
Adding this include removes build failure.