### PR TITLE
[Flang] Remove '-std=f2003'.

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -149,7 +149,7 @@ set(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/include/hipsparse)
 add_library(hipsparse_fortran OBJECT ${hipsparse_fortran_source})
 
 # Target compile options
-target_compile_options(hipsparse_fortran PRIVATE -std=f2003 -ffree-form -cpp)
+target_compile_options(hipsparse_fortran PRIVATE -ffree-form -cpp)
 endif()
 
 # Create hipSPARSE library


### PR DESCRIPTION
The option value '-std=f2003' is not supported by llvm flang.