### PR TITLE
Add missing GTest includes and linking

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -21,6 +21,8 @@
 #
 # ########################################################################
 
+find_package(GTest REQUIRED)
+
 set(HIPSPARSE_BENCHMARK_SOURCES
   client.cpp
   hipsparse_arguments_config.cpp
@@ -46,7 +48,7 @@ target_compile_options(hipsparse-bench PRIVATE -Wno-deprecated -Wno-unused-comma
 target_include_directories(hipsparse-bench PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 
 # Target link libraries
-target_link_libraries(hipsparse-bench PRIVATE roc::hipsparse)
+target_link_libraries(hipsparse-bench PRIVATE GTest::GTest roc::hipsparse)
 
 # Add OpenMP if available
 if(OPENMP_FOUND AND THREADS_FOUND)

--- a/clients/include/testing_bsrmv.hpp
+++ b/clients/include/testing_bsrmv.hpp
@@ -35,6 +35,7 @@
 #include "utility.hpp"
 
 #include <cmath>
+#include <gtest/gtest.h>
 #include <hipsparse.h>
 #include <string>
 


### PR DESCRIPTION
The missing gtest.h causes a compile error because of GTEST_SKIP use, which also seems to be the cause of a linking issue:

```
/usr/bin/ld: CMakeFiles/hipsparse-bench.dir/hipsparse_routine.cpp.o: in function `testing_coo2csr<float>(Arguments)::{lambda()#1}::operator()() const':
./obj-x86_64-linux-gnu/clients/benchmarks/./clients/benchmarks/../include/testing_coo2csr.hpp:103:(.text+0x6fe9b): undefined reference to `testing::Message::Message()'
```

This patch resolves the issue on my end.