### PR TITLE
ci: Remove call to junit from math ci

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -37,7 +37,6 @@ def runTestCommand (platform, project, gfilter)
                 """
 
     platform.runCommand(this, command)
-    junit "${project.paths.project_build_prefix}/build/release/clients/staging/*.xml"
 }
 
 def runCoverageCommand (platform, project, gfilter, String dirmode = "release")


### PR DESCRIPTION
math-ci no longer uses junit